### PR TITLE
🤖 Add the backend skills migrated from `hora-skills`

### DIFF
--- a/kit/skills/backend/hb-agent-loop/SKILL.md
+++ b/kit/skills/backend/hb-agent-loop/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: hb-agent-loop
+description: >
+  Build an LLM agent loop (iterative agent) in a backend repository with the three
+  @openreachtech/mentsu-agent-loop packages — core (the transport-agnostic iteration engine),
+  renchan-job (run a loop as a BullMQ/Redis job with progress publishing), and graphql (a mutation
+  that launches the loop plus a subscription that streams its progress). Use whenever the user
+  asks to add or edit an agent loop, an agent action, a composite agent, or to stream agent
+  progress.
+---
+
+# Agent Loop (building agent loops with mentsu-agent-loop)
+
+A skill for implementing an LLM agent's iteration ("loop") in a backend. The iteration engine,
+progress delivery, composition, job execution, and GraphQL integration are all provided by the
+**three `@openreachtech/mentsu-agent-loop-*` packages**. The app writes only the domain-specific
+**actions and loops**; iteration, stopping, compression, parallelism, and transport ride on the
+ready-made base classes.
+
+This skill covers the libraries' specs and use cases, plus the integration patterns for renchan's
+GraphQL and renchan-job-bullmq. **Always use these three packages** (never hand-roll your own
+iteration engine, queue bridge, or progress channel). The details are split into the [detail
+files](#detail-files) at the end.
+
+## Grand principle: write actions and loops without knowing about AI, DB, queues, or GraphQL (one-way dependency)
+
+The center of this package family's design is a **one-way dependency direction (outer → core)**.
+The iteration logic the app writes (actions / loops) **imports no business dependency and no
+transport**; everything is reached through the **`context` (an opaque DI seam)** and through **thin
+adapters**.
+
+| Layer | Package | Responsibility | Depends on |
+| --- | --- | --- | --- |
+| **core** | `@openreachtech/mentsu-agent-loop-core` | Iteration engine (Action / Loop / composition / Runner / Topic). **Zero dependencies** | imports nothing |
+| **job execution** | `@openreachtech/mentsu-agent-loop-renchan-job` | Run a loop as a renchan-job / BullMQ Redis job and publish progress | → core, renchan-job-bullmq |
+| **GraphQL** | `@openreachtech/mentsu-agent-loop-graphql` | Launch mutation + progress-subscription | → core, renchan |
+| **app** | (this repository) | Actions / loops / wiring | → all of the above |
+
+- **Why keep the dependency one-way**: the moment core imports AI/DB/queue/transport, the iteration
+  logic is bound to a specific backend and can no longer be tested in-process or switched between
+  execution modes. Keeping core dependency-free and receiving dependencies from `context` means **the
+  same loop runs in-process or as a job, and tests just swap `context` for a stub**.
+- **Why write only actions and loops**: the iteration body (the tail-recursive `iterate`), the
+  progress seam (`emitProgress`), composition (parallel / sequential), the queue bridge, and channel
+  naming are all **shared machinery**; writing them per app guarantees drift. Push them into the base
+  classes and implement only the abstract hooks.
+- **Why "always these three packages"**: hand-rolling an iteration engine or progress channel
+  reintroduces known failures — publish/subscribe channel mismatch, no retry, untestable code. The
+  packages prevent these by design (e.g. `AgentTopic` structurally matches the publish and subscribe
+  channels).
+- **Everything is an instance method, overridable via `extends`**. No pure functions or static-only
+  classes. Why: even if the library has a bug or a gap, the app can always work around it by extending
+  and overriding the relevant method (there is no true `final`). Write the app's overrides in the same
+  style.
+
+## Cross-cutting rules
+
+- **Business dependencies and transport are always received through `context`.** Do not directly
+  import AI clients, DB, HTTP, or queues inside an action or loop ([core.md](./references/core.md)).
+  Why: a direct import breaks in-process execution and stub injection, collapsing the one-way
+  dependency of the grand principle.
+- **Return `null` / an empty array for missing values, not `undefined`.** **One property per line in
+  object literals** (applies to sample code too). **Avoid single-character variables and
+  `for` / `forEach` / `switch` / `else if`**; write with `map` / `filter` / `reduce` and early return.
+  Why: match the existing codebase style so review attention goes to the logic.
+- **One class per file, one `export default`.** The constructor only assigns; defaults live in the
+  factory (`static create`); getters just return the field.
+- **Comments in produced artifacts (`.js`) are English**, and this skill is written entirely in
+  English (prose, tables, and example-code comments).
+
+## Choosing modules (what to install)
+
+Stack adapters onto core per the requirement. **Core is always required**; add an adapter only when
+that integration is needed.
+
+| What you want | Packages needed |
+| --- | --- |
+| Run a loop in-process (CLI / tests / synchronous work / Lambda) | core only |
+| Turn a long loop into a Redis job (horizontal scale, retry, rate limiting) | core + renchan-job |
+| Launch over GraphQL and subscribe to progress in realtime | core + renchan-job + graphql |
+
+- **Why stack incrementally**: actions and loops written with core alone can be turned into a job or a
+  GraphQL endpoint **without any change** (the adapter swaps only the transport step). Do not install
+  everything up front; layer on only what you need.
+
+## End-to-end progress (the backbone of the realtime log)
+
+"Launch with a mutation → return `accepted` immediately → stream progress over a subscription" is the
+typical shape for an agent on the web. Progress follows this single path. Because the publish side
+(the Worker) and the subscribe side (the Subscription) use the **same `AgentTopic`**, the channel
+names match structurally.
+
+```
+[core]        loop.run({ input, onProgress })
+                └ iterate emits emitProgress → onProgress(event) each iteration
+[renchan-job] BaseAgentJobWorker: onProgress → job.updateProgress(event)
+                → onJobProgress → publish to the channel AgentTopic.create({ channel, scope }).value
+[graphql]     BaseAgentProgressSubscriptionResolver: subscribes to the same channel + scope
+[frontend]    receives it in realtime over a GraphQL Subscription
+```
+
+- **Why use `AgentTopic` on both sides**: if the publish and subscribe channel names drift apart, you
+  get a silent "progress never arrives" failure. Concentrating the naming in one core class, with both
+  sides composing from the same `channel` + `scope`, makes drift impossible by design. To change the
+  naming rule, extend `AgentTopic` and override `get value()` in one place.
+
+## Detail files
+
+- [core.md](./references/core.md) — the core (`@openreachtech/mentsu-agent-loop-core`) spec and use
+  cases: actions / registry, the two loop types (AI-driven / procedural), composition (parallel
+  Composite / sequential Pipeline / ActionStage), Runners, `AgentTopic` / `AgentProgressEvent`, the
+  state model (state / context / compression).
+- [graphql-integration.md](./references/graphql-integration.md) — the pattern for integrating with
+  renchan's GraphQL: the launch mutation (`BaseRequestAgentMutationResolver`) and the progress
+  subscription (`BaseAgentProgressSubscriptionResolver`), channel matching via `AgentTopic`.
+- [renchan-job-integration.md](./references/renchan-job-integration.md) — the pattern for integrating
+  with renchan-job-bullmq: the Worker (`BaseAgentJobWorker`) / Dispatcher (`BaseAgentJobDispatcher`) /
+  `JobAgentRunner`, Engine / Share / Context wiring, `concurrency` / `limiter`, and the full
+  progress-publish flow.
+- [testing.md](./references/testing.md) — testing guidelines: the contract test kit
+  (`LoopContractAssertion` / `ActionContractAssertion`) and the unit-test approach for actions / loops
+  / composition / Worker / Dispatcher / Resolver (stub `context`, assert `onProgress`, assert abstract
+  throws).

--- a/kit/skills/backend/hb-agent-loop/references/core.md
+++ b/kit/skills/backend/hb-agent-loop/references/core.md
@@ -1,0 +1,485 @@
+# Core (`@openreachtech/mentsu-agent-loop-core` spec and use cases)
+
+Rules for the iteration engine itself. Referenced from `SKILL.md`. Core has **zero dependencies
+(deps:0)** and imports nothing about AI, DB, queues, or GraphQL. Business dependencies are all received
+through **`context` (a DI seam)** (the grand principle in `SKILL.md`). Job execution and GraphQL
+integration are [renchan-job-integration.md](./renchan-job-integration.md) /
+[graphql-integration.md](./graphql-integration.md); testing is [testing.md](./testing.md).
+
+All imports come from `@openreachtech/mentsu-agent-loop-core`.
+
+## Exported classes
+
+| Category | Class | Role |
+| --- | --- | --- |
+| Action | `BaseAgentAction` | Base for an app "capability". Implement `get name` / `get description` / `run` |
+| Action | `AgentActionRegistry` | Bundles actions by `name → action` (`getAction` / `describeActions`) |
+| Loop | `BaseAgentLoop` | Skeleton of the iteration engine (tail-recursive `iterate`, QC hooks, automatic progress) |
+| Loop | `AiDrivenAgentLoop` | **The AI decides the next move.** Implement `registry` / `decideNext` / `reduceActionResult` |
+| Loop | `ProceduralAgentLoop` | **Code decides the procedure.** Implement `advanceState` (the procedure body) |
+| Composition | `BaseCompositeAgent` | Parallel fan-out / fan-in (`planSubTasks` / `createSubAgent` / `mergeResults`, `concurrency`) |
+| Composition | `BaseAgentPipeline` | Sequential composition (`get stageCtors`). Threads the payload via immutable merge |
+| Composition | `BaseActionStage` | Wraps a single action as a Runnable (`ActionCtor` / `buildArgumentHash` / `buildOutput`) |
+| Runner | `BaseAgentRunner` / `InlineAgentRunner` | Execution-mode abstraction and in-process implementation (`request({ input, onProgress })`) |
+| VO | `AgentProgressEvent` | Standard shape of a progress event (`create({ phase, iteration, payload }).toHash()`) |
+| VO | `AgentTopic` | Structurally matches the publish/subscribe channel name (`create({ channel, scope }).value`) |
+| Error | `AgentLoopError` / `ConcreteMemberNotFoundError` / `ActionNotFoundError` | Error base and concretes |
+| Testing | `LoopContractAssertion` / `ActionContractAssertion` in `.../lib/testing/index.js` | Contract test kit ([testing.md](./testing.md)) |
+
+## The Runnable contract (why composition works)
+
+`BaseAgentLoop` / `BaseCompositeAgent` / `BaseAgentPipeline` / `BaseActionStage` / Runner all satisfy
+the same contract. **Because of this one contract, loops, composites, and stages can be nested inside
+one another.**
+
+```
+static create({ context })   +   async run({ input, onProgress })
+```
+
+- **Why unify it**: you can freely put a loop as a pipeline stage, or another pipeline inside a
+  composite, because every Runnable has the same `create` / `run`. When you add a new Runnable,
+  always give it this shape.
+
+## The state model (do not mix the three concepts)
+
+| Concept | Holds | Lifetime |
+| --- | --- | --- |
+| **state (iteration state)** | Per-step output, history, score | One run; **updated immutably** per iteration (`{ ...state, ... }`) |
+| **context (shared dependencies)** | DI for AI / DB / external clients | Read-only and constant across the whole run |
+| **compression (working context)** | The cumulative context passed to the AI | Grows per iteration → shrunk by `compressContext` |
+
+- **Why separate them**: making state mutable, or mixing iteration state into context, breaks resume,
+  parallelism, and testing. **Keep state immutable-updated and context read-only.**
+
+## Action: `BaseAgentAction`
+
+Define a "capability" as one class per file. Business dependencies are **always reached through
+`argumentHash` and `context`**.
+
+Members to override:
+
+- `get name` (required): the registry key / the identifier the AI selects by.
+- `get description` (required): the description used for selection (`describeActions()` formats it into
+  a prompt).
+- `async run({ argumentHash, context, onProgress })` (required): the capability body. Side effects
+  through `context` only.
+- `isValidArgumentHash({ argumentHash })` (optional): pre-run argument validation (default `true`).
+
+```js
+import {
+  BaseAgentAction,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+/**
+ * An action that searches for a topic.
+ *
+ * @extends {BaseAgentAction}
+ */
+export default class SearchAction extends BaseAgentAction {
+  /** @override */
+  get name () {
+    return 'search'
+  }
+
+  /** @override */
+  get description () {
+    return 'Search by keyword. Arguments: { keyword: string }'
+  }
+
+  /** @override */
+  async run ({
+    argumentHash,
+    context,
+    onProgress = null,
+  }) {
+    // Progress can be emitted from inside an action too (onProgress is optional).
+    onProgress?.({
+      phase: 'searching',
+      keyword: argumentHash.keyword,
+    })
+
+    // Business dependencies come from context (no direct import).
+    return context.searchClient.search({
+      keyword: argumentHash.keyword,
+    })
+  }
+}
+```
+
+```js
+// Avoid: importing a dependency directly inside an action
+//   → it can't be swapped for a stub in in-process tests, breaking the one-way dependency. Use context.
+import searchClient from '../../clients/searchClient.js' // ← NG
+```
+
+Bundle actions with `AgentActionRegistry.create({ actions: [...] })`. Resolve with `getAction({ name })`
+(throws `ActionNotFoundError` if unregistered); `describeActions()` yields a `- name: description` list.
+
+## Choosing a loop type (two types)
+
+A loop always implements the four abstract hooks of `BaseAgentLoop`: `createInitialState({ input })` /
+`advanceState({ state, iteration })` / `isComplete({ state, iteration })` / `buildResult({ state })`.
+Tune the QC hooks via getters: `get maxIterations` (default 10, the safety bound) / `get
+compressionInterval` (default null). `iterate` **always stops on `isComplete` or `maxIterations`** and
+emits `onProgress` every iteration (not overridable).
+
+| Aspect | `AiDrivenAgentLoop` (AI-driven) | `ProceduralAgentLoop` (procedural) |
+| --- | --- | --- |
+| Who decides the next move | **The AI** (`decideNext` asks each time) | **Code** (the fixed procedure in `advanceState`) |
+| Control flow | Non-deterministic, exploratory | Deterministic, reproducible |
+| What the app writes | `registry` / `decideNext` / `reduceActionResult` | `advanceState` (calls capabilities via `performAction`) |
+| Fits | Exploratory tasks with no readable procedure | Tasks with a fixed procedure |
+
+- **Why `maxIterations` is always enforced**: whether AI-driven or procedural, a bug in the stop
+  condition or an unstable external response can loop forever. `maxIterations` (default 10) is the
+  safety bound; even if `isComplete` never returns true, the loop still stops.
+- ⚠️ Procedural does not mean "no AI". You may use the AI as a **tool inside a step**. The difference is
+  **whether the AI holds the control flow**.
+
+### AI-driven: `AiDrivenAgentLoop`
+
+The base implements `advanceState` as "`decideNext` → `registry.getAction` → `action.run` →
+`reduceActionResult`". The app writes the following.
+
+```js
+import {
+  AiDrivenAgentLoop,
+  AgentActionRegistry,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+import SearchAction from './actions/SearchAction.js'
+import RefineAction from './actions/RefineAction.js'
+
+/**
+ * @extends {AiDrivenAgentLoop}
+ */
+export default class ResearchAgentLoop extends AiDrivenAgentLoop {
+  /** @override */
+  get maxIterations () {
+    return 6
+  }
+
+  /** @override */
+  get registry () {
+    return AgentActionRegistry.create({
+      actions: [
+        SearchAction.create(),
+        RefineAction.create(),
+      ],
+    })
+  }
+
+  /** @override */
+  createInitialState ({
+    input,
+  }) {
+    return {
+      keyword: input.keyword,
+      history: [],
+      score: 0,
+    }
+  }
+
+  /** @override */
+  async decideNext ({
+    state,
+  }) {
+    // Let the AI decide the next action (AI client via context).
+    return this.context.aiAgent.decideNextAction({
+      history: state.history,
+      describedActions: this.registry.describeActions(),
+    })
+  }
+
+  /** @override */
+  async reduceActionResult ({
+    state,
+    action,
+    result,
+  }) {
+    return {
+      ...state,
+      history: [
+        ...state.history,
+        {
+          action: action.name,
+          result,
+        },
+      ],
+      score: result.score ?? state.score,
+    }
+  }
+
+  /** @override */
+  isComplete ({
+    state,
+  }) {
+    return state.score >= 0.8
+  }
+
+  /** @override */
+  buildResult ({
+    state,
+  }) {
+    return {
+      items: state.history.at(-1)?.result?.items ?? [],
+      iterations: state.history.length,
+    }
+  }
+}
+```
+
+### Procedural: `ProceduralAgentLoop`
+
+Write the procedure in `advanceState`, and call a capability with `performAction({ name, argumentHash,
+context })`.
+
+```js
+/** @override */
+async advanceState ({
+  state,
+}) {
+  const found = await this.performAction({
+    name: 'search',
+    argumentHash: {
+      keyword: state.keyword,
+    },
+    context: this.context,
+  })
+
+  const refined = await this.performAction({
+    name: 'refine',
+    argumentHash: {
+      previousResults: found.items,
+    },
+    context: this.context,
+  })
+
+  return {
+    ...state,
+    keyword: refined.keyword,
+    items: found.items,
+    score: found.score,
+  }
+}
+```
+
+## Composition (bundling multiple Runnables)
+
+### Sequential: `BaseAgentPipeline`
+
+Chain stages of different natures (each stage is a Runnable) in series. The app declares only
+`get stageCtors` (`[{ name, Ctor }]`); the base handles payload hand-off, progress tagging, and
+sequential execution.
+
+- Override `createInitialPayload({ input })` (default: the input as-is), `mapStageOutput({ stage, input,
+  output })` (default: the immutable merge `{ ...input, ...output }`), and `buildResult({ payload })`
+  (default: the payload as-is) only when needed.
+- The base attaches `stage: <name>` to progress events (`buildStageEvent`).
+
+```js
+import {
+  BaseAgentPipeline,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+import KeywordStage from './KeywordStage.js'
+import SearchStage from './SearchStage.js'
+import RerankStage from './RerankStage.js'
+
+/**
+ * @extends {BaseAgentPipeline}
+ */
+export default class ResearchPipeline extends BaseAgentPipeline {
+  /** @override */
+  get stageCtors () {
+    return [
+      {
+        name: 'keyword',
+        Ctor: KeywordStage,
+      },
+      {
+        name: 'search',
+        Ctor: SearchStage,
+      },
+      {
+        name: 'rerank',
+        Ctor: RerankStage,
+      },
+    ]
+  }
+
+  /** @override */
+  buildResult ({
+    payload,
+  }) {
+    return {
+      ranked: payload.ranked,
+    }
+  }
+}
+```
+
+- **Do not override `run()`.** Sequential execution, payload merging, and progress tagging are the
+  base's assets. Why: reimplementing `run` forces you to re-guarantee progress tagging and immutable
+  merging yourself, and its behavior drifts from other pipelines. If you need resume/idempotency,
+  handle it in the stages / `context` (see idempotency in
+  [renchan-job-integration.md](./renchan-job-integration.md)).
+
+### A single action as a stage: `BaseActionStage`
+
+A thin base that turns one `BaseAgentAction` into a pipeline stage (a Runnable). Declare just three
+members.
+
+```js
+import {
+  BaseActionStage,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+import RerankAction from './actions/RerankAction.js'
+
+/**
+ * @extends {BaseActionStage}
+ */
+export default class RerankStage extends BaseActionStage {
+  /** @override */
+  static get ActionCtor () {
+    return RerankAction
+  }
+
+  /** @override */
+  buildArgumentHash ({
+    input,
+  }) {
+    return {
+      hits: input.hits, // ← the previous stage's output becomes the argument
+    }
+  }
+
+  /** @override */
+  buildOutput ({
+    result,
+  }) {
+    return {
+      ranked: result.items,
+    }
+  }
+}
+```
+
+### Parallel: `BaseCompositeAgent`
+
+Split the input into sub-tasks, run sub-agents (Runnables) in **parallel bounded by `concurrency`**,
+and combine with `mergeResults`. Implement `planSubTasks` / `createSubAgent` / `mergeResults`, and cap
+the degree of parallelism with `get concurrency` (default `Infinity`).
+
+```js
+/** @override */
+get concurrency () {
+  return 3
+}
+
+/** @override */
+planSubTasks ({
+  input,
+}) {
+  return input.keywords
+    .map(keyword => ({
+      keyword,
+    }))
+}
+
+/** @override */
+createSubAgent ({
+  subTask,
+}) {
+  return ResearchAgentLoop.create({
+    context: this.context,
+  })
+}
+
+/** @override */
+mergeResults ({
+  results,
+}) {
+  return {
+    items: results.flatMap(one => one.items),
+  }
+}
+```
+
+- **Why cap `concurrency`**: if sub-agents hit an AI / external API, unbounded parallelism causes rate
+  overruns and memory exhaustion. Do not leave it at the default `Infinity`; set a finite value
+  whenever external I/O is involved.
+
+## Runner (execution-mode abstraction)
+
+Make the caller depend only on `runner.request({ input, onProgress })`, so the concrete (in-process vs
+Redis job) can be swapped. The contract is `BaseAgentRunner#request`.
+
+- `InlineAgentRunner.create({ AgentLoopCtor, context })` — in-process execution. `request` returns the
+  loop's **final result**. For CLI / tests / synchronous work / Lambda.
+- The Redis version `JobAgentRunner` is provided by the renchan-job adapter
+  ([renchan-job-integration.md](./renchan-job-integration.md)). Its `request` returns `{ accepted, jobId }`
+  and progress goes over a Subscription.
+
+```js
+import {
+  InlineAgentRunner,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+const runner = InlineAgentRunner.create({
+  AgentLoopCtor: ResearchAgentLoop,
+  context: {
+    aiAgent,
+    searchClient,
+  },
+})
+
+const result = await runner.request({
+  input: {
+    keyword: 'example',
+  },
+  onProgress: event => console.log(event),
+})
+```
+
+- **Why put a Runner in front**: the same loop can be in-process in development and a Redis job in
+  production, switched by `env`, with no change to the caller. Keep the caller from touching a concrete
+  Loop or Dispatcher directly.
+
+## Progress VO and Topic
+
+- `AgentProgressEvent.create({ phase, iteration, payload }).toHash()` — the standard progress shape
+  `{ phase, iteration, payload }`. `iteration` / `payload` default to `null`. A VO that produces a shape
+  that rides directly on `job.updateProgress` or JSON. The loop's default per-iteration event is
+  `{ phase: 'iteration', iteration }`.
+- `AgentTopic.create({ channel, scope }).value` — composes the publish/subscribe channel name. If
+  `scope` is `null`, the value is `channel` itself; otherwise `channel:key=value&...` (**keys sorted
+  ascending** before joining).
+
+```js
+import {
+  AgentTopic,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+AgentTopic
+  .create({
+    channel: 'researchProgress',
+    scope: {
+      userId: 1001,
+    },
+  })
+  .value // → 'researchProgress:userId=1001'
+```
+
+- **Why sort the scope keys**: even if the publish and subscribe sides build the scope object with a
+  different key order, sorting produces the same string. This is the key to "the publish and subscribe
+  channels match" ([graphql-integration.md](./graphql-integration.md) /
+  [renchan-job-integration.md](./renchan-job-integration.md)).
+- To change the naming rule, extend `AgentTopic`, override `get value()`, and use the **same** extended
+  class on both the publish and subscribe sides. Swapping only one side makes the channels drift.
+
+## Unimplemented abstracts throw `ConcreteMemberNotFoundError`
+
+Touching an abstract member (`get name` / `createInitialState`, etc.) without implementing it throws
+`ConcreteMemberNotFoundError`. Use this in tests to "detect the unimplemented" ([testing.md](./testing.md)).

--- a/kit/skills/backend/hb-agent-loop/references/graphql-integration.md
+++ b/kit/skills/backend/hb-agent-loop/references/graphql-integration.md
@@ -1,0 +1,178 @@
+# GraphQL Integration (`@openreachtech/mentsu-agent-loop-graphql`)
+
+Rules for the resolver bases that **launch** a core loop from renchan's GraphQL (a Mutation) and
+**subscribe to its progress in realtime** (a Subscription). Referenced from `SKILL.md`. The core side is
+[core.md](./core.md), the job-execution and publish side is
+[renchan-job-integration.md](./renchan-job-integration.md), and testing is [testing.md](./testing.md).
+
+The typical shape for an agent on the web is "launch with a Mutation → return `accepted` immediately →
+stream progress over a Subscription". This package bases those two resolvers, so the app completes the
+integration with a few member declarations. Because the publish side (the Worker) and the subscribe side
+(the Subscription) share the **same `AgentTopic`**, the channel names match structurally.
+
+| Class | Extends (renchan) | Role |
+| --- | --- | --- |
+| `BaseRequestAgentMutationResolver` | `BaseMutationResolver` | Turns GraphQL variables into a job body, enqueues, and returns `{ accepted, jobId }` immediately |
+| `BaseAgentProgressSubscriptionResolver` | `BaseSubscriptionResolver` | Subscribes to what the Worker publishes, on the same `AgentTopic` channel |
+
+## Launch Mutation: `BaseRequestAgentMutationResolver`
+
+Enqueue without waiting for the long loop, and respond immediately. The app implements only two members.
+
+| Member | Kind | Description |
+| --- | --- | --- |
+| `buildJobBody({ variables })` | abstract | GraphQL variables → the job body (= the loop input) |
+| `enqueue({ body, context })` | abstract | Enqueue the body via `context.share`; return the dispatch response (exposing `hasResponse()` / `idKey`) |
+| `resolve({ variables, context })` | implemented | Calls `enqueue({ body: buildJobBody(...), context })` → returns `{ accepted, jobId }` |
+
+```js
+import {
+  BaseRequestAgentMutationResolver,
+} from '@openreachtech/mentsu-agent-loop-graphql'
+
+import ResearchJobDispatcher from '../../../jobs/research/ResearchJobDispatcher.js'
+
+/**
+ * @extends {BaseRequestAgentMutationResolver}
+ */
+export default class RequestResearchMutationResolver extends BaseRequestAgentMutationResolver {
+  /** @override */
+  static get schema () {
+    return 'requestResearch' // ← the corresponding GraphQL mutation name (renchan binding)
+  }
+
+  /** @override */
+  buildJobBody ({
+    variables,
+  }) {
+    return {
+      jobId: variables.input.jobId,
+    }
+  }
+
+  /**
+   * Source the dispatch seam from context.share (the house DI convention) and enqueue.
+   *
+   * @override
+   */
+  async enqueue ({
+    body,
+    context,
+  }) {
+    return context.share.jobDispatcherProvider.dispatchJob({
+      DispatcherCtor: ResearchJobDispatcher,
+      body,
+    })
+  }
+}
+```
+
+- **Why enqueue and return immediately**: the loop can be long-running. Running it synchronously inside
+  the API causes an HTTP timeout, and a mid-way disconnect cannot recover. Enqueuing lets the API respond
+  immediately while execution, retry, and progress ride on the Worker side.
+- **Source the dispatcher from `context.share`, not a resolver field**: shared, connection-reusing
+  instances (the job-dispatcher provider) live on `share` and are torn down at process exit, so read
+  them through `context.share`. This keeps DI in one place and lets tests swap the provider via a fake
+  share. The provider reuses its connection, so the resolver never calls `createAsync` / `teardown`.
+- **Why the seam takes `context`**: the `enqueue({ body, context })` hook receives the per-request
+  `context` so that the dispatcher can be sourced from `context.share`. A parameterless getter could
+  not — a renchan resolver instance holds only `errorHash`, and `context` is a per-call argument to
+  `resolve`. `resolve` (implemented by the base) calls `enqueue` with the built body, so the app never
+  reimplements `resolve`. The house provider is keyed by `DispatcherCtor`
+  (`dispatchJob({ DispatcherCtor, body })`), which the app passes inside `enqueue`.
+- **Do not turn a light loop into a job**: a loop that finishes quickly and needs no progress
+  subscription can be run inside a normal resolver with `InlineAgentRunner` ([core.md](./core.md)),
+  returning the result synchronously, instead of using `BaseRequestAgentMutationResolver`. Why: the
+  enqueue → subscribe machinery is for long-running, asynchronous work; bringing it to light work adds
+  needless complexity.
+
+## Progress Subscription: `BaseAgentProgressSubscriptionResolver`
+
+Subscribe to the channel the Worker publishes to. The app implements only `channel` and
+`generateChannelQuery`.
+
+| Member | Kind | Description |
+| --- | --- | --- |
+| `get channel()` | abstract | The subscribe channel name (**same as the Worker's `channel`**) |
+| `generateChannelQuery({ variables })` | abstract | Scope extraction (GraphQL-specific; e.g. `{ userId }`) |
+| `static get AgentTopicCtor()` | hook | Default `AgentTopic`. Override to change the naming rule (**use the same extended class as the Worker**) |
+| `generateChannel({ query })` | implemented | Overrides renchan's channel hook to return `AgentTopic.create({ channel, scope: query }).value` |
+| `buildTopic({ variables })` | implemented | `generateChannel({ query: generateChannelQuery({ variables }) })` |
+
+```js
+import {
+  BaseAgentProgressSubscriptionResolver,
+} from '@openreachtech/mentsu-agent-loop-graphql'
+
+/**
+ * @extends {BaseAgentProgressSubscriptionResolver}
+ */
+export default class OnResearchProgressSubscriptionResolver extends BaseAgentProgressSubscriptionResolver {
+  /** @override */
+  static get schema () {
+    return 'onResearchProgress' // ← the corresponding GraphQL subscription name
+  }
+
+  /** @override */
+  get channel () {
+    return 'researchProgress' // ← must be the same string as the Worker's channel
+  }
+
+  /** @override */
+  generateChannelQuery ({
+    variables,
+  }) {
+    return {
+      // The scope key set must match the key set the Worker's buildScope returns.
+      userId: variables.input.userId,
+    }
+  }
+
+  /**
+   * Pass the Worker's raw event straight through.
+   *
+   * @override
+   */
+  resolve (payload) {
+    return payload
+  }
+}
+```
+
+- **Why override `resolve` to pass through**: renchan's Subscription base sometimes assumes it should
+  unwrap `payload[schema]`. The Worker publishes a raw `{ phase, ... }` event, so returning it **as-is**
+  with `resolve(payload) => payload` lets the frontend receive the Worker's event shape directly. Only
+  reshape here if you want to change the event shape.
+- **Match `channel` and scope with the publish side**: `get channel()` must be the same string as the
+  Worker's `get channel()`, and the scope keys of `generateChannelQuery` must match the scope keys of
+  the Worker's `buildScope`. Why: a mismatch publishes to a channel nobody subscribes to and progress
+  never arrives, a silent failure (see "keep the progress channel identical" in
+  [renchan-job-integration.md](./renchan-job-integration.md)). Define the `channel` string in one place
+  and share it with the Worker.
+
+## How progress arrives (the full flow)
+
+```
+RequestResearchMutationResolver.resolve
+  → buildJobBody → enqueue → context.share.jobDispatcherProvider.dispatchJob(...) → returns { accepted, jobId } immediately
+  → the Worker picks it up → loop.run({ input: body, onProgress }) inside executeJob
+  → onProgress → job.updateProgress(event) → onJobProgress
+  → publish to the channel AgentTopic.create({ channel: 'researchProgress', scope }).value
+  → OnResearchProgressSubscriptionResolver (subscribing to the same channel + scope) → delivered to the frontend
+```
+
+The publish side (the Worker) and the subscribe side (this resolver) share the **core `AgentTopic`**
+that `generateChannel` calls internally, so the channel names match structurally. To change the naming
+rule, set the same `AgentTopic`-extended class as both sides' `AgentTopicCtor` (never change only one
+side).
+
+## Registering the GraphQL schema
+
+Register the Mutation (`requestResearch: RequestResearchOutput`) and the Subscription
+(`onResearchProgress: ...`) in the app's GraphQL schema, matching the name each resolver's `schema`
+getter returns. Authentication, authorization, and input validation put these two resolvers on the same
+path as any other renchan resolver.
+
+- **In a non-GraphQL setup** (REST / tRPC, etc.), this package is unnecessary. Publish `onProgress` to
+  the broker in the app and subscribe to the core `AgentTopic` channel directly (the publish/subscribe
+  matching principle is the same).

--- a/kit/skills/backend/hb-agent-loop/references/renchan-job-integration.md
+++ b/kit/skills/backend/hb-agent-loop/references/renchan-job-integration.md
@@ -1,0 +1,368 @@
+# renchan-job Integration (`@openreachtech/mentsu-agent-loop-renchan-job`)
+
+Rules for the adapter that runs a core loop (any Runnable) **as a Redis job** inside a renchan-job-bullmq
+Worker and publishes progress. Referenced from `SKILL.md`. The core side is [core.md](./core.md), GraphQL
+launch/subscribe is [graphql-integration.md](./graphql-integration.md), and testing is
+[testing.md](./testing.md).
+
+The point of this adapter is to move in-process execution onto Redis job execution **without changing any
+action or loop code**. Queues, the worker pool, Redis, retry, shutdown, and logging are all delegated to
+renchan-job-bullmq; the adapter bridges only **executeJob → `loop.run` / onProgress →
+`job.updateProgress` / lifecycle → publish**.
+
+## Classes and the overall wiring
+
+| Class | Extends | What the app overrides |
+| --- | --- | --- |
+| `BaseAgentJobWorker` | renchan-job `BaseJobWorker` | `static get AgentLoopCtor` / `get channel` / `createAgentContext` |
+| `BaseAgentJobDispatcher` | renchan-job `BaseJobDispatcher` | `static get EngineCtor` / `static get ManifestCtor` |
+| `JobAgentRunner` | core `BaseAgentRunner` | (none; use it via `create({ DispatcherCtor })`) |
+
+Combine these with the renchan-job-bullmq **Engine / Share / Context / Manifest** (provided by the app).
+If an existing renchan-job setup is present, you can **ride along** on it (just do not reuse a `jobName`
+of an existing job).
+
+## Worker: `BaseAgentJobWorker`
+
+The core that runs the loop inside the job. **The app implements only three abstract members**; the
+`executeJob` body, progress bundling, publish, and parallelism control are already implemented by the
+adapter base.
+
+| Member | Kind | Description |
+| --- | --- | --- |
+| `static get AgentLoopCtor()` | abstract | The Ctor of the Runnable (Loop / Pipeline / Composite) to run |
+| `get channel()` | abstract | The progress publish channel name (**same as the Subscription resolver's**) |
+| `createAgentContext({ context, parcel })` | abstract | Build the agent-loop context (DI seam) from the renchan-job context |
+| `buildScope({ jobModel })` | hook | The scope that namespaces the channel (default `null`) |
+| `static get AgentTopicCtor()` | hook | Default `AgentTopic`. Override to change the naming rule |
+| `get subscriptionBroker()` | hook | Default `this.engine.subscriptionBroker` |
+| `publishProgress({ topic, event })` | hook | Default `this.subscriptionBroker.publish(topic, event)` |
+| `buildOptionHash()` | implemented | Forwards `concurrency` / `limiter` to the BullMQ Worker (the base only passes `connection`) |
+| `executeJob` / `onJobProgress` / `onJobCompleted` / `onJobFailed` / `onWorkerError` | implemented | Execution and publish |
+
+What `executeJob({ body, context, parcel })` does (implemented by the base):
+
+```
+createAgentContext({ context, parcel })                     ← assemble the DI seam
+AgentLoopCtor.create({ context: agentContext })
+  .run({ input: body, onProgress: buildProgressSink({ parcel }) })
+        └ buildProgressSink = event => parcel.jobModel.job.updateProgress(event)
+```
+
+After that, BullMQ's progress/completed/failed events call `onJobProgress` / `onJobCompleted` /
+`onJobFailed`, each publishing to the channel `buildTopic({ scope: buildScope({ jobModel }) })`
+(completed publishes `{ phase: 'done', payload: result }`, failed publishes
+`{ phase: 'error', payload: { message } }`).
+
+```js
+import {
+  BaseAgentJobWorker,
+} from '@openreachtech/mentsu-agent-loop-renchan-job'
+
+import ResearchPipeline from '../../agentLoops/ResearchPipeline.js'
+import ResearchJobManifest from './ResearchJobManifest.js'
+
+/**
+ * @extends {BaseAgentJobWorker}
+ */
+export default class ResearchJobWorker extends BaseAgentJobWorker {
+  /** @override */
+  static get ManifestCtor () {
+    return ResearchJobManifest
+  }
+
+  /** @override */
+  static get AgentLoopCtor () {
+    return ResearchPipeline
+  }
+
+  /** @override */
+  get channel () {
+    return 'researchProgress' // ← must be the same string as the Subscription resolver
+  }
+
+  /**
+   * Build the agent-loop context (DI seam) from the renchan-job context.
+   *
+   * @override
+   */
+  createAgentContext ({
+    context,
+  }) {
+    return {
+      // context exposes delegating getters, so this is a 1-hop read (Demeter).
+      aiAgent: context.aiAgent,
+      searchClient: context.searchClient,
+    }
+  }
+}
+```
+
+### `createAgentContext` must do synchronous "wiring" only
+
+`createAgentContext` is the **synchronous wiring** that maps the renchan-job context onto the agent-loop
+context. **Do not do async work (DB loads, external calls) eagerly here.**
+
+- **Why synchronous**: the base's `executeJob` calls `createAgentContext(...)` **without `await`**.
+  Returning a Promise here corrupts the context. If you need async resource acquisition, put a
+  **lazily-resolving getter/method** on `context` and let the **action call it through `context` at run
+  time**. This avoids overriding `executeJob` and keeps the iteration logic in the "fetch from context
+  when needed" shape.
+
+```js
+// Good: createAgentContext is synchronous wiring; async is passed as a context method the action awaits
+/** @override */
+createAgentContext ({
+  context,
+}) {
+  return {
+    resolveAiAgent: params => context.resolveAiAgent(params), // actual resolution is awaited inside the action
+  }
+}
+```
+
+```js
+// Avoid: making createAgentContext async so it carries a DB load
+//   → the base executeJob does not await it, so the context becomes a Promise and breaks. Forces an executeJob override.
+async createAgentContext ({
+  context,
+}) { // ← NG
+  const record = await context.loadRecord(...) // eager async
+
+  return {
+    record,
+  }
+}
+```
+
+### Keep the progress channel identical on the publish and subscribe sides
+
+The publish side (the Worker's `channel` + `buildScope`) and the subscribe side (the Subscription's
+`channel` + `generateChannelQuery`) must use the **same `channel` string and the same scope keys**.
+
+- **Why**: `AgentTopic` guarantees the channel **format** matches, but the **`channel` string itself and
+  the scope key set** are the app's responsibility to align. A mismatch here is a silent "dropped
+  progress" (e.g. the Worker publishes with a `{ jobId }` scope while the Subscription subscribes to
+  `{ userId }`).
+- Define the `channel` string in **one place (a shared constant, etc.)** and have the Worker and the
+  Subscription reference the same value. Do not duplicate the literal in several places (a source of
+  drift).
+- Make the key set returned by `buildScope` match the key set returned by the Subscription's
+  `generateChannelQuery` ([graphql-integration.md](./graphql-integration.md)). Do not publish a scope
+  that nothing subscribes to.
+
+### Parallelism and rate limiting
+
+`concurrency` (loops one Worker runs at once) and `limiter` (per-window ceiling) are forwarded to the
+BullMQ Worker by `buildOptionHash()` (required, because the base renchan-job only passes `connection`).
+The app just writes `concurrency` / `limiter` into the Worker's config seam.
+
+```js
+/** @override */
+static get additionalConfig () {
+  return {
+    concurrency: 3, // ← number of Agent Loops one Worker runs at once
+    limiter: { // ← rate limit (guards an external AI API ceiling; optional)
+      max: 10,
+      duration: 1000,
+    },
+  }
+}
+```
+
+- **Why set it**: if the loop hits an AI / external API, unbounded parallelism causes rate overruns and
+  memory exhaustion. For loops with external I/O, keep `concurrency` finite and add a `limiter` when
+  needed. Scale horizontally (number of Worker processes) on the operations side.
+
+## Dispatcher: `BaseAgentJobDispatcher`
+
+The enqueue side. A thin wrapper over renchan-job's dispatcher; the app just points to `EngineCtor` /
+`ManifestCtor`. It provides the `dispatchAgentJob({ input, optionHash })` alias that enqueues the loop
+input as the job body (`dispatchJob` / `createAsync` / `teardown` are inherited from the renchan-job
+base as-is).
+
+```js
+import {
+  BaseAgentJobDispatcher,
+} from '@openreachtech/mentsu-agent-loop-renchan-job'
+
+import ResearchJobEngine from './ResearchJobEngine.js'
+import ResearchJobManifest from './ResearchJobManifest.js'
+
+/**
+ * @extends {BaseAgentJobDispatcher}
+ */
+export default class ResearchJobDispatcher extends BaseAgentJobDispatcher {
+  /** @override */
+  static get EngineCtor () {
+    return ResearchJobEngine
+  }
+
+  /** @override */
+  static get ManifestCtor () {
+    return ResearchJobManifest
+  }
+
+  /** @override */
+  static get optionHash () {
+    return {
+      defaultJobOptions: {
+        attempts: 2, // ← job-axis retry (distinct from the loop's maxIterations)
+        backoff: {
+          type: 'exponential',
+          delay: 30000,
+        },
+      },
+    }
+  }
+}
+```
+
+- To share `EngineCtor` across several jobs, make one **app-wide Dispatcher base** that returns only
+  `EngineCtor`, and have each job Dispatcher return only `ManifestCtor` (avoids duplicated wiring).
+
+## Manifest (input schema = loop input)
+
+Extend renchan-job-bullmq's `BaseJobManifest` and return `jobName` (the queue name) and `bodySchema`
+(= the loop input). Keep the body **minimal (ids, tokens)**.
+
+```js
+import {
+  BaseJobManifest,
+} from '@openreachtech/renchan-job-bullmq'
+
+import {
+  ScalarHash,
+} from '@openreachtech/mentsu-schema'
+
+const {
+  Integer,
+} = ScalarHash
+
+/**
+ * @extends {BaseJobManifest}
+ */
+export default class ResearchJobManifest extends BaseJobManifest {
+  /** @override */
+  static get jobName () {
+    return 'research'
+  }
+
+  /** @override */
+  static get bodySchema () {
+    return {
+      jobId: Integer,
+    }
+  }
+}
+```
+
+## Engine / Share / Context (renchan-job-bullmq; one set per app)
+
+The Redis connection, worker discovery, and shared DI live in the renchan-job-bullmq Engine / Share /
+Context. Reuse existing ones if present; otherwise provide them. **The progress-publish broker is held
+by the Share and exposed by the Engine via a delegating getter.**
+
+- **Engine** (`extends BaseJobEngine`): `config` (`workersPath` / `redisConfig`, etc.), `ShareCtor` /
+  `ContextCtor`, `createAsync({ subscriptionBroker })`, and the delegating `get subscriptionBroker()`.
+- **Share** (`extends BaseJobShare`; shared across the process): holds `subscriptionBroker` and shared
+  clients (AI, DB, etc.).
+- **Context** (`extends BaseJobContext`; per job): exposes the dependencies `createAgentContext` reads
+  via **delegating getters** (`get aiAgent()` → `this.share.aiAgent`, etc.; a 1-hop Demeter read).
+
+```js
+// Engine (excerpt): inject subscriptionBroker and expose it via a delegating getter for 1-hop access from the Worker.
+/** @override */
+static async createAsync ({
+  config = this.config,
+  subscriptionBroker,
+} = {}) {
+  const share = await this.ShareCtor.createAsync({
+    subscriptionBroker,
+  })
+
+  return this.create({
+    config,
+    share,
+  })
+}
+
+/** @override */
+get subscriptionBroker () {
+  return this.share.subscriptionBroker
+}
+```
+
+### If you use renchan's SubscriptionBroker, match `publishProgress` to it
+
+The adapter base's `publishProgress` defaults to calling **`this.subscriptionBroker.publish(topic,
+event)` (positional args)**. If the broker you use has a different signature (e.g. renchan's
+`SubscriptionBroker` takes `publish({ channel, message })`), override `publishProgress` to match the
+shape.
+
+```js
+// Good: adapt publishProgress to renchan SubscriptionBroker's signature
+/** @override */
+publishProgress ({
+  topic,
+  event,
+}) {
+  return this.subscriptionBroker.publish({
+    channel: topic,
+    message: event,
+  })
+}
+```
+
+- **Why absorb it here**: the broker's call shape is a transport difference and must not leak into
+  actions/loops. Absorbing it in the Worker's `publishProgress` (and, if needed, `get
+  subscriptionBroker()`) in one place lets the rest of the progress path (`buildTopic` / `onJobProgress`)
+  stay untouched.
+
+## Startup and enqueue
+
+- **Daemon**: build the `SubscriptionBroker`, inject it via `Engine.createAsync({ subscriptionBroker })`,
+  and start the Workers under `workersPath` with renchan-job's `JobWorkersDaemon`. In enqueue-only
+  processes (which do not publish progress), pass no broker and publish becomes a no-op.
+- **Enqueue (request-based)**: enqueue from a GraphQL/REST handler via the Dispatcher. The standard for
+  GraphQL launch is `BaseRequestAgentMutationResolver` in
+  [graphql-integration.md](./graphql-integration.md). To enqueue directly inside a handler, use
+  `dispatcher.dispatchJob({ body })` (or `dispatchAgentJob({ input })`).
+
+## Idempotency (assume BullMQ retries)
+
+Setting `optionHash.attempts` means the job may re-run. **Make `executeJob` idempotent.**
+
+- **Why**: so a retry re-running from the middle does not cause double writes or duplicated side effects.
+- To carry intermediate results across retries, **do not reimplement `run()` or `executeJob`**; handle
+  it via the loop's state and persistence hooks through `context` (saving/reading a checkpoint), so the
+  base's iteration and payload merge stay intact (see `BaseAgentPipeline` in [core.md](./core.md)).
+
+## Switching execution mode (in-process ⇔ Redis)
+
+Make the caller depend only on `BaseAgentRunner#request` and swap the concrete by `env`, etc. Actions
+and loops do not change at all.
+
+```js
+import {
+  InlineAgentRunner,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+import {
+  JobAgentRunner,
+} from '@openreachtech/mentsu-agent-loop-renchan-job'
+
+const runner = env.USE_REDIS
+  ? JobAgentRunner.create({ // Redis (async; returns { accepted, jobId })
+    DispatcherCtor: ResearchJobDispatcher,
+  })
+  : InlineAgentRunner.create({ // in-process (sync; returns the final result)
+    AgentLoopCtor: ResearchPipeline,
+    context: agentContext,
+  })
+```
+
+| Mode | `request` returns | Progress | Use |
+| --- | --- | --- | --- |
+| `InlineAgentRunner` (core) | The loop's final result | in-process (`onProgress` immediately) | dev / test / CLI / synchronous work |
+| `JobAgentRunner` (this adapter) | `{ accepted, jobId }` | over a Subscription | production / long-running / horizontal scale |

--- a/kit/skills/backend/hb-agent-loop/references/testing.md
+++ b/kit/skills/backend/hb-agent-loop/references/testing.md
@@ -1,0 +1,492 @@
+# Testing (agent-loop testing guidelines)
+
+The testing approach for actions / loops / composition / Worker / Dispatcher / Resolver written with
+`@openreachtech/mentsu-agent-loop-*`. Referenced from `SKILL.md`. The specs of the target classes are in
+[core.md](./core.md) / [renchan-job-integration.md](./renchan-job-integration.md) /
+[graphql-integration.md](./graphql-integration.md).
+
+These follow the **`hc-jest` skill** — read it for the general rules; this file only
+applies them to the agent-loop classes. In short: one file per class; nest
+`describe(ClassName) > describe('#member()' / '.get:member') > describe('should …') > test.each(cases)`;
+write each test as **Arrange / Act / Assert** separated by blank lines, taking the Act result into a
+`received` variable; bind every `jest.fn()` to a `~Spy` variable; and keep `cases` data unique and
+index-readable (`fake-keyword-0001`, `100001`, …).
+
+## Grand principle: swap `context` for a stub and touch no real I/O
+
+Because this library is deps:0 with `context` DI, **everything can be unit-tested without touching AI,
+DB, Redis, or the network**. Tests always stub `context` and never hit external systems.
+
+- **Why**: since the iteration logic reaches dependencies through `context` rather than importing them
+  directly (the grand principle in `SKILL.md`), a test just fakes `context` and becomes fast and
+  deterministic. Tests that touch real I/O are slow, flaky, and throw away this design's benefit.
+- Test a Worker by **`new`-ing it directly** rather than going through the BullMQ factory (below). Do
+  not start a daemon or Redis.
+
+## The contract test kit (secure the baseline first)
+
+The core `@openreachtech/mentsu-agent-loop-core/lib/testing/index.js` provides `LoopContractAssertion` /
+`ActionContractAssertion`. Calling `create({ createInstance }).assert()` inside a jest test verifies the
+base contract (inheritance, required getters, presence of abstract hooks, validity of QC values).
+
+```js
+import {
+  LoopContractAssertion,
+} from '@openreachtech/mentsu-agent-loop-core/lib/testing/index.js'
+
+import ResearchAgentLoop from '../../app/agentLoops/ResearchAgentLoop.js'
+
+describe('ResearchAgentLoop', () => {
+  describe('loop contract', () => {
+    test('should satisfy the base loop contract', () => {
+      const assertion = LoopContractAssertion.create({
+        createInstance: () => ResearchAgentLoop.create({
+          context: {
+            aiAgent: {},
+            searchClient: {},
+          },
+        }),
+      })
+
+      const received = assertion.assert()
+
+      expect(received)
+        .toBeTruthy()
+    })
+  })
+})
+```
+
+- What `LoopContractAssertion` checks: `instanceof BaseAgentLoop` / `maxIterations` is an integer ≥ 1 /
+  `compressionInterval` is `null` or an integer ≥ 1 / `run`, `createInitialState`, `advanceState`,
+  `isComplete`, `buildResult` are functions.
+- What `ActionContractAssertion` checks: `instanceof BaseAgentAction` / `name` and `description` are
+  non-empty strings / `run` is a function.
+- **Why put the contract test first**: before testing individual logic, it catches base-contract
+  violations (an unimplemented hook, an invalid `maxIterations`) in one line. The contract test is the
+  **baseline**, not coverage. Test the logic separately.
+
+## Unit-test approach per class
+
+### Action (`BaseAgentAction`)
+
+`Action.create()` and call `run({ argumentHash, context, onProgress })`, asserting that the **context
+stub is called as expected and the return value is correct**, and that **`onProgress` fires**.
+
+```js
+describe('SearchAction', () => {
+  describe('#run()', () => {
+    describe('should search via the injected client', () => {
+      const cases = [
+        {
+          tally: {
+            keyword: 'fake-keyword-0001',
+          },
+        },
+        {
+          tally: {
+            keyword: 'fake-keyword-0002',
+          },
+        },
+      ]
+
+      test.each(cases)('keyword: $tally.keyword', async ({ tally }) => {
+        const searchSpy = jest.fn()
+          .mockResolvedValue({
+            items: [], // neutral; not under test
+          })
+        const args = {
+          argumentHash: tally,
+          context: {
+            searchClient: {
+              search: searchSpy,
+            },
+          },
+          onProgress: jest.fn(),
+        }
+
+        await SearchAction.create()
+          .run(args)
+
+        expect(searchSpy)
+          .toHaveBeenCalledWith(tally)
+      })
+    })
+
+    describe('should resolve the search result', () => {
+      const cases = [
+        {
+          input: {
+            keyword: 'fake-keyword-0001',
+          },
+          expected: {
+            items: [
+              'fake-item-0001',
+            ],
+          },
+        },
+        {
+          input: {
+            keyword: 'fake-keyword-0002',
+          },
+          expected: {
+            items: [
+              'fake-item-0002',
+            ],
+          },
+        },
+      ]
+
+      test.each(cases)('keyword: $input.keyword', async ({ input, expected }) => {
+        const searchSpy = jest.fn()
+          .mockResolvedValue(expected)
+        const args = {
+          argumentHash: {
+            keyword: input.keyword,
+          },
+          context: {
+            searchClient: {
+              search: searchSpy,
+            },
+          },
+          onProgress: jest.fn(),
+        }
+
+        const received = await SearchAction.create()
+          .run(args)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+```
+
+Verify `onProgress` fires with a third `describe('should emit progress')` of the same shape — bind
+the callback to `onProgressSpy` and assert `.toHaveBeenCalled()`.
+
+### Loop (`BaseAgentLoop` subclasses)
+
+Look at it in two layers.
+
+1. **The whole `run`**: with a fake `context`, call `run({ input, onProgress })` and assert the final
+   result, the **stop (`isComplete` / `maxIterations`)**, and **progress firing**. In a separate case,
+   confirm that even when the stop condition keeps returning false, it stops at `maxIterations` (the
+   infinite-loop safety bound).
+2. **Individual hooks**: call `createInitialState` / `isComplete` / `buildResult` (and `decideNext` /
+   `reduceActionResult` for AI-driven, or `advanceState` for procedural) directly, and check the
+   immutable state update and the branching.
+
+```js
+// maxIterations safety bound: stops even when isComplete is always false.
+// Override via jest.spyOn (not a test-only subclass); test.each proves the bound
+// reads maxIterations rather than a hardcoded number.
+describe('ResearchAgentLoop', () => {
+  describe('#run()', () => {
+    describe('should stop at maxIterations when never complete', () => {
+      const cases = [
+        {
+          override: {
+            maxIterations: 2,
+          },
+          expected: 2,
+        },
+        {
+          override: {
+            maxIterations: 3,
+          },
+          expected: 3,
+        },
+      ]
+
+      test.each(cases)('maxIterations: $override.maxIterations', async ({ override, expected }) => {
+        jest.spyOn(ResearchAgentLoop.prototype, 'maxIterations', 'get')
+          .mockReturnValue(override.maxIterations)
+        jest.spyOn(ResearchAgentLoop.prototype, 'isComplete')
+          .mockReturnValue(false) // never complete → forces the safety bound
+
+        const loop = ResearchAgentLoop.create({
+          context: {
+            aiAgent: {},
+            searchClient: {},
+          },
+        })
+        const args = {
+          input: {
+            keyword: 'fake-keyword-0001',
+          },
+        }
+
+        const result = await loop.run(args)
+        const received = result.iterations
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+```
+
+### Composition (`BaseAgentPipeline` / `BaseCompositeAgent` / `BaseActionStage`)
+
+- **Pipeline**: that `get stageCtors` returns the expected stage list, and that `run` threads the payload
+  across stages into the final `buildResult`. Stage Ctors may be stubs (fake Runnables with `create` /
+  `run`).
+- **Composite**: the split from `planSubTasks`, the combine in `mergeResults`, and the `concurrency`
+  value.
+- **ActionStage**: `static get ActionCtor` / `buildArgumentHash` (payload → arguments) / `buildOutput`
+  (result → output).
+
+### Worker (`BaseAgentJobWorker` subclasses)
+
+**Do not** go through the BullMQ factory; fake the engine / broker and **`new` it directly** in each
+test's Arrange. Do **not** extract a `createWorker()` helper into the test file — a helper defined in
+the test file is unverified logic (see the `hc-jest` skill's anti-pattern); if the construction is
+genuinely reused, put the builder under `tests/tools/` with its own test.
+
+Behaviors to verify:
+
+- **`buildOptionHash()`**: that `concurrency` / `limiter` from `config` are forwarded to the BullMQ
+  options (needed because the base only passes `connection`).
+- **`buildTopic({ scope })`**: `channel` when `scope` is `null`, otherwise `channel:key=value` (keys
+  sorted ascending).
+- **`onJobProgress` / `onJobCompleted` / `onJobFailed`**: that the broker's `publish` is called with the
+  **correct channel and event shape** (completed is `{ phase: 'done', payload: result }`, failed is
+  `{ phase: 'error', payload: { message } }`).
+- **`executeJob({ body, context, parcel })`**: that the loop runs and returns a result, and progress
+  flows to `parcel.jobModel.job.updateProgress`.
+- **If you overrode `publishProgress`** (e.g. to match renchan's broker shape), verify that call shape
+  too.
+
+```js
+describe('ResearchJobWorker', () => {
+  describe('#executeJob()', () => {
+    describe('should stream progress to the job', () => {
+      const cases = [
+        {
+          input: {
+            jobId: 100001,
+          },
+        },
+        {
+          input: {
+            jobId: 100002,
+          },
+        },
+      ]
+
+      test.each(cases)('jobId: $input.jobId', async ({ input }) => {
+        const worker = new ResearchJobWorker({
+          engine: {
+            subscriptionBroker: {
+              publish: jest.fn(),
+            },
+          },
+          config: {
+            connection: {
+              host: 'localhost',
+              port: 6379,
+            },
+          },
+          manifest: null,
+          dispatcherHash: {},
+          errorHash: {},
+        })
+
+        const updateProgressSpy = jest.fn()
+        const args = {
+          body: {
+            jobId: input.jobId,
+          },
+          context: {},
+          parcel: {
+            jobModel: {
+              job: {
+                updateProgress: updateProgressSpy,
+              },
+            },
+          },
+        }
+
+        await worker.executeJob(args)
+
+        expect(updateProgressSpy)
+          .toHaveBeenCalled()
+      })
+    })
+  })
+})
+```
+
+Verify the return value with a sibling `describe('should return a result')` — take
+`const received = await worker.executeJob(args)` and assert `.toBeDefined()`.
+
+### Dispatcher (`BaseAgentJobDispatcher` subclasses)
+
+- That `static get EngineCtor` / `static get ManifestCtor` return the correct classes.
+- That `dispatchAgentJob({ input })` delegates to `dispatchJob({ body: input, optionHash })` (stub
+  `dispatchJob` and check the arguments; do not actually enqueue).
+
+### Mutation resolver (`BaseRequestAgentMutationResolver` subclasses)
+
+Pass a fake `context` whose `share` carries a stubbed dispatch provider, and verify that
+`resolve({ variables, context })` **dispatches with the body from `buildJobBody`** and returns
+**`{ accepted, jobId }`**. (This matches sourcing the dispatcher from `context.share`; see the note in
+[graphql-integration.md](./graphql-integration.md).)
+
+```js
+describe('RequestResearchMutationResolver', () => {
+  describe('#resolve()', () => {
+    describe('should return acceptance with the dispatched job id', () => {
+      const cases = [
+        {
+          input: {
+            jobId: 100001,
+          },
+          expected: {
+            accepted: true,
+            jobId: 'fake-job-id-0001',
+          },
+        },
+        {
+          input: {
+            jobId: 100002,
+          },
+          expected: {
+            accepted: true,
+            jobId: 'fake-job-id-0002',
+          },
+        },
+      ]
+
+      test.each(cases)('jobId: $input.jobId', async ({ input, expected }) => {
+        const resolver = new RequestResearchMutationResolver({
+          errorHash: {},
+        })
+
+        const dispatchJobSpy = jest.fn()
+          .mockResolvedValue({
+            hasResponse: () => true,
+            idKey: expected.jobId,
+          })
+        const args = {
+          variables: {
+            input: {
+              jobId: input.jobId,
+            },
+          },
+          context: {
+            share: {
+              jobDispatcherProvider: {
+                dispatchJob: dispatchJobSpy,
+              },
+            },
+          },
+        }
+
+        const received = await resolver.resolve(args)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+```
+
+Verify the dispatch itself with a sibling `describe('should dispatch the job body')` — assert
+`dispatchJobSpy` was called with `{ DispatcherCtor: ResearchJobDispatcher, body: <buildJobBody> }`.
+
+### Subscription resolver (`BaseAgentProgressSubscriptionResolver` subclasses) — always verify channel match
+
+Verify that `generateChannel` / `buildTopic` produce **the same string as the `AgentTopic` the Worker
+builds from**, by comparing against a hand-built `AgentTopic` expected value. This is the only guard
+against publish/subscribe drift.
+
+```js
+import {
+  AgentTopic,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+describe('OnResearchProgressSubscriptionResolver', () => {
+  describe('#generateChannel()', () => {
+    describe('should match the channel the worker publishes to', () => {
+      const cases = [
+        {
+          input: {
+            query: {
+              userId: 100001,
+            },
+          },
+        },
+        {
+          input: {
+            query: {
+              userId: 100002,
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('userId: $input.query.userId', ({ input }) => {
+        const resolver = new OnResearchProgressSubscriptionResolver({
+          errorHash: {},
+        })
+
+        const expected = AgentTopic.create({
+          channel: 'researchProgress', // the same channel the Worker builds from
+          scope: input.query,
+        })
+          .value
+        const args = {
+          query: input.query,
+        }
+
+        const received = resolver.generateChannel(args)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+```
+
+- Also confirm that `generateChannelQuery({ variables })` returns the expected scope, and that
+  `get channel()` is the same string as the Worker's.
+- **Why compare against a hand-built `AgentTopic`**: even though the Worker and the Subscription are
+  implemented independently, one test pins that both resolve to the same channel string. The moment
+  `channel` or a scope key is changed on only one side, this test fails.
+
+### Runner
+
+- `InlineAgentRunner`: that `request({ input, onProgress })` runs the loop and returns the final result.
+- `JobAgentRunner`: stub `DispatcherCtor.createAsync` / `dispatchJob` / `teardown`, and verify that
+  `request({ input })` enqueues, returns `{ accepted, jobId }`, and calls `teardown`.
+
+## Verifying unimplemented abstracts
+
+Touching an abstract member of a base class throws `ConcreteMemberNotFoundError`. Assert this with
+`expect(operation).toThrow(ConcreteMemberNotFoundError)` to guarantee **the subclass overrides it
+correctly**.
+
+```js
+describe('BaseAgentJobWorker', () => {
+  describe('.get:AgentLoopCtor', () => {
+    describe('when not inherited', () => {
+      test('should throw error', () => {
+        const operation = () => BaseAgentJobWorker.AgentLoopCtor
+
+        expect(operation)
+          .toThrow(ConcreteMemberNotFoundError)
+      })
+    })
+  })
+})
+```
+
+- **Why**: with both the contract test (the kit) and individual tests, "forgot to implement" is detected
+  at runtime rather than by types. This library has no true `final` and works around gaps via override,
+  so the unimplemented is detected by a throw.

--- a/kit/skills/backend/hb-ai-agent-structure/SKILL.md
+++ b/kit/skills/backend/hb-ai-agent-structure/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: hb-ai-agent-structure
+description: >
+  Structure an app-side AI agent on @openreachtech/mentsu-agent-loop-core in a renchan backend: an
+  app/agents/<name>/ directory holding a ProceduralAgentLoop subclass (fixed procedure) plus
+  per-step BaseAgentAction subclasses, driven synchronously by a generator tool, each AI step
+  making one forced tool call. Use whenever the user asks to add or edit such an agent, an agent
+  action, or the generator that runs the loop. The iteration engine itself is a separate
+  convention.
+---
+
+# AI Agent Structure (app-side agents on mentsu-agent-loop-core)
+
+This skill covers **how this backend structures an AI agent as application code** — the directory layout,
+the `ProceduralAgentLoop` subclass, the per-step actions, and the `*Generator` that runs the loop. The
+iteration engine, progress delivery, composition, job execution, and GraphQL integration are provided by
+the `@openreachtech/mentsu-agent-loop-core` package family; see the **`hb-agent-loop` skill** for those. Do
+not re-explain the core package here — this skill is only the app layer on top of it.
+
+## Grand principle: the procedure is code, the AI only judges inside a step
+
+An app agent here is a **`ProceduralAgentLoop`** whose steps are fixed in code (e.g. `plan → execute →
+compose`), where each step either runs a **single forced AI tool call** or runs **deterministic code** —
+never an open-ended "let the AI decide what to do next" loop.
+
+- **Why a procedural loop, not an AI-driven one**: the business shape (search records, fill a form) is
+  known; only small judgments (is this a search request? what are the search steps? phrase the answer)
+  need the model. Fixing the procedure in `advanceState` keeps the flow reviewable, testable, and cheap
+  (usually one iteration), and confines model non-determinism to individual steps.
+- **Why one forced tool call per AI step**: each AI step declares exactly one tool and forces it
+  (`toolChoices: [{ name }]`, `isAutoHandleFunctionCall: false`), then reads the function-call arguments
+  as the step's typed output. This turns a free-text model into a structured function returning a known
+  shape, so the surrounding code can validate and branch on it.
+- **Why load the tool schema from the DB**: the tool JSON (name, description, parameters) lives in the
+  `AiTool` table, not in code. The action only holds the tool's **id**; swapping wording or parameters is
+  a data change, not a deploy. See the **`hb-ai-prompt-document-store` skill**.
+- **Everything reaches AI / DB / services through `context`.** Actions and the loop never import an AI
+  client or a repository directly; they read `context.processor`, `context.recordSearchService`, etc. This
+  is the one-way dependency of the agent-loop core — keep it.
+
+## Directory layout
+
+One directory per agent under `app/agents/<agentName>/`, with the loop at the top and actions in
+`actions/`:
+
+```
+app/agents/recordSearch/
+  RecordSearchAgentLoop.js              extends ProceduralAgentLoop
+  actions/
+    BaseRecordSearchAgentAction.js      extends BaseAgentAction (app base, abstract)
+    ClassifySearchIntentAction.js       run standalone by the generator (intent gate)
+    PlanSearchAction.js                 registered: 'planSearch'
+    ExecuteSearchPlanAction.js          registered: 'executeSearchPlan' (no AI — pure code)
+    ComposeAnswerAction.js              registered: 'composeAnswer'
+```
+
+The runner/wiring lives one level up in `app/tools/<Agent>Generator.js` (e.g.
+`RecordSearchGenerator.js`). Keep the layout identical across agents so review attention goes to the
+agent's *procedure*.
+
+## 1. The loop — a `ProceduralAgentLoop` subclass
+
+Override these members (no constructor, no `static create` — `InlineAgentRunner` instantiates the loop
+with the `context`):
+
+| Member | Responsibility |
+| --- | --- |
+| `#get:maxIterations` | Iteration cap (a procedural agent usually finishes in 1; e.g. `4`) |
+| `#get:registry` | `AgentActionRegistry.create({ actions: [...] })` — the actions the procedure can call |
+| `#createInitialState({ input })` | The starting state object (e.g. `{ result: null }`) |
+| `#advanceState({ state })` | **The procedure body** — the ordered steps |
+| `#isComplete({ state })` | Stop condition (e.g. `Boolean(state.result)`) |
+| `#buildResult({ state })` | The final return value (e.g. `state.result`) |
+
+`#advanceState()` calls `this.performAction({ name, argumentHash, context })` for each step, matching an
+action by its `#get:name`. Deterministic branches (e.g. "couldn't understand the request") are written as
+plain code between the AI steps.
+
+```js
+import {
+  ProceduralAgentLoop,
+  AgentActionRegistry,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+import PlanSearchAction from './actions/PlanSearchAction.js'
+import ExecuteSearchPlanAction from './actions/ExecuteSearchPlanAction.js'
+import ComposeAnswerAction from './actions/ComposeAnswerAction.js'
+
+export default class RecordSearchAgentLoop extends ProceduralAgentLoop {
+  get maxIterations () {
+    return 4
+  }
+
+  get registry () {
+    return AgentActionRegistry.create({
+      actions: [
+        PlanSearchAction.create(),
+        ExecuteSearchPlanAction.create(),
+        ComposeAnswerAction.create(),
+      ],
+    })
+  }
+
+  createInitialState ({
+    input,
+  }) {
+    return {
+      result: null,
+    }
+  }
+
+  async advanceState ({
+    state,
+  }) {
+    const plan = await this.performAction({
+      name: 'planSearch',
+      argumentHash: {
+        message: this.context.message,
+        searchableCategories: this.context.searchableCategories,
+      },
+      context: this.context,
+    })
+
+    if (!plan) {
+      return {
+        ...state,
+        result: {
+          message: 'I could not turn that into a record search. Could you rephrase what you are looking for?',
+          targetRecords: [],
+        },
+      }
+    }
+
+    const executed = await this.performAction({
+      name: 'executeSearchPlan',
+      argumentHash: {
+        plan,
+      },
+      context: this.context,
+    })
+
+    const answer = await this.performAction({
+      name: 'composeAnswer',
+      argumentHash: {
+        message: this.context.message,
+        resultSummary: {
+          foundCount: executed.targetRecords.length,
+          isTruncated: executed.isTruncated,
+          resultCategoryName: this.resolveCategoryName({
+            originObjectCategoryId: executed.resultOriginObjectCategoryId,
+          }),
+        },
+      },
+      context: this.context,
+    })
+
+    return {
+      ...state,
+      result: {
+        message: answer.message,
+        targetRecords: executed.targetRecords,
+      },
+    }
+  }
+
+  isComplete ({
+    state,
+  }) {
+    return Boolean(state.result)
+  }
+
+  buildResult ({
+    state,
+  }) {
+    return state.result
+  }
+}
+```
+
+- **State is updated immutably** (`{ ...state, ... }`) — never mutate it in place.
+- **`registry` is rebuilt each access** — it is cheap and keeps the getter pure.
+- Progress within the procedure is forwarded through `this.context.notifyProgress?.({ phase, status })`
+  (a no-op unless the caller sets it), not through the runner's `onProgress`.
+
+## 2. Actions — an app base over `BaseAgentAction`, one forced tool call each
+
+Each agent has an abstract app base (e.g. `BaseRecordSearchAgentAction extends BaseAgentAction`) holding
+the shared forced-tool helpers; each concrete action overrides `#get:name`, `#get:description`, and
+`#run()`.
+
+App-base helpers (the forced-single-tool machinery):
+
+| Method | Responsibility |
+| --- | --- |
+| `#loadToolPayloadObject({ aiToolId })` | `AiTool.findByPk(aiToolId)` → `JSON.parse(payload)`, `null` on missing/parse error |
+| `#sendForcedToolRequest({ context, instruction, toolPayloadObject })` | one AI turn: `context.processor.sendRequestToAi(...)` forcing the single tool |
+| `#extractFunctionCallFromAiResponse({ response, toolName })` | first function call whose name matches, else `null` |
+| `#parseFunctionCallArguments({ functionCall })` | parse `functionCall.arguments` (string→JSON), `null` on error |
+
+```js
+import {
+  BaseAgentAction,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+import AiTool from '../../../../sequelize/models/AiTool.js'
+
+/** @abstract */
+export default class BaseRecordSearchAgentAction extends BaseAgentAction {
+  async loadToolPayloadObject ({
+    aiToolId,
+  }) {
+    const aiTool = await AiTool.findByPk(aiToolId)
+
+    if (!aiTool) {
+      return null
+    }
+
+    try {
+      return JSON.parse(aiTool.payload)
+    } catch (error) {
+      return null
+    }
+  }
+
+  async sendForcedToolRequest ({
+    context,
+    instruction,
+    toolPayloadObject,
+  }) {
+    return context.processor.sendRequestToAi({
+      aiAgent: context.aiAgent,
+      documents: context.documents,
+      extraToolOptions: {},
+      fileUrls: context.files,
+      historyMessages: context.historyMessages,
+      instruction,
+      isAutoHandleFunctionCall: false,
+      toolChoices: [
+        {
+          name: toolPayloadObject.name,
+        },
+      ],
+      tools: [
+        toolPayloadObject,
+      ],
+    })
+  }
+}
+```
+
+A concrete AI action then runs the fixed flow — load tool → build instruction → force the call → extract
+→ parse → return a typed value (return `null` / a fallback on any failure, never `undefined`):
+
+```js
+export default class PlanSearchAction extends BaseRecordSearchAgentAction {
+  get name () {
+    return 'planSearch'
+  }
+
+  get description () {
+    return 'Decompose the request into ordered record-search steps'
+  }
+
+  get toolName () {
+    return 'plan_record_search'
+  }
+
+  async run ({
+    argumentHash: {
+      message,
+      searchableCategories,
+    },
+    context,
+  }) {
+    const toolPayloadObject = await this.loadToolPayloadObject({
+      aiToolId: context.planRecordSearchAiToolId,
+    })
+
+    if (!toolPayloadObject) {
+      return null
+    }
+
+    const instruction = this.buildInstruction({
+      message,
+      searchableCategories,
+    })
+
+    const response = await this.sendForcedToolRequest({
+      context,
+      instruction,
+      toolPayloadObject,
+    })
+
+    if (response.hasError()) {
+      return null
+    }
+
+    const functionCall = this.extractFunctionCallFromAiResponse({
+      response,
+      toolName: this.toolName,
+    })
+
+    if (!functionCall) {
+      return null
+    }
+
+    const parsed = this.parseFunctionCallArguments({
+      functionCall,
+    })
+
+    return this.normalizePlan({
+      functionCall: parsed,
+      searchableCategories,
+    })
+  }
+}
+```
+
+- **Instructions embed user data in CDATA** (`<user_request><![CDATA[${message}]]></user_request>`) so
+  free text cannot break the prompt structure.
+- **The model's output is always re-validated in code** (e.g. `#normalizePlan()` checks every category id
+  against the catalog and returns `null` if anything is off) — never trust the raw function-call arguments.
+- **A non-AI action is just code**: `ExecuteSearchPlanAction` has no `toolName` and no AI turn; it
+  drives `context.recordSearchService` and returns records.
+
+## 3. The generator — build `context` and run via `InlineAgentRunner`
+
+The loop is run **synchronously, in-process** (no Redis) by an `app/tools/<Agent>Generator.js`. The
+generator assembles the `context` (all dependencies the loop and actions read), then:
+
+```js
+import {
+  InlineAgentRunner,
+} from '@openreachtech/mentsu-agent-loop-core'
+
+import RecordSearchAgentLoop from '../agents/recordSearch/RecordSearchAgentLoop.js'
+
+// inside the generator method:
+const runner = InlineAgentRunner.create({
+  AgentLoopCtor: RecordSearchAgentLoop,
+  context: {
+    ...chatContext,
+    searchableCategories,
+    recordSearchService: this.recordSearchService,
+  },
+})
+
+const result = await runner.request({
+  input: {},
+  onProgress: () => {
+    // phase progress is forwarded through context.notifyProgress instead
+  },
+})
+```
+
+The assembled `context` is exactly the object the loop reads as `this.context` and each action receives as
+`context`. Its keys are the agent's dependency contract — for the record-search agent:
+
+| Key | What it is |
+| --- | --- |
+| `message` | the user input / question |
+| `aiAgent` | the DB agent config (instruction, model) |
+| `historyMessages`, `files`, `documents` | chat history, attachments, RAG documents |
+| `processor` | the LLM processor (see the `hb-multi-llm-provider` skill) |
+| `searchableCategories` | the catalog the plan/execute steps work over |
+| `recordSearchService` | the deterministic search/traversal service |
+| `<step>AiToolId` | the `AiTool` ids the AI actions load their schema from |
+| `notifyProgress` | optional progress callback (set only by the standalone worker) |
+
+Two entrypoints on the generator are common:
+
+- **Chat flow** (`#generate(...)`) runs a standalone **intent gate first** — it creates
+  `ClassifySearchIntentAction` directly (not in the loop registry) and returns `null` when the input is
+  ordinary conversation, so the loop only runs for real requests.
+- **Explicit flow** (`#generateForExplicitSearch(...)`) skips the gate, passes empty history/files, and
+  sets `notifyProgress` for streaming.
+
+A `static createWithDefaults(...)` wires the concrete services so callers do not hand-assemble them.
+
+## 4. Exposing the agent
+
+The GraphQL mutation resolvers under `server/graphql/resolvers/user/actual/mutations/` (e.g.
+`SendMessageToChatRoomMutationResolver`, `GenerateRecordFieldValuesByAiMutationResolver`) build the
+processor + context and call the generator. Because the loop runs in-process via `InlineAgentRunner`, no
+job/queue is involved; to run the same loop as a background job with progress streaming, use the
+**`hb-agent-loop` skill** (`renchan-job` / `graphql` adapters) instead of the synchronous runner.
+
+## Cross-cutting rules
+
+- **All dependencies flow through `context`** — never import an AI client, model, or service inside a loop
+  or action.
+- **Return `null` / a fallback for missing values, not `undefined`.** Every AI step must have a
+  deterministic fallback (return `null`, or a canned message) so a model failure never crashes the flow.
+- **Re-validate every model output in code** before using it.
+- **One class per file, one `export default`**; getters return a constant/field; the state object is
+  updated immutably.
+- Match the surrounding style (no semicolons, one property per line, `map`/`filter`/`reduce` over loops).
+
+## Detail files
+
+- [loop-and-actions.md](./references/loop-and-actions.md) — the full `RecordSearchAgentLoop` procedure and
+  all four actions method-by-method, plus the `RecordFieldValuesAgentLoop` variant (branching procedure,
+  no progress) to show what changes between agents.

--- a/kit/skills/backend/hb-ai-agent-structure/references/loop-and-actions.md
+++ b/kit/skills/backend/hb-ai-agent-structure/references/loop-and-actions.md
@@ -1,0 +1,100 @@
+# Loop and actions in full (record-search + record-field-values agents)
+
+Referenced from `SKILL.md`. This walks the two concrete agents method-by-method so a new agent can be
+modeled on them. The core-package members (`ProceduralAgentLoop`, `BaseAgentAction`, `AgentActionRegistry`,
+`InlineAgentRunner`) belong to the `hb-agent-loop` skill; here we only show how the app uses them.
+
+## Record-search agent — the linear `plan → execute → compose` procedure
+
+`RecordSearchAgentLoop extends ProceduralAgentLoop`. Overrides, in order:
+
+- `#get:maxIterations` → `4` (the procedure normally completes in one iteration; the cap is a safety net).
+- `#get:registry` → `AgentActionRegistry.create({ actions: [PlanSearchAction.create(), ExecuteSearchPlanAction.create(), ComposeAnswerAction.create()] })`. **`ClassifySearchIntentAction` is intentionally not here** — it is the gate, run by the generator before the loop.
+- `#createInitialState({ input })` → `{ result: null }` (`input` unused).
+- `#advanceState({ state })` — the body:
+  1. progress `plan_search / started`
+  2. `plan = await this.performAction({ name: 'planSearch', argumentHash: { message, searchableCategories }, context })`
+  3. `if (!plan)` → return a canned "couldn't understand" result with empty `targetRecords` (deterministic branch, no more AI)
+  4. progress plan completed / execute started; `executed = await this.performAction({ name: 'executeSearchPlan', argumentHash: { plan }, context })`
+  5. progress execute completed (`foundCount`) / compose started; `answer = await this.performAction({ name: 'composeAnswer', argumentHash: { message, resultSummary: { foundCount, isTruncated, resultCategoryName } } })`
+  6. return `{ ...state, result: { message: answer.message, targetRecords: executed.targetRecords } }`
+- `#isComplete({ state })` → `Boolean(state.result)`.
+- `#buildResult({ state })` → `state.result`.
+
+Helpers: `#resolveCategoryName({ originObjectCategoryId })` looks the name up in `context.searchableCategories`
+(`matched?.name ?? null`); `#notifyProgress({ phase, status, foundCount = null })` calls
+`this.context.notifyProgress?.(...)` (no-op in the chat flow, wired only by the standalone search worker).
+
+### The four actions
+
+All extend `BaseRecordSearchAgentAction` (which holds the forced-tool helpers from `SKILL.md`). Each AI
+action overrides `#get:name`, `#get:description`, `#get:toolName`, and `#run()`.
+
+| Action | `name` | `toolName` | AI? | `#run()` returns |
+| --- | --- | --- | --- | --- |
+| `ClassifySearchIntentAction` | `classifySearchIntent` | `classify_search_intent` | yes | `boolean` (`parsed?.isRecordSearch === true`); `false` on any failure |
+| `PlanSearchAction` | `planSearch` | `plan_record_search` | yes | `RecordSearchPlan \| null` (validated) |
+| `ExecuteSearchPlanAction` | `executeSearchPlan` | — | **no** | `{ targetRecords, isTruncated, resultOriginObjectCategoryId }` |
+| `ComposeAnswerAction` | `composeAnswer` | `compose_search_answer` | yes | `{ message }` (always — fallback if AI fails) |
+
+- **`ClassifySearchIntentAction#run()`** — loads its tool (`context.classifySearchIntentAiToolId`); on
+  missing tool / `response.hasError()` / no function call → `false`; else parse and return
+  `parsed?.isRecordSearch === true`. The gate defaults to "not a search" whenever anything is uncertain.
+- **`PlanSearchAction#run()`** — forced-tool flow, then `#normalizePlan({ functionCall, searchableCategories })`.
+  Normalization is strict: every step's category id must be in the catalog `Set`; the plan must be
+  non-empty; the first step must be `kind: 'anchor'`; `resultStepIndex` must be in range; an
+  `association` step's `fromStepIndex` must reference an earlier step (`0 <= fromStepIndex < index`, 1-hop
+  only). Any violation → `null`, which the loop turns into the "couldn't understand" branch.
+- **`ExecuteSearchPlanAction#run()`** — **no AI**. `#executeSteps()` runs the steps sequentially with a
+  `reduce` over `Promise.resolve([])`, threading prior results; an `anchor` step calls
+  `context.recordSearchService.searchAnchorRecords({ originObjectCategoryId, keyword })`, an `association`
+  step calls `context.recordSearchService.findAssociatedRecords({ targetOriginObjectCategoryId, sourceRecords })`
+  using `priorResults[step.fromStepIndex]`. It then picks `stepResults[plan.resultStepIndex]`.
+- **`ComposeAnswerAction#run()`** — computes a deterministic `#buildFallbackMessage()` first, loads its
+  tool, and returns `{ message: parsed.message }` only when the AI produced a non-empty string; otherwise
+  returns `{ message: fallbackMessage }`. **This step never returns null** — the user always gets a reply.
+
+### Instruction building (shared shape)
+
+Each AI action's `#buildInstruction(...)` joins a `lines` array with `\n` and embeds user/catalog data in
+CDATA blocks, e.g. `<user_request><![CDATA[${message}]]></user_request>` and
+`<searchable_categories>${categoriesJson}</searchable_categories>`, and states "call the tool `<toolName>`
+exactly once." Serialized catalogs carry only the minimum fields (`originObjectCategoryId`, `name`).
+
+## Record-field-values agent — a branching `narrow → search → fill` procedure
+
+`RecordFieldValuesAgentLoop extends ProceduralAgentLoop` follows the same skeleton but shows what varies
+between agents:
+
+- `#get:maxIterations` → `3`.
+- `#get:registry` → `SelectSearchTargetsAction`, `SearchEditOptionsAction`, `FillFormAction`.
+- `#createInitialState()` → `{ searchedOptionsByColumnId: {}, result: null }` (richer than record-search).
+- `#advanceState()` has **conditional branches** (not a fixed linear chain):
+  - `searchableColumns = context.editableColumns.filter(column => column.searchOption?.hasTextSearch === true)`
+  - `targets` = `[]` when there are no searchable columns, else `selectSearchTargets`
+  - `searchedOptionsByColumnId` = `{}` when there are no targets, else `searchEditOptions`
+  - always `filled = fillForm({ message, editableColumns, currentValues, fixedOptionsByColumnId, searchedOptionsByColumnId })`
+  - returns `{ ...state, searchedOptionsByColumnId, result: filled }` where `filled` is `{ message, updateValues }`
+- `#isComplete()` / `#buildResult()` identical to record-search.
+- **No `notifyProgress`** — this agent does not emit phase progress.
+- Context keys used: `editableColumns`, `message`, `currentValues`, `fixedOptionsByColumnId` (vs
+  record-search's `message`, `searchableCategories`, `notifyProgress`).
+
+The takeaway: the **skeleton is fixed** (six overridden members, immutable state, actions matched by
+`name`), and what an agent customizes is the **procedure in `#advanceState()`**, the **action set in
+`#get:registry`**, and the **context keys** its steps read.
+
+## The forced-single-tool turn (shared by every AI action)
+
+The pattern, provided once on the app base and reused by all AI actions:
+
+1. `toolPayloadObject = await this.loadToolPayloadObject({ aiToolId })` — the tool JSON from the `AiTool`
+   table (see the `hb-ai-prompt-document-store` skill); `null` guards the step.
+2. `instruction = this.buildInstruction(...)` — CDATA-wrapped user data + "call `<toolName>` once".
+3. `response = await this.sendForcedToolRequest({ context, instruction, toolPayloadObject })` — one turn
+   with `isAutoHandleFunctionCall: false`, `toolChoices: [{ name }]`, `tools: [toolPayloadObject]` (see the
+   `hb-multi-llm-provider` skill for `context.processor.sendRequestToAi`).
+4. `if (response.hasError())` → fallback/`null`.
+5. `functionCall = this.extractFunctionCallFromAiResponse({ response, toolName })` → `null` guard.
+6. `parsed = this.parseFunctionCallArguments({ functionCall })` → the typed step output, then
+   **re-validated in code** before use.

--- a/kit/skills/backend/hb-ai-prompt-document-store/SKILL.md
+++ b/kit/skills/backend/hb-ai-prompt-document-store/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: hb-ai-prompt-document-store
+description: >
+  Store and compose AI-agent prompts and documents from the database rather than hard-coding them
+  in a renchan backend — agent config, default and role instructions, documents, and tool schemas
+  all held as data, assembled into the runtime prompt at request time and versioned through backup
+  tables. Use whenever the user asks to add or change how agent instructions, roles, documents or
+  tools are stored, seeded, read or written, or to model the AiAgent / Document / AiTool tables.
+---
+
+# AI Prompt & Document Store (DB-backed prompts, documents, and tools)
+
+Every editable part of an AI agent — its instruction, its role, its attached documents, and its available
+tool schemas — lives in the database, not in code. At request time a **composer** turns those rows into the
+final prompt; edits are ordinary data changes, versioned by backup tables.
+
+## Grand principle: prompts, documents, and tool schemas are versioned data; the prompt is composed at runtime
+
+Nothing agent-facing is a string constant in code. The agent's `instruction` and `role` are DB columns; its
+documents are `Document` rows linked by an assignment; its tools are JSON stored in `AiTool.payload`. A
+`DocumentInstructionComposer` assembles the runtime prompt from these rows; every editable text has a `*Bk`
+backup copy so history is preserved.
+
+- **Why store prompts in the DB**: instruction/role wording changes constantly and per-agent — making it
+  data means editing it is a mutation (with history), not a deploy. Seeders provide the baseline text from
+  `constants/aiConstants.cjs`; runtime edits go through resolvers.
+- **Why compose at runtime from parts**: a prompt is not one blob. It is **background knowledge** (RAG docs +
+  runtime datetime) + **task-specific instruction** (docs + instruction for this call) + **agent preset**
+  (the agent's own instruction). Composing these separately lets each source change independently and lets
+  RAG (see the `hb-light-rag` skill) inject only what a task needs.
+- **Why tool schemas as `AiTool.payload` JSON**: the actions in the `hb-ai-agent-structure` skill hold only a
+  tool **id** and `JSON.parse(payload)` at runtime — so tool wording/parameters are data. Provider tools
+  (Claude web search, Gemini googleSearch) and function-declaration tools live side by side as rows.
+- **Why `*Bk` / `*StatusPhase` history**: `.save()` on a `BackupMixinModel` copies the pre-change row into
+  its backup table, so the live row always holds the current value while every prior version is retained —
+  you get an audit trail for free (never overwrite without it).
+
+## The store at a glance
+
+| Concern | Where |
+| --- | --- |
+| Agent identity | `AiAgent` (`name`, `description`) |
+| Agent **instruction** (preset) | `AiAgentDefaultInstruction.instruction` (TEXT) → `AiAgentDefaultInstructionBk` |
+| Agent **role** (system prompt) | `AiAgentRoleInstruction.role` (TEXT) → `AiAgentRoleInstructionBk` |
+| Agent model | `AiAgentDefaultModel → AiModel` (see `hb-multi-llm-provider` skill) |
+| Agent documents | `AiAgentDocumentAssignment` → `Document` + `DocumentAttachmentCategory` |
+| Documents | `Document.content` (+ `DocumentEmbedding` / `DocumentSkill`; see `hb-light-rag` skill) → `DocumentBk` |
+| Agent tools | `AiAgentAvailableAiTool` → `AiTool.payload` (JSON schema) |
+| Status / history | `AiAgentLatestStatus`+`AiAgentStatusPhase`, `DocumentLatestStatus`+`DocumentStatusPhase` |
+
+## 1. Composing the runtime prompt — `DocumentInstructionComposer`
+
+`.createAsync(...)` wires a `TaskSpecificInstructionGenerator` and an `AiAgentBaseKnowledgeAssembler` (the
+light-rag seam), plus the agent's `defaultInstruction`. `#generateComposedInstruction()` joins **three
+parts** with `\n\n`, in this order:
+
+```js
+generateComposedInstruction () {
+  const taskSpecificInstruction = this.taskSpecificInstructionGenerator.generateInstruction()
+  const backgroundKnowledge = this.aiAgentBaseKnowledgeAssembler.generateBackgroundKnowledge()
+  const defaultInstruction = this.generateDefaultInstruction()
+
+  return [
+    backgroundKnowledge,     // 1. runtime datetime + BASE docs (inlined) + dynamic doc bodies (RAG)
+    taskSpecificInstruction, // 2. this call's documents + instruction
+    defaultInstruction,      // 3. the agent preset
+  ]
+    .join('\n\n')
+}
+```
+
+The parts are XML-wrapped so the model can tell them apart:
+
+- **Part 3 — agent preset**: `<instruction><agent_preset>${defaultInstruction}</agent_preset></instruction>`.
+- **Part 2 — task-specific** (`TaskSpecificInstructionGenerator#generateInstruction`): a `<documents>` block
+  (`<document index=N><source>…</source><content>…</content></document>`) followed by
+  `<instruction>${instruction}</instruction>`. Its documents are loaded from the DB by id
+  (`Document.findAll`) plus any one-time documents, sorted by `order`.
+- **Part 1 — background knowledge** (`AiAgentBaseKnowledgeAssembler`): runtime datetime + BASE-knowledge
+  document bodies inlined + the dynamic-documents section (RAG) when prefetch selected any. This is the
+  `hb-light-rag` skill's output.
+
+## 2. Exporting an agent as a document — `#generateAiAgentDocument()`
+
+The same composer also renders a **Markdown** document (used by the export mutation), created with the three
+generator deps `null` — only the formatting methods are used:
+
+```
+# AI Agent: <name>
+
+<description>
+
+## Default Instructions
+
+<AiAgentDefaultInstruction.instruction>
+
+## Attached Documents
+
+### Document 1: <name>
+
+*<description>*
+
+<content>
+```
+
+`#formatAttachedDocuments()` sorts `AiAgentDocumentAssignments` by `order`, or emits "*No documents
+attached*".
+
+## 3. The models — prompts vs documents
+
+All extend `BaseAppRenchanModel`, attributes via `ModelAttributeFactory` (`factory.ID_BIGINT` for
+entities/junctions, `factory.ID_INTEGER` for small status lookups). See the **`hb-sequelize-model` skill** for
+the declaration conventions.
+
+**Prompt / agent:**
+
+| Model | Key columns | Notable |
+| --- | --- | --- |
+| `AiAgent` | `name`, `description`, `registeredAt`, `savedAt` | hasOne `AiAgentDefaultInstruction`/`AiAgentRoleInstruction`/`AiAgentDefaultModel`/`AiAgentLatestStatus`; hasMany `AiAgentDocumentAssignment`/`AiAgentAvailableAiTool` |
+| `AiAgentDefaultInstruction` | `AiAgentId`, `instruction` (TEXT), `savedAt` | `BackupMixinModel` → `AiAgentDefaultInstructionBk` |
+| `AiAgentRoleInstruction` | `AiAgentId`, `role` (TEXT), `savedAt` | `BackupMixinModel` → `AiAgentRoleInstructionBk` (the system prompt) |
+| `AiAgentDefaultModel` | `AiAgentId`, `AiModelId`, `savedAt` | model selection (`hb-multi-llm-provider` skill) |
+| `AiAgentDocumentAssignment` | `AiAgentId`, `DocumentId`, `DocumentAttachmentCategoryId` (default 1), `order` | binds documents; BASE vs DYNAMIC + `order` |
+| `AiAgentAvailableAiTool` | `AiAgentId`, `AiToolId`, `isEnabled`, `isDefault` | which tools the agent may use |
+| `AiAgentDocumentInstructionRecord` | `DocumentId`, `AiAgentId`, `instruction` (TEXT) | per-document instruction override |
+
+**Document:**
+
+| Model | Key columns | Notable |
+| --- | --- | --- |
+| `Document` | `name`, `description`, `content` (TEXT, the body), `generatedAt` | `BackupMixinModel` → `DocumentBk`; hasOne `DocumentEmbedding`/`DocumentSkill` (`hb-light-rag` skill) |
+| `DocumentAttachmentCategory` | `name`, `displayName`, `displayOrder` | `BASE_KNOWLEDGE {ID:1}` (body inlined) vs `DYNAMIC_DOCUMENT {ID:2}` (catalog only) |
+| `DocumentSkill` | `DocumentId`, `skillName`, `skillCoverageDescription`, `contextHint` | `BackupMixinModel` → `DocumentSkillBk`; drives dynamic catalog |
+
+**Tool:**
+
+| Model | Key columns | Notable |
+| --- | --- | --- |
+| `AiTool` | `name`, `description`, `payload` (TEXT, **stringified JSON schema**), `isVisible`, `displayOrder` | no associations; loaded by PK + `JSON.parse(payload)` at runtime |
+
+### The `*Bk` / `*StatusPhase` history pattern
+
+`AiAgentRoleInstruction` declares `static get Mixins () { return [BackupMixinModel] }` and
+`static get BackupModel () { return this._.AiAgentRoleInstructionBk }`. The `*Bk` model is a plain
+`BaseAppRenchanModel` with **identical columns** and no mixin — the write-once history sink. On `.save()`
+the mixin copies the pre-change row into `*Bk`. Same for `AiAgentDefaultInstruction`, `Document`,
+`DocumentSkill`. A variant: `AiAgentLatestStatus` / `DocumentLatestStatus` use `BackupMixinModel` but point
+`BackupModel` at the `*StatusPhase` table — every status change appends a phase row while the LatestStatus
+row is mutated in place. **This is why writes use `.save()`, never `.update()`** (see the sequelize-model
+skill).
+
+## 4. `AiTool.payload` — tool schemas as data
+
+Tool schemas are `JSON.stringify`-ed into `AiTool.payload` by seeders and `JSON.parse`-d at runtime:
+
+- **Provider tools** (`sequelize/seeders/master/…-ai_tools_related.cjs`): e.g. Claude
+  `JSON.stringify({ type: 'web_search_20250305', name: 'web_search' })`, OpenAI
+  `{ type: 'web_search_preview' }`, Gemini `{ googleSearch: {} }`.
+- **Function-calling tools** (from `constants/aiRecordSearchToolsConstants.cjs`): full
+  function-declaration objects (`{ name, description, parameters: { type, properties, required } }`)
+  stringified into `payload`, seeded with `is_visible: false` (internal forced tools — see the
+  `hb-ai-agent-structure` skill).
+
+Runtime read (in an action): `const aiTool = await AiTool.findByPk(aiToolId); JSON.parse(aiTool.payload)`.
+Agent↔tool binding is `AiAgentAvailableAiTool`; model↔tool availability is `AiModelToolAssignment`.
+
+## 5. Seeders — master / dev-master / development
+
+Three tiers under `sequelize/seeders/` (see the **sequelize-seeder skill**):
+
+- **`master/`** — production baseline: the built-in system-worker agents and the AI-tools rows.
+- **`dev-master/`** — the same data duplicated for the dev DB (identical filenames).
+- **`development/`** — sample/demo rows with high fixed ids (`documents-id1000`, `ai_agents-id50000`).
+
+Pattern: `TimestampSeedsSupplier.supplyAll(rows)` + `queryInterface.bulkInsert`; `down` = `bulkDelete` by
+id. **Prompt text comes from `constants/aiConstants.cjs` → `DEFAULT_AI_AGENT.*`** — each entry has
+`ID`, `NAME`, `DESCRIPTION`, `DEFAULT_INSTRUCTION` (→ `ai_agent_default_instructions.instruction`),
+`ROLE_INSTRUCTION` (→ `ai_agent_role_instructions.role`). A single agent seeder wires ~10 tables (agent,
+default/role instruction, latest status + status phase, default model, avatar, role category, emotional
+level). See the **`hb-constant-definition` skill** for the `.cjs` constants rule.
+
+## 6. Reading and writing (resolvers)
+
+Schema `server/graphql/schemas/user/019-aiAgent.graphql` — queries `aiAgent` / `aiAgents` / `aiModels`;
+mutations `addAiAgent` / `updateAiAgent` / `updateAiAgentStatus` / `exportAiAgentInstructionDocument` /
+`generateDocumentByAiAgent`.
+
+- **Read** (`AiAgentQueryResolver`): `AiAgent.findOne` with a deep `include` (LatestStatus, DefaultModel,
+  AvailableAiTool→AiTool `where isVisible`, DocumentAssignment→Document + DocumentAttachmentCategory
+  ordered by `order`, `AiAgentDefaultInstruction`, `AiAgentRoleInstruction`, …); `#formatResponse()` exposes
+  `instruction` (from `AiAgentDefaultInstruction.instruction`) and `role` (from `AiAgentRoleInstruction.role`).
+  The list resolver omits the instruction bodies. See the **`hb-query-resolver` skill**.
+- **Write** (`AddAiAgentMutationResolver` / `UpdateAiAgentMutationResolver`): one transaction; build a nested
+  `AiAgent.build({ AiAgentDefaultInstruction: { instruction }, AiAgentRoleInstruction: { role },
+  AiAgentDocumentAssignments: [...], AiAgentDefaultModel, AiAgentLatestStatus })` with cascading `include`,
+  then bulk-create `AiAgentAvailableAiTool`. Update uses `.set(...)` + `await
+  builtAiAgent.AiAgentDefaultInstruction.save()` / `.AiAgentRoleInstruction.save()` (**these `.save()` calls
+  trigger the `*Bk` backup**), then destroy+recreate the assignment/tool rows. Verify requested tools belong
+  to the model (`AiModelToolAssignment`). See the **`hb-mutation-resolver` skill**.
+- **Export** (`ExportAiAgentInstructionDocumentMutationResolver`): loads the agent, in a transaction calls
+  `DocumentInstructionComposer.create({ ...: null }).generateAiAgentDocument({ aiAgent })`, persists a
+  `Document` (status DRAFT), and **after commit** dispatches `DocumentEmbeddingDispatcher` +
+  `DocumentSkillSnapshotDispatcher` jobs so the exported document is indexed for later dynamic retrieval
+  (`hb-light-rag` skill; jobs via the `hb-renchan-job-bullmq` skill).
+
+## Cross-cutting rules
+
+- **No agent-facing text as a code constant** — instruction/role/document/tool text is DB data; baseline
+  comes from seeders.
+- **Write editable text with `.save()` on the backup-mixin model**, never `.update()`, so history is
+  captured; wrap multi-table writes in one transaction.
+- **Compose the prompt at runtime from the three parts** — do not concatenate a prompt by hand in a resolver.
+- Return `null` for missing values, not `undefined`; one class per file; migrations use snake_case `field:`
+  names (see the `hb-sequelize-migration` skill).
+
+## Detail files
+
+- [models-and-composition.md](./references/models-and-composition.md) — every prompt/document/tool model
+  with columns and associations, the `*Bk` / `*StatusPhase` mechanics, the full composed-instruction and
+  exported-document skeletons, and the seeder wiring from `DEFAULT_AI_AGENT`.

--- a/kit/skills/backend/hb-ai-prompt-document-store/references/models-and-composition.md
+++ b/kit/skills/backend/hb-ai-prompt-document-store/references/models-and-composition.md
@@ -1,0 +1,156 @@
+# Models and composition (full)
+
+Referenced from `SKILL.md`. The exact model shapes, the backup/history mechanics, the composed-prompt and
+exported-document skeletons, and the seeder wiring.
+
+## Composed runtime prompt — the three XML parts
+
+`DocumentInstructionComposer#generateComposedInstruction()` joins with `\n\n`, in order: background
+knowledge → task-specific → agent preset.
+
+- **Agent preset** (`#generateDefaultInstruction()`):
+  `<instruction><agent_preset>${this.defaultInstruction}</agent_preset></instruction>`.
+- **Task-specific** (`TaskSpecificInstructionGenerator#generateInstruction()`):
+
+  ```
+  attached documents for this task:
+  <documents>
+  <document index=0>
+  <source>${name}</source>
+  <content>${content}</content>
+  </document>
+  </documents>
+  Instruction for this task:
+  <instruction>
+  ${this.instruction}
+  </instruction>
+  ```
+
+  Documents are loaded by id (`Document.findAll({ where: { id } })`) plus one-time docs (named
+  `Additional Reference N`), sorted by `order`.
+- **Background knowledge** (`AiAgentBaseKnowledgeAssembler#assembleCombinedBackgroundSection()`, joined with
+  `\n\n`, empties filtered):
+  - runtime datetime:
+    `<runtime_context>\n<current_datetime_iso>${iso}</current_datetime_iso>\n</runtime_context>`
+  - BASE-knowledge docs (bodies inlined) preceded by the legacy delimiter line
+    `----Please remember the content of the document below as prior knowledge, and then respond to the
+    instructions-----`, then a `<documents>…<document index=N><source>…</source><content>…</content>
+    </document>…</documents>` block.
+  - dynamic docs (only when prefetch selected any):
+    `<dynamic_documents_retrieved_for_background>\n<![CDATA[${payload}]]>\n
+    </dynamic_documents_retrieved_for_background>` — the payload is the `hb-light-rag` skill's
+    `<retrieve_dynamic_documents_result>` XML.
+
+  BASE vs DYNAMIC is decided by `DocumentAttachmentCategoryId ===
+  DOCUMENT_ATTACHMENT_CATEGORY.BASE_KNOWLEDGE.ID`.
+
+## Exported Markdown document
+
+`#generateAiAgentDocument({ aiAgent })` (composer built with all three deps `null`):
+
+```
+# AI Agent: <name>
+
+<description>
+
+## Default Instructions
+
+<AiAgentDefaultInstruction.instruction>
+
+## Attached Documents
+
+### Document 1: <name>
+
+*<description>*
+
+<content>
+```
+
+`#formatAttachedDocuments()` sorts `AiAgentDocumentAssignments` by `order`, else "*No documents attached*".
+
+## Prompt / agent models (columns + associations)
+
+- `AiAgent` — `name` STRING(191), `description` TEXT, `registeredAt`/`savedAt`/`lastModifiedAt`,
+  `CreatedByUserId`/`LastModifiedByUserId`. hasOne: `AiAgentLatestStatus`, `AiAgentDefaultInstruction`,
+  `AiAgentRoleInstruction`, `AiAgentAvatarUrl`, `AiAgentRoleCategory`, `AiAgentEmotionalLevel`,
+  `AiAgentDefaultModel`. hasMany: `AiAgentStatusPhase`, `AiAgentAvailableAiTool`, `AiAgentTagAssignment`,
+  `AiAgentDocumentAssignment`, `AiAgentDocumentInstructionRecord`. belongsToMany `AiAgentTag`, and `Document`
+  as `GeneratedDocuments` via `AiAgentDocumentGeneration`.
+- `AiAgentDefaultInstruction` — `AiAgentId`, `instruction` TEXT, `savedAt`; belongsTo `AiAgent`;
+  `BackupMixinModel` → `AiAgentDefaultInstructionBk`.
+- `AiAgentRoleInstruction` — `AiAgentId`, `role` TEXT, `savedAt`; belongsTo `AiAgent`; `BackupMixinModel` →
+  `AiAgentRoleInstructionBk`. (`role` is the provider system prompt — see the `hb-multi-llm-provider` skill's
+  payload generators.)
+- `AiAgentDefaultModel` — `AiAgentId`, `AiModelId`, `savedAt`; belongsTo `AiAgent`, `AiModel`.
+- `AiAgentAvailableAiTool` — `AiAgentId`, `AiToolId`, `isEnabled` BOOL, `isDefault` BOOL, `savedAt`;
+  belongsTo `AiAgent`, `AiTool`.
+- `AiAgentDocumentAssignment` — `AiAgentId`, `DocumentId`, `DocumentAttachmentCategoryId` (default 1),
+  `order` INT, `savedAt`; belongsTo `AiAgent`, `Document`, `DocumentAttachmentCategory`.
+- `AiAgentDocumentInstructionRecord` — `DocumentId`, `AiAgentId`, `instruction` TEXT, `savedAt`.
+- `AiAgentStatus` — `ID_INTEGER`, `name`, `description` STRING(191); hasMany `AiAgentLatestStatus`,
+  `AiAgentStatusPhase`.
+- `AiAgentLatestStatus` — `AiAgentId`, `AiAgentStatusId` INT, `savedAt`; belongsTo `AiAgent`,
+  `AiAgentStatus`; subquery `?AiAgentStatusId.AiAgentId`; `BackupMixinModel` → `AiAgentStatusPhase`.
+- `AiAgentStatusPhase` — `AiAgentId`, `AiAgentStatusId` INT, `savedAt` (the status history sink).
+
+## Document models (columns + associations)
+
+- `Document` — `name` STRING(191), `description` TEXT, `content` TEXT (the body), `generatedAt`,
+  `savedAt`/`lastModifiedAt`, `CreatedByUserId`/`LastModifiedByUserId`. hasOne `DocumentLatestStatus`,
+  `DocumentSkill`, `DocumentSkillGenerationOutcome`, `DocumentEmbedding`; hasMany `DocumentStatusPhase`,
+  `AiAgentDocumentAssignment`, `AiAgentDocumentInstructionRecord`, `AiAgentDocumentGeneration`,
+  `AiChatRoomMessageDocumentLinkage`; `BackupMixinModel` → `DocumentBk`.
+- `DocumentEmbedding` — `DocumentId`, `embedding` TEXT, `embeddingModelVersion` STRING(191),
+  `embeddingDimension` INT, `savedAt` (`hb-light-rag` skill).
+- `DocumentSkill` — `DocumentId`, `skillName` STRING(191), `skillCoverageDescription` TEXT, `contextHint`
+  TEXT, `generatedAt`; `BackupMixinModel` → `DocumentSkillBk`.
+- `DocumentAttachmentCategory` — `name`, `description`, `displayName` STRING(191), `displayOrder` INT;
+  hasMany `AiAgentDocumentAssignment`.
+- `DocumentStatus` — `ID_INTEGER`, `name`, `description`; hasMany `DocumentLatestStatus`,
+  `DocumentStatusPhase`.
+- `DocumentLatestStatus` — `DocumentId`, `DocumentStatusId` INT, `savedAt`; `BackupMixinModel` →
+  `DocumentStatusPhase`.
+- `DocumentStatusPhase` — `DocumentId`, `DocumentStatusId` INT, `savedAt`.
+
+## Tool model
+
+- `AiTool` — `name` STRING(191), `description` STRING(191), `payload` TEXT (NOT NULL, stringified JSON
+  schema), `displayOrder` INT (default 0), `isVisible` BOOL (default true), `savedAt`; `associate()` is
+  noop. Migration `…-create_table-ai_tools.cjs` → table `ai_tools`, column `payload` TEXT NOT NULL.
+- `AiModelToolAssignment` (join) — `AiModelId`, `AiToolId`, `savedAt` (model↔tool availability).
+
+## The `*Bk` / `*StatusPhase` mechanics
+
+- A backed-up model declares `static get Mixins () { return [BackupMixinModel] }` and
+  `static get BackupModel () { return this._.<Name>Bk }`. The `*Bk` model has identical columns, no mixin,
+  no `BackupModel` — the write-once sink. `.save()` copies the pre-change row into `*Bk`.
+- Status variant: `AiAgentLatestStatus` / `DocumentLatestStatus` set `BackupModel` to the `*StatusPhase`
+  table — each change appends a phase row while the latest row is updated in place. Subqueries like
+  `?AiAgentStatusId.AiAgentId` filter agents by current status.
+- Consequence: **always `.save()` on these models, never `.update()`** — `.update()` can bypass the mixin and
+  lose history / miss columns.
+
+## Seeder wiring from `DEFAULT_AI_AGENT`
+
+`constants/aiConstants.cjs` → `DEFAULT_AI_AGENT` is keyed by well-known agent; each entry:
+`{ ID, NAME, DESCRIPTION, DEFAULT_INSTRUCTION, ROLE_INSTRUCTION }`. A master agent seeder (e.g.
+`…-ai_agent_for_document_skill_snapshot.cjs`) `require`s it and seeds across ~10 tables in one file:
+
+- `ai_agents` (`name`/`description` from the entry)
+- `ai_agent_default_instructions` — `instruction: DEFAULT_AI_AGENT.<KEY>.DEFAULT_INSTRUCTION`
+- `ai_agent_role_instructions` — `role: DEFAULT_AI_AGENT.<KEY>.ROLE_INSTRUCTION`
+- `ai_agent_latest_statuses` + `ai_agent_status_phases` (from `AI_AGENT_STATUS`)
+- `ai_agent_default_models` (an `AI_MODEL.*.ID`)
+- plus `ai_agent_avatar_urls`, `ai_agent_role_categories`, `ai_agent_emotional_levels`,
+  `ai_agent_tag_assignments`
+
+Tool seeders: `…-ai_tools_related.cjs` seeds `ai_tools` + `ai_model_tool_assignments` (Claude→Anthropic
+models, OpenAI→OpenAI, Gemini→Google, from `AI_MODEL` provider ids); `…-ai_tools-record-search.cjs` seeds
+`ai_tools` only, payloads from `aiRecordSearchToolsConstants.cjs`, `is_visible: false`. Document seeder
+(`development/…-documents-id1000.cjs`) seeds `documents` (markdown `content`) then derives
+`document_latest_statuses` + `document_status_phases` (`DOCUMENT_STATUS.ACTIVE.ID`).
+
+Relevant limits/categories in `aiConstants.cjs`: `AI_AGENT` (`MAX_INSTRUCTION_LENGTH: 10000`,
+`MAX_ROLE_LENGTH: 200`, `MAX_NAME_LENGTH: 50`, `MAX_DESCRIPTION_LENGTH: 500`),
+`DOCUMENT_ATTACHMENT_CATEGORY` (`BASE_KNOWLEDGE {ID:1}` / `DYNAMIC_DOCUMENT {ID:2}`), `DOCUMENT_STATUS`,
+`AI_AGENT_STATUS`.

--- a/kit/skills/backend/hb-backend-testing/SKILL.md
+++ b/kit/skills/backend/hb-backend-testing/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: hb-backend-testing
+description: >
+  Organize and run the backend repository's tests: where a test file goes (tests/__tests__ for
+  tests that do not write to the database, tests/_orders for tests that do), how run order among
+  DB-writing tests is guaranteed, how to run the whole suite or a single test, and the purity
+  rules for tests and their doubles. Use whenever the user asks where to place a test, how to
+  guarantee test order, how to run tests, or how to keep tests pure. Manual E2E verification is
+  out of scope.
+---
+
+# Backend Testing
+
+A skill for **implementing tests in a backend repository**: **where** each test file belongs, **how**
+DB-writing tests are ordered so they do not corrupt each other, **how** to run them, and the
+**purity** rules that keep a failing test meaningful. It governs test *organization and discipline* —
+the *writing style* of an individual test (describe/test structure, case data, naming) follows the
+project's own Jest conventions and is out of scope here.
+
+> This skill states a **general, project-independent rule**, not one repo's current tree. The
+> directory names (`tests/__tests__`, `tests/_orders`, `tests/mocks`, `tests/tools`) are the
+> **recommended layout** — map them onto your project. Sample code follows the project's lint style
+> (no semicolons, 2-space indent, trailing commas).
+
+## Core principle: a test fails only when the code under test is wrong
+
+A test must fail **only** because the code it exercises is wrong — not because another test ran
+first, and not because the test itself contains untested logic. Two rules enforce that, and
+everything below follows from them:
+
+1. **Isolate database state.** A test that **writes to the DB** mutates shared seed data that other
+   tests read, so it is placed **apart** from tests that don't, and **ordered** among its peers.
+2. **Keep tests pure.** A test may only exercise code that is **itself already tested** — no logic is
+   invented inside a test, and every mock/tool it leans on has its own test cases.
+
+## 1. Placement & execution order
+
+Split every test by one question: **does it write to the database?**
+
+| Location | Contents | Ordering |
+| --- | --- | --- |
+| `tests/__tests__/` | tests that **do not** write to the DB (pure units, read-only) | order-independent — run in any order |
+| `tests/_orders/<Category>/` | tests that **do** write to the DB | order-**guaranteed within a category** via a `_.test.js` barrel |
+
+- **Why the split.** A DB-writing test changes the shared `development` / `dev-master` seed fixtures,
+  so a later test can observe a mutated database. Read-only tests can't interfere, so they need no
+  ordering; DB-writing tests must be ordered.
+- **The order barrel.** Each category folder holds `_.test.js` that **imports its test files in the
+  order they must run** — that import order *is* the execution order within the category.
+- **Cross-category order is NOT guaranteed.** `_orders` fixes order *within* a category only. If two
+  categories can interfere, isolate them into **separate CI jobs** — add/update a
+  `.github/workflows/*.yml` per category so each runs against its own fresh database.
+- **Verification against real middleware belongs in neither location.** Exercising the product
+  against a real broker, search cluster and change-data-capture pipeline needs those services brought
+  up in Docker and is done **by hand, outside `tests/` entirely** — see the E2E environment
+  convention. No such file is added here, and `npm run test` stays runnable with nothing but Node
+  installed.
+
+Details, the barrel example, and the per-category workflow snippet are in
+[placement-and-ordering.md](./references/placement-and-ordering.md).
+
+## 2. Running tests
+
+- **Whole suite**: `npm run test` — rebuilds the DB (teardown → migrate → seed) and runs everything on
+  **SQLite** (the local default). Authoritative, slowest.
+- **A single test (fast, no rebuild)**: iterate by invoking Jest directly against one file —
+  `NODE_OPTIONS="--experimental-vm-modules" NODE_ENV=development npx jest <path>` (add `--runInBand`
+  for DB-writing/order-sensitive tests). It runs against the DB **as it currently is**, so prepare the
+  DB once and reset it piecemeal (migrations-only / one-seeder-set) instead of a full rebuild.
+- **Live (real-dialect) run**: running against MariaDB instead of SQLite **requires a MariaDB
+  running locally**, selected with `NODE_ENV=live`. How that database is stood up is not part of this
+  convention.
+- **Parallelism × per-worker heap must fit in real memory.** Jest runs one worker per core by
+  default, and `--max-old-space-size` is **not a reservation — it is how far the GC may be
+  deferred**, so a value the machine cannot actually give lets every worker grow until it crashes
+  the machine (one worker alone can do it). Derive the cap from a **measured peak**, check that
+  workers × cap fits in the memory actually free, and re-check as the project grows: per-worker
+  usage rises with every model and seeder added, so a pair that fit at the start can later crash the
+  machine.
+
+The exact commands, the suite runner's steps, the fast single-test loop with the piecemeal DB
+reset, and how to size the worker/heap budget are in
+[running-tests.md](./references/running-tests.md).
+
+## 3. Test purity & test doubles
+
+- **No new logic in a test.** Never define a function or class inside a test to compute an expected
+  value or stand in for production behavior — an untested helper can be wrong, making the test lie.
+  Assert against literal expectations.
+- **Everything a test uses must already be tested.** Every function, class, mock, and tool the test
+  leans on has its own test cases.
+- **Doubles live under `tests/`, and are themselves tested.** Mocks go in `tests/mocks/`, shared test
+  tools/factories in `tests/tools/`, and **each mock class has its own test file**. Prefer explicit
+  fakes (obviously-fake names/values).
+
+The rule with good/avoid examples, and the mocks/tools layout, are in
+[purity-and-mocks.md](./references/purity-and-mocks.md).
+
+## Finishing checklist
+
+- [ ] The test is in `tests/__tests__/` if it does no DB write, or `tests/_orders/<Category>/` if it does ([§1](#1-placement--execution-order)).
+- [ ] A DB-writing test is imported (in the right position) by its category's `_.test.js` barrel.
+- [ ] If the new test's category can interfere with another, a per-category CI workflow isolates them.
+- [ ] The test defines **no** new logic; every function/class/mock it uses is already tested ([§3](#3-test-purity--test-doubles)).
+- [ ] Any new mock/tool lives under `tests/mocks/` or `tests/tools/` and has its **own** test file.
+- [ ] Verified with a single-test run ([§2](#2-running-tests)).
+
+## Detail files
+
+- [placement-and-ordering.md](./references/placement-and-ordering.md) — `__tests__` vs `_orders`, why
+  DB-writing tests need ordering, the `_.test.js` order barrel, cross-category isolation via
+  per-category CI workflows (§1)
+- [running-tests.md](./references/running-tests.md) — the whole-suite runner and what it does, running
+  a single test with the dev/master seed sets, resetting the database piecemeal, sizing the
+  parallelism × heap budget against real memory, and what a live (real-dialect) run requires (§2)
+- [purity-and-mocks.md](./references/purity-and-mocks.md) — no-new-logic and only-tested-code rules
+  with good/avoid examples, and the `tests/mocks` / `tests/tools` layout where doubles are themselves
+  tested (§3)

--- a/kit/skills/backend/hb-backend-testing/references/placement-and-ordering.md
+++ b/kit/skills/backend/hb-backend-testing/references/placement-and-ordering.md
@@ -1,0 +1,89 @@
+# Placement & execution order
+
+Where a test file goes, and how DB-writing tests are ordered so they do not corrupt each other.
+Referenced from §1 of [SKILL.md](../SKILL.md). Directory and category names are the recommended
+layout with illustrative fakes.
+
+## The two locations
+
+Every test file lives in exactly one of two places, chosen by **whether it writes to the database**.
+
+| Location | Put here | Ordering |
+| --- | --- | --- |
+| `tests/__tests__/` | tests that **do not** write to the DB — pure units, read-only queries, formatters, validators | none needed; run in any order |
+| `tests/_orders/<Category>/` | tests that **do** write to the DB — anything that inserts/updates/deletes rows | guaranteed **within a category** by a `_.test.js` barrel |
+
+- Mirror the source tree inside `tests/__tests__/` so a unit's test sits at the matching path.
+- Under `tests/_orders/`, group by a **category** (a cohesive area of write behavior); each category is
+  its own folder.
+- **Classify by what the method _does_, not by whether the test mocks the write away.** A method that
+  writes to the DB directly or transitively (calls `create` / `update` / `destroy` /
+  `beginTransaction`, or orchestrates sub-methods that do) belongs in `_orders` **even if the test
+  stubs the persist call** — mocking the write does not move it to `__tests__`.
+- **Placement is per-method, so one class usually splits across both trees.** A DB-writing class
+  keeps its writing methods in `_orders` and its non-writing methods (`find~`, getters, builders,
+  validators, `format~`) in the sibling `__tests__` file. Do not dump a read-only method into
+  `_orders` just to keep it beside the class's other tests — keeping tests together is not a reason
+  to place it there.
+
+## Why DB-writing tests need ordering
+
+A DB-writing test mutates the **shared seed fixtures** (`development` / `dev-master`) that the running
+database was seeded with. Because the database is shared across the tests in a run, a test that runs
+**after** a mutation observes the changed state.
+
+- Read-only tests can't change what others see, so they never need ordering (hence
+  `tests/__tests__/`); DB-writing tests can, so their run order must be **deterministic**, not left
+  to file-discovery order.
+
+## The `_.test.js` order barrel
+
+Each category folder contains a `_.test.js` that **imports the category's test files in the exact
+order they must run**. Jest discovers `_.test.js`, and its import order becomes the execution order.
+
+```js
+// tests/_orders/<Category>/_.test.js
+// Imports define the run order for this category; add each new test in its correct position.
+import './CreateRecord.js'
+import './UpdateRecord.js'
+import './DeleteRecord.js'
+```
+
+- The individual test files in the folder are **imported by the barrel**, not discovered independently
+  — name them so they are not matched as standalone tests by the runner, and let `_.test.js` be the
+  single entry point for the category.
+- When you add a DB-writing test, add one `import` line to the category's barrel at the position where
+  it must run (e.g. after the test that creates the row it depends on).
+
+## Cross-category isolation via CI
+
+`tests/_orders` guarantees order **within** a category, but **not across** categories — two categories
+run independently and may both mutate overlapping seed data. When two categories can interfere, run
+them in **separate CI jobs** so each starts from its own fresh database.
+
+- Add or update a **per-category** workflow under `.github/workflows/` that runs only that category's
+  path. Two interfering categories then never share a database within a single job.
+
+```yaml
+# .github/workflows/test-<category>.yml — one interfering category, isolated in its own job/DB
+name: test <Category>
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: development
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm ci
+      - run: npm run test -- --seeded tests/_orders/<Category>/
+```
+
+- The default catch-all workflow can run the rest of `tests/_orders/`; peel a category **out** into its
+  own workflow only when it demonstrably interferes with another.

--- a/kit/skills/backend/hb-backend-testing/references/purity-and-mocks.md
+++ b/kit/skills/backend/hb-backend-testing/references/purity-and-mocks.md
@@ -1,0 +1,82 @@
+# Test purity & test doubles
+
+Why a test may only lean on already-tested code, and where test doubles live. Referenced from §3 of
+[SKILL.md](../SKILL.md). Names are illustrative fakes.
+
+## No new logic in a test
+
+Never define a function or class **inside a test** to compute an expected value or to reproduce
+production behavior. Logic written in a test is **untested logic**: if it is wrong, the test passes (or
+fails) for the wrong reason — the test lies instead of catching the bug.
+
+```js
+// Avoid: an untested helper defined in the test computes the expectation
+function buildExpectedLabel ({
+  first,
+  last,
+}) {
+  return `${last} ${first}` // if this is wrong, the assertion is meaningless
+}
+
+expect(formatLabel(input))
+  .toBe(buildExpectedLabel(input))
+```
+
+```js
+// Good: assert against a literal expected value — no logic in the test
+expect(formatLabel({
+  first: 'Ada',
+  last: 'Byte',
+}))
+  .toBe('Byte Ada')
+```
+
+- Assert against **literals** (or values a test fixture already provides), not against something the
+  test recomputes.
+- If the expectation is tedious to write out, that is a signal to build a **tested** fixture/factory
+  (below), not to inline a calculation.
+
+## Everything a test uses must already be tested
+
+Every function, class, mock, and tool a test leans on has its **own** test cases. The chain of trust
+only holds if each link is verified:
+
+- Exercising production code A that internally calls B is fine — B is production code with its own
+  tests. What is banned is **new** code that exists only to serve the test and has no tests of its own.
+- If a test needs a helper to build inputs or doubles, that helper is a **tested tool** (below), not an
+  inline function.
+
+## Mock only when necessary — default to real
+
+A method that **can** run for real must not be mocked: mocking the very behavior a test exists to
+verify lets a hard-coded or regressed implementation still pass. Reach for a mock in only two cases —
+**external systems** (third-party APIs that must never be hit, in success *and* failure tests) and
+**steering an otherwise-unreachable branch** (e.g. forcing a not-found guard that seeded data cannot
+naturally trigger).
+
+- **Never mock a database row — add a seeder instead.** DB-touching tests read real seeded data; if
+  the data you need is missing, extend the seed fixtures rather than stubbing a row. Stubbing a call
+  that could have run for real, or mocking rows, is over-mocking and defeats the test.
+- **Don't hand-query the DB inside a test to check a result.** Assert only the return value of the
+  method under test; never call `Model.findOne` / `findAll` / `update` directly in the test body to
+  fetch or verify state. Exercising the method *is* the test — re-reading the row yourself tests the
+  ORM, not the code under test.
+- A double that is *only ever* borrowed as a stub must still be exercised **for real** in its own
+  test (below) — always test it too.
+
+## Test doubles live under `tests/`, and are themselves tested
+
+Shared test infrastructure has a home, and is held to the same bar as production code.
+
+| Directory | Holds |
+| --- | --- |
+| `tests/mocks/` | mock/stub classes that stand in for a collaborator (a fake model, a fake client, a fake tokenizer) |
+| `tests/tools/` | shared test tools — factories, builders, fixtures used across many tests |
+
+- **Each mock class has its own test file.** A mock is code; an untested mock can drift from the real
+  collaborator's contract and silently invalidate every test that uses it. Test the mock's behavior
+  just like a unit.
+- **Prefer explicit fakes** — obviously-fake class and data names (e.g. `Alpha` / `Beta` sample models,
+  clearly-fake tokens) so a reader never mistakes a double for real data or production code.
+- A double or tool used by exactly one test can sit beside it, but the moment a second test needs it,
+  move it to `tests/mocks/` or `tests/tools/` (with its own test) rather than copy it.

--- a/kit/skills/backend/hb-backend-testing/references/running-tests.md
+++ b/kit/skills/backend/hb-backend-testing/references/running-tests.md
@@ -1,0 +1,186 @@
+# Running tests
+
+How to run the whole suite, a single test (with and without rebuilding the database), reset the
+database piecemeal, size the worker/heap budget so a run cannot take the machine down, and what a
+live (real-dialect) run requires. Referenced from §2 of [SKILL.md](../SKILL.md). Commands are the
+recommended shape; adapt the script names to your project (they are defined in `package.json`).
+
+## The whole suite
+
+```bash
+npm run test
+```
+
+- Runs on **SQLite** — the local default (fast, zero external services), under
+  `NODE_ENV=development`.
+- **Rebuilds the database first**, then runs, so every full run starts clean:
+  1. teardown (drop the local DB)
+  2. migrate (recreate the schema)
+  3. seed (master, then the development / dev-master fixtures)
+  4. run `tests/__tests__/` (read-only) and `tests/_orders/` (DB-writing, in category order)
+
+Because the suite re-seeds up front, a green full run proves the tests pass **from a clean database in
+the committed order**. It is the authoritative run — and the slowest.
+
+## Parallelism and memory: the worker budget
+
+Jest runs test files in **parallel workers** — roughly one per core by default — and each worker is
+its own Node process with its own heap. Two levers set the budget, and they must be set **together**:
+
+```bash
+# the shape — the numbers come from the measurement below, never from a default
+NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=1536" npx jest --maxWorkers=4
+```
+
+- **`--max-old-space-size` is a ceiling, not a reservation.** It does not set memory aside; it is
+  the point up to which V8 may **defer garbage collection**. A generous value therefore gives no
+  headroom — it just lets each worker grow that far before the GC is forced to run. Set it above
+  what the machine can actually give and the limit never engages: the worker keeps growing until the
+  **operating system**, not V8, ends it — and **one worker is enough** to take the machine down.
+- **The budget is a multiplication.** Every worker may sit at its peak at once, so the invariant is:
+
+  ```
+  workers × (heap cap + per-process overhead) ≤ memory actually free
+  ```
+
+  "Actually free" means what is left **after everything else resident on the machine** — a local
+  database, an E2E stack's daemons and pollers — not the installed total.
+- **Derive the cap from a measured peak, not from hope.** Run the suite once with `--logHeapUsage`
+  (Jest prints each test file's heap as it finishes) and set the cap comfortably above the largest
+  value. A cap below the real peak thrashes the GC and fails anyway; a cap far above it only shifts
+  where the crash happens — from V8's out-of-memory error (which comes with a trace) to the
+  machine's (which comes with nothing).
+- **The budget goes stale as the project grows.** Per-worker usage rises with every model, seeder
+  and test added, so a workers × cap pair that fit when it was chosen silently stops fitting. When a
+  previously green suite starts dying without output, **re-measure the peak and re-do the
+  multiplication** before suspecting the tests.
+
+You can tell the two failures apart by how each announces itself: a worker stopped **by the cap**
+throws `JavaScript heap out of memory` with a stack trace; a worker stopped **by the machine** is
+killed silently and can take the whole run — and every other process on the box — with it.
+
+### Check the machine first, then dial parallelism to fit it
+
+The default worker count (one per core) is sized for an **idle** machine with nothing else resident.
+A real developer machine rarely is: an editor, a browser, a local database, and, worst of all, a
+running E2E stack's daemons and pollers are all holding memory before the suite starts. So **read
+the machine's actual free resources before a full run**, and set the workers to what is free, not to
+what is installed:
+
+```bash
+# free memory and core count — the two inputs to the worker budget above
+free -h            # Linux: the "available" column is what a run may actually use
+nproc              # cores — the ceiling on useful workers
+# macOS equivalents: `vm_stat` (free/inactive pages) and `sysctl -n hw.ncpu`
+```
+
+- **When the machine is under pressure, lower `--maxWorkers` before anything else.** The budget is
+  `workers × (heap cap + overhead) ≤ available memory`; when `available` shrinks because something
+  else is resident, the only lever that keeps the product ≤ available without re-measuring the heap is
+  the worker count. Halve it and re-run — `--maxWorkers=2`, then `1` — rather than letting the OS pick
+  which process to kill. `--maxWorkers=50%` expresses it as a fraction of cores when the constraint is
+  CPU rather than memory.
+- **If one worker's cap already approaches what is free, go serial.** When even a single worker at
+  its measured peak does not comfortably fit beside what else is resident, there is no room left for
+  parallelism — run the suite in-band:
+
+  ```bash
+  NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=1536" npx jest --runInBand
+  ```
+
+  `--runInBand` runs every test file in the **main process, one after another**, so the peak is one
+  worker's, not `workers ×` it. It is slower, but a serial run that finishes beats a parallel one the
+  OS kills halfway. This is the same flag the single-test fast loop uses for DB-writing tests below —
+  there for correctness, here for memory; both reasons point the same way on a constrained machine.
+- **Bring the E2E stack down before a full run, or count it in.** A running E2E stack
+  ([hb-build-e2e-test-environment](../../hb-build-e2e-test-environment/SKILL.md)) is capped, but its
+  capped footprint is still spent memory: subtract it from `available` before doing the
+  multiplication, or run `e2e/down.sh` first so the suite has the machine. Size the run with the
+  stack counted in.
+
+## A single test through the suite runner
+
+Run the runner against **one path**, choosing which seed set the database has. It re-establishes the
+seeds, then runs only that path:
+
+```bash
+# with the development (dev-master) seeds applied — the usual mode for a DB-writing test
+./test.sh --seeded tests/_orders/<Category>/SomeCreator.js
+
+# with master seeds only (no development fixtures)
+./test.sh --empty tests/__tests__/<path>/SomeUnit.js
+```
+
+- **`--seeded`** applies the development fixtures before running; **`--empty`** runs against master
+  seeds only.
+- Point the path at a category's `_.test.js` to run the whole category in order, or at a single file.
+
+## A single test without rebuilding the database (fastest)
+
+For a tight edit-run loop, invoke Jest **directly** against the file — this skips migrations and
+seeders entirely and runs against the database **exactly as it currently is**:
+
+```bash
+NODE_OPTIONS="--experimental-vm-modules" NODE_ENV=development npx jest <path-of-test-file>
+```
+
+For a DB-writing or order-sensitive test, run the cases **serially** with `--runInBand` (no parallel
+workers racing on the same database):
+
+```bash
+NODE_OPTIONS="--experimental-vm-modules" NODE_ENV=development npx jest --runInBand <path-of-test-file>
+```
+
+- **Prerequisite: the database must already be prepared** (migrated + seeded once). This mode does not
+  set anything up — it assumes the schema and fixtures the test expects are already present. Prepare
+  them once with `npm run test` (or the piecemeal commands below), then iterate with `npx jest`.
+- `--experimental-vm-modules` is required for the ES-module test loader; `NODE_ENV=development`
+  selects the SQLite config.
+- **`_orders` caveat**: a DB-writing test **mutates shared state**. After running one this way, the
+  database no longer matches its seeded baseline, so a later fast run can produce a **different
+  result**. Before trusting subsequent runs, **restore the database** — re-run the relevant migrations
+  / seeders (below), or a full `npm run test`.
+
+## Preparing or resetting the database piecemeal
+
+When you only need to re-establish part of the state — instead of a full rebuild — run just that
+step. This is what makes the fast `npx jest` loop usable.
+
+**Migrations only** (schema):
+
+```bash
+npm run db:teardown                    # drop the local DB
+NODE_ENV=development npm run db:setup   # re-apply migrations (schema only, no data)
+```
+
+**One seeder set only** — undo or (re)apply a single set without touching the others. The general
+lever is `sequelize-cli` with an explicit `--seeders-path`:
+
+```bash
+NODE_ENV=development npx sequelize-cli db:seed:undo:all --seeders-path sequelize/seeders/<set>/
+NODE_ENV=development npx sequelize-cli db:seed:all       --seeders-path sequelize/seeders/<set>/
+```
+
+The three standard sets, and the npm wrappers the project provides for the common two:
+
+| Seeder set (dir) | Undo | (Re)apply |
+| --- | --- | --- |
+| dev-master fixtures (`sequelize/seeders/dev-master/`) | `sequelize-cli db:seed:undo:all --seeders-path sequelize/seeders/dev-master/` | `npm run db:seed:master` |
+| development fixtures (`sequelize/seeders/development/`) | `sequelize-cli db:seed:undo:all --seeders-path sequelize/seeders/development/` | `npm run db:seed:dev` |
+| production master (`sequelize/seeders/master/`) | `sequelize-cli db:seed:undo:all --seeders-path sequelize/seeders/master/` | `sequelize-cli db:seed:all --seeders-path sequelize/seeders/master --debug` |
+
+- Prefix each `sequelize-cli` / `npm run` command with `NODE_ENV=development` (SQLite).
+- **After running `_orders` tests**, re-applying the mutated seeder set (undo → apply) is usually
+  enough to get back to a known baseline without a full teardown/migrate.
+- The rebuild-everything shortcut is `npm run db:refresh` (alias `npm run r`): teardown → migrate →
+  seed dev-master → seed dev, in one command.
+
+## A live (real-dialect) run
+
+Everything above runs on **SQLite**, the local default. A test that depends on real-dialect behavior
+SQLite does not emulate has to run against **MariaDB**, and that means **a MariaDB running locally**;
+`NODE_ENV=live` selects its connection config, and the same test files run unchanged — only the
+dialect differs.
+
+Standing that database up is deliberately **not covered here**: this skill governs where tests go and
+how they are run, not how a database is provisioned.

--- a/kit/skills/backend/hb-bank-id/SKILL.md
+++ b/kit/skills/backend/hb-bank-id/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: hb-bank-id
+description: Allocate an exclusive, collision-free row-id prefix for a requester inside one backend repository, so two writers never pick the same id. Use it before writing an explicit id into a seeder or a test that creates its own rows.
+---
+
+# hb-bank-id
+
+Hand this skill a **requester id** and it returns an **id prefix** you may use, exclusively, for every row you create in this repository — in any table, in any seeder or test — for as long as this project exists.
+
+## Why
+
+Several writers touch the same backend repository over time: every feature `/hora-build` takes through its checkpoints writes into the same tables, and a human team may split work by hand. When two of them pick the same explicit row `id`, whichever runs its seeder last silently overwrites or collides with the other's data. `hb-bank-id` gives each requester its own slice of the id space, once.
+
+**Being serial does not remove the need.** A seeder written for feature A is still in the tree when feature B writes its own, and both are loaded together on the next database refresh. What has to be exclusive is the id space across time, not across concurrent processes.
+
+## The id shape
+
+Every explicit id is an 8-digit integer, split into two parts.
+
+```
+1  0  0  0  0  0  0  1
+└──┬──┘ └────┬────┘
+ prefix    free (yours alone)
+(100-999)  (00000-99999)
+```
+
+- **The first 3 digits (100-999, 900 values)** are the prefix this skill hands out. One requester, one prefix, forever
+- **The last 5 digits (00000-99999)** are yours to use however you like, in whatever order is convenient
+- **A prefix is not scoped to one table.** Once you hold `137`, you may use `13700001` in `users` and `13700001` in `reservations` — different tables have independent primary keys
+
+900 prefixes comfortably exceeds the number of features any one project realistically produces. Overflow is not handled.
+
+## The requester id
+
+Whatever uniquely names the caller, chosen by the caller:
+
+- **`/hora-build`'s own main session** passes the feature's `id`, once per feature, and hands the prefix it gets back to every agent working in that repository. **The agents themselves never call this skill** — several units of one checkpoint run at once, and each asking for itself would queue them behind one another's `mkdir` for no gain
+- a human working by hand picks their own name (`alice`), or a per-feature name for more than one slice
+
+The same requester id always gets back the same prefix. Asking twice, or retrying after a crash, is always safe.
+
+## State
+
+Both live directly under the backend repository's own root — never under the outer app repository's `.hora/`, which belongs to `/hora` and means something unrelated there.
+
+```
+<backend-repo>/.hora/id-bank.json     the registry
+<backend-repo>/.hora/id-bank.lock/    the lock (a directory — mkdir is atomic on POSIX)
+```
+
+`id-bank.json` is a flat object, requester id to prefix, as a string so a leading `1` is never mistaken for an octal digit:
+
+```json
+{
+  "sign-up": "100",
+  "verify-two-factor": "101",
+  "alice": "102"
+}
+```
+
+## Allocating (the normal call)
+
+1. Try `mkdir <backend-repo>/.hora/id-bank.lock`.
+2. If it fails because the directory already exists, wait 1 second and retry. **Stop retrying after 5 attempts (5 seconds total)** and go to "A lock that will not clear" — do not remove the lock yourself here.
+3. Once `mkdir` succeeds, you hold the lock. Read `id-bank.json` (treat a missing file as `{}`).
+4. If the requester id is already a key, that value is the answer. Go to step 6.
+5. Otherwise, pick the lowest integer in `100..999` not already used as a value, add `{ "<requester id>": "<that number>" }`, and write the whole file back (rewrite it whole — a partial write would corrupt the JSON for the next reader).
+6. `rmdir <backend-repo>/.hora/id-bank.lock` to release the lock, then return the prefix.
+
+**Never skip the lock**, even to only read the file — a reader running concurrently with a writer's rewrite can observe a half-written file.
+
+## A lock that will not clear
+
+Reaching the retry limit means another writer is either still working or died mid-update. From outside these look identical, so **never remove the lock yourself to force through.** Report the failure instead:
+
+- **`/hora` stops the whole session** and states plainly: "the lock `hb-bank-id` uses did not clear, so this session is ending. Running `/hora` again will clear it automatically and continue" (see "Clearing a stale lock"). This should be rare — the lock is taken once per feature, by the main session, for the few seconds one allocation takes
+- **A human running this by hand** may wait and retry, or run the clearing step below themselves
+
+## Clearing a stale lock
+
+A lock still standing at the very start of a fresh run cannot belong to anything still alive — nothing in this project holds it across separate invocations. Clearing it is therefore safe at that moment, and only then.
+
+```
+rm -rf <backend-repo>/.hora/id-bank.lock
+```
+
+`/hora-build` runs this, unconditionally, as its very first action against the backend row on any invocation. A human recovering from the failure above runs the same command by hand.
+
+## Using the prefix once you have it
+
+Combine it with your own 5 digits when you write an explicit id — in a seeder, or inside a test that creates its own fixture. Do not derive ids from anything but your own prefix, and do not read or reason about another requester's rows.

--- a/kit/skills/backend/hb-build-e2e-test-environment/SKILL.md
+++ b/kit/skills/backend/hb-build-e2e-test-environment/SKILL.md
@@ -1,0 +1,609 @@
+---
+name: hb-build-e2e-test-environment
+description: >
+  Build, run and debug the manual local E2E environment under `e2e/docker/` — a
+  container-compose stack of the product's real middleware (system of record, cache and job queue,
+  event transport, read model, object storage, the reverse-proxy edge), its own seed set, and the
+  `up` / `start` / `seed` / `clean` / `down` scripts that drive it. Stated per component role, so
+  any stack maps onto it. Use also when adding E2E seed data. Verifying behavior inside the
+  environment is out of scope.
+---
+
+# Build E2E Test Environment
+
+A skill for building the local environment in which **the whole stack is real**: the application runs
+against the actual components it talks to in production — the real store its writes land in, the real
+queue its background work goes through, the real transport its change events travel over, the real
+derived store its screens read from — instead of against fakes. It exists so a developer can exercise
+the product **by hand, through its UI**, against components that behave like the deployed ones.
+
+**Building that foundation is the entire scope.** What to check once the environment is up — which
+screens, which flows, which cases — is the operator's business and is deliberately not covered here.
+Nor does this environment hold any automated tests: the unit test tree and how it is run belong to
+the project's backend test-placement convention, and the two never touch
+([§2](#2-where-the-e2e-environment-lives)).
+
+> **The component set used throughout this skill is an example, not a requirement.** Every rule is
+> stated for a **role** in the system; the stack the examples are written in — relational database
+> with a binlog, Redis, Kafka, a CDC connector, a search cluster — is one way of filling those roles,
+> chosen because it exercises all of them at once. Start by mapping your project's own components
+> onto the roles ([§1](#1-roles-first-the-component-set-here-is-one-example)), then read every service
+> name, image, environment variable, id, port and command below as an **illustration of the shape**,
+> not a value to copy. Directory names (`e2e/`, `sequelize/seeders/<stack-env>*/`) are the recommended
+> layout, and `<stack-env>` stands for the environment name that belongs to the E2E stack alone —
+> **`live-local`** is the recommended name, the local full-stack counterpart of the real-dialect test
+> environment `live` ([§3](#3-environment-a-dedicated-environment-name-with-an-env-file-of-its-own)).
+> Sample code follows the project's lint style (no semicolons, 2-space indent, trailing commas).
+
+## Core principle: hand over only a fully built stack
+
+To an operator working through the UI, **a missing piece of infrastructure looks exactly like a
+broken feature**. If the transport's channels were never created — the step the example fills with
+Kafka topic creation — the screen simply does not update, and that looks exactly like a product bug.
+An environment that comes up ninety percent of the way without warning makes every manual session a
+false bug report — worse than one that refused to start.
+
+So: **every step either completes or aborts the build, naming the log to read.** Four properties get
+you there, and the rest of this skill explains how:
+
+1. **One command per intention, fixed order inside each.** Every step is scripted, the steps within
+   a script are ordered by dependency, and which script to run is the operator's call rather than
+   something a script infers
+   ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+2. **Private.** Everything the compose file starts is reachable only from this machine, and — where
+   the two are meant to run at once — everything it starts stays clear of the developer's own stack
+   ([§4](#4-ports-are-published-to-loopback-only-on-a-dedicated-block)).
+3. **Disposable, and predictably so.** Each command's effect on the data is fixed and stated in its
+   name — rebuild, start, seed, clean — so no step has to detect state and the operator always knows
+   what survived ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+4. **Complete.** The **application and its background processes** are started by the same script, not
+   left for the operator to remember. Middleware being up is not the same as data moving
+   ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+
+## What this skill assumes about the machine
+
+Use **Ubuntu, or WSL2 on Windows**, with Docker Engine or something compatible. Plain Windows —
+PowerShell or `cmd` — is out of scope. Go through WSL2.
+
+Five rules keep the stack working on the other machines your team uses:
+
+| Rule | What goes wrong without it |
+| --- | --- |
+| Write scripts for **bash 3.2**, and use no GNU-only option | macOS still ships bash 3.2, with BSD tools. It has no `declare -A`, `mapfile`, `${x,,}`, `timeout`, `date -d` or `grep -P`. To set a deadline, count elapsed seconds in a loop. |
+| Budget memory against **what the container runtime was given**, not against the machine | Docker Desktop and WSL2 run containers inside a VM, and WSL2 gives that VM half the machine by default. Budget against the machine and you overflow the VM. On Linux the two numbers are the same, so the mistake is easy to make. |
+| Put `*.sh text eol=lf` in `.gitattributes` | A script with CRLF line endings fails with `bash\r: bad interpreter`. Cloning the repository is then enough to break the environment. |
+| Reach the edge by **loopback address and port**, not by `server_name` | Routing by host name means editing `/etc/hosts` on every machine. WSL2 rewrites that file by default. |
+| Do not use `host.docker.internal` | Podman calls it `host.containers.internal`. You do not need either one if the edge and the application stay on the same side of the container boundary ([§5](#5-the-edge-what-the-browser-actually-connects-to)). |
+
+Scripts for Windows itself are **opt-in**. Write them only when someone asks. The `.sh` scripts stay
+the real ones. See [windows-runner.md](./references/windows-runner.md).
+
+## 1. Roles first: the component set here is one example
+
+Before writing anything, **enumerate what the product actually talks to and classify each component
+by the role it fills.** The rules in this skill attach to roles, so that list is what makes the rest
+of the skill apply to a stack it was not written in.
+
+| Role in the system | What the examples in this skill use | Other stacks fill the same role with |
+| --- | --- | --- |
+| **system of record** — where the product's writes land | a relational database configured to write a row-format change log | PostgreSQL with logical replication, SQL Server with CDC enabled, a document store with change streams, a local emulator of a managed database |
+| **cache and job queue** — where deferred work is queued | Redis behind the job queue | RabbitMQ, a local queue emulator, a table-backed queue in the system of record, an in-memory cache server |
+| **event transport** — what carries change events between processes | Kafka in single-node mode | Redpanda, NATS JetStream, a pub/sub or stream emulator, RabbitMQ, the database's own notification channel |
+| **change propagation** — what turns a write in the system of record into an update of the read model | a CDC connector running in Kafka Connect | a CDC runner without Connect, an outbox table plus a poller, a database trigger, an application-level write to both stores |
+| **read model / search** — the derived store screens read from | a search cluster with an analyzer plugin baked in | another search engine, a materialized view, a denormalized table, a cache the read path is served from |
+| **object storage** — where uploaded and derived files live | a per-run directory on the filesystem | an S3-compatible object server, a cloud-storage emulator, a bucket with a per-run prefix |
+| **edge** — what the browser actually connects to | nginx as a reverse proxy in front of the application | Apache httpd, Caddy, Traefik, HAProxy, or a managed load balancer / API gateway whose behaviour the product depends on |
+| **the application and its own processes** — the product itself | the API server, a worker daemon, a change-log consumer | whatever process set has to be running for a request to be answered end to end |
+
+- **A role your product does not have simply drops out.** No read model means no index-creation step,
+  no backfill and none of the propagation traps — and every other rule still holds. Two roles filled
+  by one component (a database that is both system of record and job queue) collapse into one service
+  and one set of values.
+- **Roles the example does not name join the same list.** A mail catcher, an identity-provider stub, a
+  payment sandbox, a headless browser: if the product genuinely talks to it, it belongs in the
+  environment, or the environment is not end-to-end. Give it the same treatment — loopback-only port
+  on the E2E block, healthcheck, started by the runner.
+- **What is universal and what is example.** These hold for any stack: one command in dependency
+  order with idempotent steps; loopback-only publishing on a port block and compose project name of
+  its own; an environment name and env file of the stack's own; a seed set of its own in a reserved id band;
+  waiting on healthchecks to a deadline; the application and background processes started by the
+  script; abort on failure and hand over on success. What is example is the *mechanics* of each
+  component — and each of those mechanics is an instance of a general shape:
+
+| The example's specific detail | The general shape it is an instance of |
+| --- | --- |
+| `--binlog-format=ROW --binlog-row-image=FULL` on the database | the system of record has to be configured to emit whatever change propagation needs to read, **before** anything reads it |
+| the broker's published port must equal its advertised listener port | any service that answers a client with **its own address** must be published on the port it advertises |
+| transport channels created explicitly, auto-creation off | the transport's channels must exist, with their final shape, before anything produces to them — some of their properties cannot be changed afterwards |
+| the capture database name is part of the change channel's name | every identity a **derived name** is built from must be overridden together with the thing it names |
+| a schema-only capture needs a backfill after seeding | data that existed before propagation was wired up never propagates; load it into the read model explicitly |
+| the analyzer plugin and connector plugin baked into images | everything a service needs at start is in its image, so the stack comes up with no network access |
+
+Read the rest of the skill through this table: where a section talks about a binlog, a broker or an
+index, it is talking about the role — and the general shape is what you carry across to a different
+component.
+
+## 2. Where the E2E environment lives
+
+Everything the environment needs — the stack definition and the scripts that build and dispose of
+it — is committed under a **single top-level directory of its own**:
+
+```
+e2e/
+├── docker/                     the stack definition, and everything the compose file references
+│   ├── compose.yaml            the services, loopback-published on the E2E port block (§2, §4)
+│   ├── nginx/                  the edge configuration the compose file mounts (§5)
+│   ├── images/                 build contexts for images that need a plugin baked in
+│   │   ├── search/Dockerfile
+│   │   └── connect/Dockerfile
+│   └── initdb/                 the SQL the system of record runs when its volume is created
+├── up.sh                       rebuild: clean → start → seed (§7)
+├── start.sh                    bring the stack and the processes up. no data operation (§7)
+├── seed.sh                     load the seed set into a stack that is already up (§7)
+├── clean.sh                    delete the data in every store — the only script that destroys (§7)
+├── down.sh                     stop the processes and the stack, keep the data (§7)
+└── logs/                       the background processes' output, git-ignored (§7)
+```
+
+Three kinds of thing live here, and the layout says which is which: **`docker/` is the definition**,
+the scripts are the **lifecycle**, and `logs/` is the **output**. The **wiring** is the fourth kind
+and deliberately lives outside `e2e/`: the stack's own `.env.<stack-env>`, committed at the
+repository root beside the other environments' files, where the environment facade finds it
+([§3](#3-environment-a-dedicated-environment-name-with-an-env-file-of-its-own)).
+
+- **This directory is entirely separate from the automated test suite.** This directory holds no
+  test files, and `npm run test` does not run or use any part of it. The unit suite's promise is
+  that it runs in seconds, on a local file database, with no services running; adding this
+  environment to the repository must not change that in any way.
+- **The separation is of namespaces, not of the machine.** While the stack is up, its resident
+  processes — the application, the worker daemons, and anything that **polls on an interval** —
+  keep taking CPU and memory the whole time, with no operator touching a screen. Any memory-hungry
+  job run beside them — the unit suite in parallel workers is the classic — competes for the same
+  memory, and a job that fit on an idle machine can be killed by the operating system on
+  one where the stack resides. Two defences, and they are complementary: the compose file **hard-caps
+  every container with `mem_limit` and holds the sum of those caps to a conservative slice of the
+  memory the container runtime was given** (~40%, sized so two stacks can be up at once), so the stack's *ceiling* is bounded no matter
+  what runs beside it ([compose-definition.md](./references/compose-definition.md)); and even under
+  that ceiling, run heavy jobs after `down.sh` — or count the stack's capped footprint against the
+  memory the job budgets for itself — because the ceiling protects the machine, it does not make the
+  memory free.
+- **The compose file for E2E is its own file**, not the development one. The development stack is a
+  place to *work*; this one is built to be filled from scratch and thrown away — it binds different
+  ports, hard-caps every container's memory and holds a smaller heap, and is expected to be destroyed.
+  Sharing one file would force the two to compromise.
+- **Everything the compose file references by relative path lives beside it, under `docker/`.**
+  `build:` contexts, init SQL, config files a service mounts: compose resolves all of them against
+  the compose file's own directory, so a path that worked from the repository root resolves
+  somewhere else here. Keeping them in one directory means the definition moves as a unit, and no
+  entry has to point outside the directory with `../`.
+- **Git-ignore what the run produces** — the process logs and the per-run file storage. The
+  definition is committed; the output of a session is not.
+
+Besides the env file, the other thing that does **not** live here is the seed data: the E2E seed
+sets stay wherever the project's seeder tooling looks for them (`sequelize/seeders/` in the
+examples). What separates them there is the **set**, not the path ([§6](#6-data-a-seed-set-of-its-own)).
+
+## 3. Environment: a dedicated environment name, with an env file of its own
+
+The stack runs under an **environment name that belongs to the E2E environment alone** — written
+`<stack-env>` here. **`live-local` is the recommended name**: the project's real-dialect test
+environment (`live`, per the backend testing convention) selects the same database engine but exists
+for running the unit suite against it, not for a running full stack — so the local full-stack
+environment gets a name of its own, derived from it. A dedicated name stops a build — or a seeder or
+migration run by hand — from reaching the developer's development stack or the `live` test database
+by default: `NODE_ENV=<stack-env>` selects the E2E stack's own values everywhere, instead of relying
+on every command remembering to apply overrides.
+
+The stack reads its own committed **`.env.<stack-env>`**, at the repository root beside the other
+environments' files. Two rules govern that file:
+
+- **It is a complete, standalone description of the E2E stack.** Every key the application, the
+  tooling and the background processes read has to be present, because a missing key reads as `null`
+  rather than throwing (see below) and surfaces as a confusing failure deep inside a service call.
+  When authoring it, start from the key set of the fullest existing env file and set every value
+  deliberately.
+- **Values shared with another environment are independent copies, deliberately.** The database
+  connection shape in `.env.live` and in `.env.live-local` may be identical today; they are still two
+  environments' own values, and each file is the source of truth for its own environment. Do not
+  build one env file out of another by reference, import or generation — when the stack gains a
+  component or a key, updating every environment's file is part of that change. (Note the deliberate
+  contrast with seed data, where master rows are **re-exported, never copied**
+  ([§6](#6-data-a-seed-set-of-its-own)): seed rows must be identical across environments *by
+  construction*, env values are per-environment *by definition*.)
+
+**Which values must differ from the other environments is a decision, not a fixed list.** Two
+questions settle it:
+
+| Question | If yes, what it forces |
+| --- | --- |
+| Must this stack run **beside** the developer's own, both up at once? | a **port block** of its own — otherwise one of the two cannot bind its ports |
+| Must a build be unable to **destroy or pollute** what the developer already has? | **names** of its own: the system of record's name, every identity a derived name is built from, the read model's name, and the object storage location |
+
+**The two questions are not equally weighted, because they fail differently:**
+
+| Left equal to another environment's value | How it fails |
+| --- | --- |
+| the port block | **loudly** — a port is already bound, and nothing starts |
+| the system of record's name | **silently and destructively** — [the build drops and recreates the schema](./references/runner-and-lifecycle.md), so it deletes the developer's data |
+| every identity a **derived name** is built from | **silently** — the example's change channels are named after the captured database, so a stale value makes the consumer subscribe to channels nobody writes to: nothing propagates and nothing errors |
+| the read model's name | **silently** — the build writes into whatever it names, and the backfill step alone writes every row, so it pollutes the developer's read model |
+| the object storage location | **silently** — uploads land in the working tree, and two runs see each other's files |
+
+So the second question matters more than the first: a shared port block announces itself, and a shared
+name does not. The full table and rationale are in
+[environment-and-ports.md](./references/environment-and-ports.md).
+
+Two mechanics of the wiring to keep in mind (details in the same reference):
+
+- **`docker compose` does not read `.env.<stack-env>`.** Any `${...}` the compose file interpolates
+  has to reach compose another way — point compose at the file with `--env-file`, or have the runner
+  export those values — or it substitutes as an empty string behind a single warning line.
+- **An exported shell variable outranks the file**, because the environment facade merges the dotenv
+  file first and `process.env` last. Useful for a one-off tweak; also a trap, since a stray variable
+  in the shell silently overrides the committed value.
+
+**A value the env file omits reads as `null`, it does not throw.** The facade returns `null` for any
+key it does not have, so a forgotten key surfaces later as a confusing failure deep inside a
+service call rather than at startup. Check that every key the code reads is present before blaming
+the wiring.
+
+## 4. Ports are published to loopback only, on a dedicated block
+
+Two firm rules:
+
+- **Every published port is prefixed with `127.0.0.1`.** `ports: ['13306:3306']` binds every
+  interface — on a developer machine that puts an unauthenticated database on the network. Written
+  as `ports: ['127.0.0.1:13306:3306']` it is reachable from this machine and nowhere else.
+- **A service the host does not need gets no `ports:` entry at all.** Container-to-container traffic
+  needs none; the compose network already carries it. Publish a port only because a process on the
+  host — the build script, the application, the operator's browser — connects to it.
+
+**If** the stack has to run beside the developer's own — the first question in
+[§3](#3-environment-a-dedicated-environment-name-with-an-env-file-of-its-own) — it takes a
+**port block of its own**. A stack that replaces the developer's rather than coexisting with it keeps
+the conventional ports and skips this table; the loopback rules above still apply either way. The rows
+are the example stack's components, and the pattern is one offset applied to every role your project
+has:
+
+| Role (example component) | Development | E2E stack | Note |
+| --- | --- | --- | --- |
+| system of record (database) | `127.0.0.1:3306` | `127.0.0.1:13306` | |
+| cache and job queue (Redis) | `127.0.0.1:6379` | `127.0.0.1:16379` | |
+| event transport (Kafka) | `127.0.0.1:29092` | `127.0.0.1:19092` | **published port must equal the port it advertises** |
+| read model (search cluster) | `127.0.0.1:9200` | `127.0.0.1:19200` | |
+| change propagation (Connect) | `127.0.0.1:8083` | `127.0.0.1:18083` | |
+| edge (nginx) | `127.0.0.1:80` | `127.0.0.1:18080` | **the URL the hand-over prints** ([§5](#5-the-edge-what-the-browser-actually-connects-to)) |
+
+**Keep the application's own port published as well**, even once the edge is in front of it. It is
+what tells an operator whether a failure is the application's or the edge's, and it costs one line.
+What changes is the hand-over: the URL the script prints is the **edge's**, because that is the path
+production takes ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+
+**The transport entry is the trap, and it generalizes.** Any service that answers a client with **its
+own advertised address** — a broker handing back cluster metadata, a clustered queue redirecting to a
+node name, a replica set naming its members — sends the client somewhere else after a connection that
+looked fine. Remap the host side only and every subsequent operation fails. Keep host and container
+port identical for such a service, and make sure the address it advertises is the one the host can
+reach.
+
+The stack also needs its **own compose project name**, or it adopts the development stack's
+containers, network and volumes. Details, the full compose walk-through, and the per-service
+settings the pipeline depends on are in [compose-definition.md](./references/compose-definition.md).
+
+## 5. The edge: what the browser actually connects to
+
+In production, the browser often reaches the product through a reverse proxy. Where it does, an
+environment that lets the browser talk to the application directly **cannot catch any bug that
+lives in the proxy** — and it still reports success. The operator sees a missing layer and a working
+one as the same thing. That is the failure the rest of this skill exists to prevent.
+
+So **where production has an edge, include one here by default**. It is a role like any other
+([§1](#1-roles-first-the-component-set-here-is-one-example)).
+
+**Where production has no edge, this section drops out**, the same as any other role the product
+does not have. Do not add one just to be thorough. An environment with a layer production does not
+have is wrong in the other direction, and it hides the same kind of bug — it would pass requests
+through a proxy nobody runs in production.
+
+Four rules:
+
+- **Copy the configuration from production.** Start with the production file. Remove TLS
+  termination. Point upstream at the E2E application. Do not write a new file: a new file has none
+  of production's bugs, and finding those bugs is the only reason this section exists.
+
+  **Where production's edge is a managed one — a cloud load balancer, an API gateway, a CDN — there
+  is no file to copy.** Do not pretend otherwise. Pick the behaviours your product actually depends
+  on (header forwarding, body size, timeouts, buffering), reproduce those in whatever proxy you run
+  locally, and write down which ones you could not reproduce. The deployment runbook checks the
+  rest after release. A local nginx standing in for an ALB is a useful rehearsal, not the same
+  thing, and saying so is what keeps it useful.
+- **Write down where the copy came from**, at the top of the file:
+
+  ```nginx
+  # derived-from: the deployment runbook's edge configuration chapter
+  # derived-at:   2026-08-22
+  # deltas:       TLS termination removed / upstream repointed to the E2E app
+  ```
+
+  When production changes, update `derived-at` and rewrite `deltas`. **A note nobody updated does
+  not tell you this is a copy. It tells you the two files are now different.** If `deltas` keeps
+  growing, the copy is turning into a rewrite. Fix the production file so both can share more.
+- **Keep the edge and the application on the same side of the container boundary.** Put both in
+  containers, or neither. If a check depends on the client's **source address**, put the client on
+  that side too. A published port rewrites the source address, so moving only the application does
+  not help.
+- **Check the edge from the side that uses it.** A healthcheck inside the container only sees the
+  inside. It reports healthy even when nothing outside can reach the edge. The same holds for
+  waiting, for reachability and for acceptance — not just for healthchecks.
+
+Two shapes follow the boundary rule. Mixing them does not work:
+
+```
+A — the edge is part of what you are checking
+  [client container ×N] → [edge container] → [app container]
+  one compose network, and the source addresses are really different
+
+B — no edge
+  [browser on the host] → [app process on the host]
+  nothing checks the proxy layer
+```
+
+**Shape B is a fair choice. Choosing it in silence is not.** A demo, a deadline, or a machine the
+edge will not run on are all good reasons. Each one still needs a note: what you measured, what you
+decided, and who checks it instead — usually the deployment runbook. Also, do not leave a broken
+edge config and a spec that always fails. A run that is red every time hides the real failures.
+
+**Say exactly what a check proves.** Testing the edge without the application behind it proves the
+edge's own configuration. It proves nothing about how the two work together. Round that up in your
+notes, and six months later someone reads it as "we tested the whole thing".
+
+The compose service, the nginx configuration, the Apache equivalents, how to make the copy, and what
+we measured when the boundary was crossed are all in
+[edge-and-proxy.md](./references/edge-and-proxy.md).
+
+## 6. Data: a seed set of its own
+
+The environment gets **two seeder directories of its own**, seeded by their own scripts:
+
+| Directory | Holds | Corresponds to |
+| --- | --- | --- |
+| `sequelize/seeders/<stack-env>-master/` | the master / metadata rows the stack needs, **re-exported** from the production master | the dev-master set |
+| `sequelize/seeders/<stack-env>/` | the operational rows the environment is filled with, and that a session mutates | the development set |
+
+- **Why separate from the unit-test fixtures.** The two sets serve opposite needs — this environment
+  wants a small, pipeline-shaped set that flows end to end, a unit test wants exhaustive branch
+  coverage. Sharing one set means every change to satisfy one silently re-tunes the other, and a
+  broken unit test is then a puzzle. Separate directories make ownership obvious.
+- **The master set is re-exported, never copied.** Rows whose ids end up **inside a derived
+  artifact** (an id written into a read-model document, a key a mapping is built from) must be
+  **identical in every environment**, or a read model built here cannot be compared with one built
+  anywhere else. A one-line `module.exports = require('../<production-master-dir>/<same-name>.cjs')`
+  keeps them the same by construction.
+- **Ids come from a reserved band of their own** — the same 10,000-wide blocks the project's seeder
+  convention already uses, set above every block the other sets use — so a row's origin is readable
+  from its id and the two sets cannot collide even if both are somehow applied.
+- **Seeds insert rows, not files.** A row that claims a stored file whose bytes are absent answers
+  404 on the screen that opens it, which reads as a product bug — so the build also **generates the
+  binary artifacts the seeds promise**, as a step of its own.
+- **Sign-in has to be possible.** The set includes the accounts the operator signs in with;
+  obviously-fake, development-grade, and committed like any other seed row.
+
+The directory layout, the re-export skeleton, the id band, the generated-artifact step and how to
+keep the set pipeline-shaped are in [seed-data.md](./references/seed-data.md).
+
+## 7. The runner: one command per intention, and no script that guesses
+
+```bash
+e2e/up.sh                 # rebuild: clean, start, seed, hand over — the from-nothing path
+e2e/up.sh --start-only    # start without touching data at all (exactly what start.sh does)
+
+e2e/start.sh              # bring the stack and the processes up. no data operation
+e2e/seed.sh               # load the seed set into a stack that is already up
+e2e/clean.sh              # delete the data in every store
+e2e/down.sh               # stop the processes and the stack, keep the data
+```
+
+The scripts sit at the root of `e2e/` and point at the definition with
+`-f e2e/docker/compose.yaml`, so the operator never has to be in a particular directory to run them.
+
+**No script inspects the data to decide what to do.** This is the rule the lifecycle is built around,
+and it is worth more than any convenience a detection step could buy. A script that checks whether
+the environment "looks seeded" has to define what that means, keep a record of it somewhere, and
+guess wrong at the worst moment — a half-finished load looks loaded, a hand-emptied table looks
+fresh. Every one of those states then needs its own branch, and the branches are invisible until one
+misfires. **The operator knows which of the four things they want; the command they type says so, and
+the script does exactly that and nothing else.**
+
+Three consequences follow:
+
+- **`up.sh` is a composition, not a fifth behaviour.** It runs `clean.sh`, then `start.sh`, then
+  `seed.sh`. Typing it *is* the request to rebuild from nothing, so it drops without asking — that is
+  what the word means. `--start-only` delegates to `start.sh` unchanged; there is no third path
+  through the code and no flag that half-rebuilds.
+- **There is no "skip the drop but still seed" mode**, because seed rows carry fixed ids and applying
+  the set onto rows that already exist collides on insert. The two useful intentions are *rebuild*
+  and *start*, and both have a command.
+- **A collision is a correct answer, not a bug to design around.** `seed.sh` run twice fails loudly
+  and says the set is already there. Do not make the seeders idempotent to smooth this over: the
+  failure is the environment telling the operator they meant `up.sh`, and hiding it costs more than
+  it saves.
+
+**`clean.sh` deletes every store in the same run, or it is worse than not cleaning.** Data lives in
+more places than the system of record: the read model holds documents, the transport holds retained
+messages and consumer offsets, change propagation holds its own offsets or slot, object storage holds
+generated files, the queue holds jobs. Drop the schema alone and the read model still answers with
+documents whose rows no longer exist — a screen that shows deleted data reads as a product bug. Stop
+the processes **first**, or a running consumer repopulates what you are deleting while you delete it.
+
+**Where a step goes is decided by whether it depends on data.** `start.sh` owns provisioning that does
+not: creating the read model, creating the transport's channels. `seed.sh` owns the schema, the rows,
+the generated artifacts, the backfill — and any provisioning **derived from data**, which in the
+example is registering the capture connector, since its table list comes from the master rows. Put a
+data-derived step in `start.sh` and starting an empty environment fails for a reason that has nothing
+to do with starting.
+
+The order inside each script is **dependency, not preference**: the transport's channels have to exist
+before anything produces to them, because properties like a partition count cannot be reduced later;
+the read model has to exist before anything is written into it; the metadata has to be in the system
+of record before data-derived propagation can be told what to watch. The per-script step tables, and
+what `clean.sh` has to reach, are in [runner-and-lifecycle.md](./references/runner-and-lifecycle.md).
+
+Four properties of the scripts matter more than the steps:
+
+- **Waiting is on healthchecks, never on `sleep`.** Every service declares a healthcheck and the
+  script polls it to a **deadline**, then reports which service never became healthy and the command
+  that shows its log. A fixed sleep is a race that passes on a fast machine. **Poll from the side
+  that will use the service** — a check run inside the container reports healthy while nothing
+  outside can reach it ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- **The edge comes up last, once the application answers.** It has nothing to serve before then, and
+  a proxy that starts first turns a slow application into a confusing 502. It holds no data, so
+  `clean.sh` has nothing to do for it.
+- **The application and the background processes are part of the environment.** Change events do not
+  reach the read model because the middleware is up: the processes that carry them — in the example a
+  **worker daemon** and a **change-log consumer** — have to be running, and the **application itself**
+  has to be running for there to be a UI at all. The script starts all of them and records their PIDs.
+- **A failed build stops the processes it started; it never cleans.** Trap on `EXIT` while building
+  and clear the trap once the hand-over is printed, so a build that died at the propagation step does
+  not leave half a stack behind — but the trap calls `down.sh`, **not** `clean.sh`. A failed build
+  that also deleted the operator's data would be the worst outcome of all.
+- **Finish by handing over.** The last thing the script prints is what the operator needs to start
+  working: the URL to open, where the process logs are, whether data was loaded or kept, and the
+  commands that stop and that wipe it. Where there is an edge, **the URL is the edge's**, because
+  that is the path production takes; the application's own port stays published for triage. An
+  environment nobody can find their way into is not finished.
+
+## 8. Traps that let a half-built stack look finished
+
+Each of these produces a stack that **starts cleanly and behaves wrongly** — the failure mode this
+skill exists to prevent, because the operator will read it as a product defect. Written in the
+example stack's components — the shape carries over
+([§1](#1-roles-first-the-component-set-here-is-one-example)). The first two are the most common.
+
+- **A remapped port on a service that advertises its own address** — connects, then fails on every
+  operation afterwards (in the example, a broker whose advertised listener is stale)
+  ([§4](#4-ports-are-published-to-loopback-only-on-a-dedicated-block)).
+- **A derived name built from a stale identity** — in the example, a capture database name that no
+  longer matches the database name, so the consumer subscribes to channels that will never receive a
+  message. Nothing errors; nothing ever propagates
+  ([§3](#3-environment-a-dedicated-environment-name-with-an-env-file-of-its-own)).
+- **Propagation wired up after the data was loaded, with no backfill** — rows that existed *before*
+  it was wired up are never captured, so everything seeded is missing from the read model while
+  everything created afterwards appears. Backfill after seeding, or accept that only new rows exist.
+- **A build step that fails without stopping the build** — the environment hands itself over
+  incomplete. `set -euo pipefail`, and abort loudly.
+- **A feature that needs a host-installed tool assumed present** — turn that feature off explicitly
+  for the environment, so its absence is a decision rather than a mystery on screen.
+- **Reusing the development stack's volumes** — the build inherits another stack's rows, and
+  fixed seed ids collide on insert ([§4](#4-ports-are-published-to-loopback-only-on-a-dedicated-block)).
+- **A clean that only reached the system of record** — the read model still answers with documents
+  whose rows are gone, the transport still holds the old messages, and the screen shows deleted data.
+  Clean every store in one command, processes stopped first
+  ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- **A script that decides for itself whether to load** — a load that died halfway looks loaded, a
+  hand-emptied table looks fresh, and the wrong branch is invisible until it misfires. Let the command
+  the operator typed say what happens ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- **Seeders made idempotent so re-running is "safe"** — the id collision was the environment saying
+  the set is already there, and smoothing it over trades a loud, correct failure for rows that quietly
+  differ from the set ([§6](#6-data-a-seed-set-of-its-own)).
+- **Background processes started by hand, or not at all** — the middleware is up, the screens work,
+  and nothing propagates. Start them from the script ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- **No logs kept** — when something does not appear on screen, the answer is in the daemon's or the
+  consumer's output, and a run that discarded it forces a rebuild to find out why.
+- **No edge at all, where production has one** — every defect that lives in the proxy layer is
+  invisible here and surfaces only in production: unforwarded `Upgrade` headers, the default body
+  size limit, buffered streaming, a missing `X-Forwarded-For`. The full list, and what each looks
+  like on screen, is in [edge-and-proxy.md](./references/edge-and-proxy.md) ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- **An edge configuration written from scratch instead of derived from production** — it shares no
+  defect with the real one, so it detects none of them. The layer is present and proves nothing
+  ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- **A derived configuration with no record of what it was derived from** — production moves, the
+  copy does not, and nothing says so. By the time anyone looks, they are two unrelated files
+  ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- **The edge and the application on opposite sides of the container boundary** — traffic crosses it
+  twice, and the paths that appear to work are the ones that mislead ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- **A source-address check read as green when the addresses were collapsed** — traffic through a
+  published port arrives with one rewritten source address, so a per-client rule passes even when
+  the implementation counts every client as one ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- **Two test beds' results reported as one end-to-end result** — exercising the edge without the
+  application behind it proves the edge's configuration and nothing about the seam. Recorded
+  rounded up, it reads later as "verified end to end" ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- **A container started with no `mem_limit`** — it grows into whatever the machine has, so one
+  uncapped service silently undoes the whole memory budget and the machine swaps or OOM-kills under a
+  load the caps were supposed to prevent. Cap every container, and set each JVM service's heap to
+  about half its cap — the heap flag alone is not a cap
+  ([compose-definition.md](./references/compose-definition.md)).
+- **JVM heap flags mistaken for the memory limit** — `-Xmx` bounds the heap only, off-heap and page
+  cache push a JVM service to two-to-three times its heap, so a stack "sized" by heap flags alone
+  uses far more than the flags suggest and exceeds the budget. Size with `mem_limit`, keep the heap
+  near half of it ([compose-definition.md](./references/compose-definition.md)).
+- **The stack left up while something heavy runs beside it** — the resident processes go on polling
+  and caching, the heavy job (a parallel test suite above all) sizes itself as if the machine were
+  idle, and the machine dies under the sum. The `mem_limit` caps bound the stack's *ceiling*, but
+  the memory under that ceiling is still spent; neither side is at fault alone if the operator chose
+  to run both at once without a budget. `down.sh` first, or budget for both
+  ([§2](#2-where-the-e2e-environment-lives)).
+
+## Finishing checklist
+
+- [ ] Every component the product talks to is accounted for by role, and the ones the project does not have are deliberately absent rather than forgotten ([§1](#1-roles-first-the-component-set-here-is-one-example)).
+- [ ] The whole environment is under `e2e/`, with the compose file and everything it references by relative path together under `e2e/docker/`, the scripts at the root, and the run's output (logs, storage) git-ignored ([§2](#2-where-the-e2e-environment-lives)).
+- [ ] `npm run test` is completely unaffected — no test file was added under `e2e/`, and the unit suite still needs nothing but Node ([§2](#2-where-the-e2e-environment-lives)).
+- [ ] Every service declares a `mem_limit`, each JVM service's heap is about half its cap, and the sum of all caps sits at a conservative slice of the memory the container runtime was given (~40%, so two stacks can be up at once — on Docker Desktop or WSL2 that is the VM's allocation, not the machine's) ([compose-definition.md](./references/compose-definition.md)).
+- [ ] No heavy job (the parallel unit suite above all) is assumed to share the machine with the running stack — it runs after `down.sh`, or the stack's capped footprint is counted against its memory budget ([§2](#2-where-the-e2e-environment-lives)).
+- [ ] Every published port is `127.0.0.1`-prefixed — on a block of its own if the stack coexists with the developer's — and services the host does not reach publish nothing ([§4](#4-ports-are-published-to-loopback-only-on-a-dedicated-block)).
+- [ ] Any service that advertises its own address is published on the port it advertises ([§4](#4-ports-are-published-to-loopback-only-on-a-dedicated-block)).
+- [ ] The stack has its own compose project name, so it cannot adopt the development stack's volumes ([§4](#4-ports-are-published-to-loopback-only-on-a-dedicated-block)).
+- [ ] Where production has an edge, this environment has one too, and **every screen was driven through it** rather than against the application's own port ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- [ ] The edge configuration was **copied from the production one**, and carries the `derived-from` / `derived-at` / `deltas` record naming what was changed. Where production's edge is managed and has no file, the behaviours reproduced and the ones that could not be are written down instead ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- [ ] Header forwarding (`Upgrade` / `Connection`) and the request body-size limit were confirmed **by exercising them**, not by reading the configuration ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- [ ] The edge and the application sit on the **same side of the container boundary** ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- [ ] Any check that depends on the client's source address has the **client on that side too**, so the addresses are not collapsed by a published port ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- [ ] Reachability and health were confirmed **from the side that consumes them**, not from inside the container ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- [ ] If the edge was left out, the measurement, the decision and where the verification was handed to are written down — and what any partial test bed proves is recorded at that granularity ([§5](#5-the-edge-what-the-browser-actually-connects-to)).
+- [ ] The stack runs under its own environment name (`live-local` is the recommendation) with its own committed `.env.<stack-env>` — a complete, standalone file in which no key is referenced, imported or generated out of another environment's file, even where the values coincide ([§3](#3-environment-a-dedicated-environment-name-with-an-env-file-of-its-own)).
+- [ ] The coexist / must-not-destroy questions have been answered out loud, and the values they force are written in `.env.<stack-env>`; anything the compose file interpolates reaches compose via `--env-file` or the runner's exports ([§3](#3-environment-a-dedicated-environment-name-with-an-env-file-of-its-own)).
+- [ ] If a build may not destroy what the developer has, the system of record's name, every derived name's identity, the read model's name and the object storage location are all the E2E stack's own — these are the failures that are silent ([§3](#3-environment-a-dedicated-environment-name-with-an-env-file-of-its-own)).
+- [ ] Seed data is in the environment's own `<stack-env>-master/` + `<stack-env>/` directories, master rows **re-exported** from the production master, ids in the reserved band, and sign-in accounts included ([§6](#6-data-a-seed-set-of-its-own)).
+- [ ] The build generates the binary artifacts the seeds promise ([§6](#6-data-a-seed-set-of-its-own)).
+- [ ] Waiting is on healthchecks with a deadline, and any failure aborts instead of handing over ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] **Each script does one thing and none of them inspects the data to choose a branch**; `up.sh` is literally `clean.sh` → `start.sh` → `seed.sh`, and `--start-only` delegates to `start.sh` ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] `start.sh` performs no data operation, and every step in it is safe to run against an environment that is already up ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] Provisioning that depends on data is in `seed.sh`, not `start.sh` — otherwise starting an empty environment fails for an unrelated-looking reason ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] Nothing but `clean.sh` deletes data, and the abort trap calls `down.sh`, not `clean.sh` ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] `clean.sh` reaches **every** store — system of record, read model, transport channels and offsets, propagation state, queue, object storage — and stops the background processes before it starts ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] `seed.sh` run against an already-seeded environment fails loudly on the fixed ids rather than being made idempotent ([§6](#6-data-a-seed-set-of-its-own)).
+- [ ] The application and every background process the product needs are started by `start.sh` and stopped by `down.sh`, with their output kept in `e2e/logs/` ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] Whichever script the operator invoked ends by printing the URL to open, the log locations, and the stop and wipe commands ([§7](#7-the-runner-one-command-per-intention-and-no-script-that-guesses)).
+- [ ] The unit suite still passes untouched and `npm run lint` passes.
+
+## Detail files
+
+Every detail file uses the same example stack, whose components illustrate the roles in
+[§1](#1-roles-first-the-component-set-here-is-one-example).
+
+- [compose-definition.md](./references/compose-definition.md) — the whole compose file for the E2E
+  stack, the per-service settings the pipeline depends on (row-image change log, transport listeners,
+  read-model heap and security, baked-in plugins), the per-container `mem_limit` caps and the
+  runtime-memory budget that sizes them, project naming, volumes vs `tmpfs`, and healthchecks
+  (§2, §4)
+- [edge-and-proxy.md](./references/edge-and-proxy.md) — the edge compose service, the nginx
+  configuration and its Apache equivalents, how to derive the E2E file from the production one and
+  record the derivation, the reduced test bed that exercises the edge alone and the propositions it
+  does not cover, and the measured record of what happens when the container boundary is crossed
+  (§5)
+- [windows-runner.md](./references/windows-runner.md) — **opt-in, read only when Windows-native
+  scripts are asked for**: the per-OS differences behind the assumptions above, why plain Windows
+  does not run the `.sh` set, the intention-by-intention PowerShell mapping, the shape of the five
+  `.ps1` scripts, and how to record what was actually verified
+- [environment-and-ports.md](./references/environment-and-ports.md) — the dedicated environment name
+  and how its standalone `.env.<stack-env>` is authored, the table of values that must differ per
+  environment, the dotenv/`process.env` precedence rule with the merge that causes it, the
+  host-vs-network address split, the port block, and the missing-key-reads-as-`null` behavior (§3, §4)
+- [seed-data.md](./references/seed-data.md) — the master / fixture split of the environment's own
+  seeder directories, the re-export skeleton, the reserved id band, the seed scripts, and the
+  generated-artifact step (§6)
+- [runner-and-lifecycle.md](./references/runner-and-lifecycle.md) — the command set, the rule that
+  puts each step in `start.sh` or `seed.sh`, a step table per script with the reason each step sits
+  where it does, `up.sh` as their composition, what `clean.sh` has to reach and in what order,
+  health-wait shapes, application and background-process handling, the hand-over, the
+  abort-on-failure trap, and the CI stance (§7, §8)

--- a/kit/skills/backend/hb-build-e2e-test-environment/references/compose-definition.md
+++ b/kit/skills/backend/hb-build-e2e-test-environment/references/compose-definition.md
@@ -1,0 +1,368 @@
+# The compose definition
+
+The compose file that brings the E2E stack up, service by service, and the settings the pipeline
+depends on. Referenced from §2 and §4 of [SKILL.md](../SKILL.md).
+
+> **One example stack.** Each service fills a *role* you map your project onto
+> ([SKILL.md §1](../SKILL.md)); keep each section's **general rule** and replace the YAML.
+> Service names, volumes, images, environment variables and ports are **illustrative values**,
+> never values to copy.
+
+## Reading a service block
+
+Whatever component fills a role, the block for it answers the same four questions:
+
+| Question | Where the answer shows up | Holds for any component |
+| --- | --- | --- |
+| what does it need to be configured to emit or accept, for the next role to work? | `command:` / `environment:` | yes — a store that feeds change propagation must be told to produce what the propagator reads |
+| does the host need to reach it, and on which port? | `ports:`, always `127.0.0.1`-prefixed | yes — and a service that advertises its own address must publish the port it advertises |
+| how does it say it is ready? | `healthcheck:` | yes — the runner waits on this and nothing else |
+| what is the most memory it may take from the machine? | `mem_limit` | yes — every container gets a hard cap, and the caps are budgeted against the runtime's memory ([§ Memory](#memory-cap-every-container-then-budget-against-the-runtimes-memory)) |
+| what must be inside its image, so the stack starts without network access? | `build:` | yes — plugins, extensions and drivers are baked in, never downloaded at start |
+
+## Why a second compose file
+
+The development stack is a place to work in; the E2E stack is a place to *operate the product* in.
+They want different things:
+
+| | development stack | E2E stack |
+| --- | --- | --- |
+| lifetime | days, kept between sessions | kept between sessions too, but destroyable in one command |
+| ports | the conventional ones | a block of its own **if** the two must run at once |
+| memory | generous, uncapped | every container hard-capped, all caps budgeted to a conservative slice of the runtime's memory ([§ Memory](#memory-cap-every-container-then-budget-against-the-runtimes-memory)) |
+| data | accumulated by hand | loaded once from the seed set, then mutated by the operator |
+| volumes | persistent | persistent **per project**, dropped only by `clean.sh` |
+
+Keeping one file for both means every one of those rows becomes a compromise. Keep two, and put the
+E2E one under `e2e/` where its purpose is obvious.
+
+## Memory: cap every container, then budget against the runtime's memory
+
+The E2E stack is a stack of resident processes — a database, one or two JVM services, a cache, the
+application and its background daemons — that all hold memory for the entire session while no one
+interacts with them. Left uncapped they will grow to whatever the machine has, and on a laptop their
+total pushes the machine into swap or the out-of-memory killer. Two rules keep that from happening,
+and both are requirements.
+
+**Every service gets a hard `mem_limit`.** Not a heap flag — a container-level cap. A container the
+compose file does not cap can use everything the runtime has, so a single uncapped service undoes the
+budget no matter how carefully the others are sized. This is the one line that protects the host.
+
+**A JVM heap flag is not a memory cap.** `-Xmx512m` bounds the *heap* only; the JVM's off-heap
+buffers, thread stacks, metaspace and the operating system's page cache for the service all sit on
+top, so a JVM service routinely uses **two to three times its heap** in resident memory. Set the heap
+*and* the `mem_limit`, keep the heap at roughly **half** the `mem_limit`, and read the `mem_limit` —
+never the heap — as the number the machine actually has to find. A store with no heap flag at all (a
+relational database, a cache) still gets a `mem_limit`; it simply grows into it via its own buffers
+and the page cache rather than a `-Xmx`.
+
+**Budget the caps against the memory the container runtime was given, conservatively, assuming two
+stacks are up at once.** On native Linux that is the machine's memory; on Docker Desktop and WSL2 it
+is the runtime VM's allocation, which is **half the machine by default** — budget against the
+machine there and the caps overflow the VM long before they trouble the host. The
+whole point of the port block and the dedicated project name ([§4](../SKILL.md)) is that this stack
+can run *beside* the developer's own — so size it as if it always does. The rule of thumb:
+
+> **The sum of every `mem_limit` in this stack stays around 40% of the memory the container
+> runtime was given.**
+
+Two stacks at 40% leave 20% for the operating system, the editor and the browser — the margin that
+keeps the machine responsive instead of swapping. This is deliberately conservative because the
+failure it prevents (the whole machine freezing) costs far more than a service running in a slightly
+tighter heap. On a 16 GB Linux laptop that is a ~6 GB budget for the entire stack. **The same 16 GB
+machine running WSL2 gives the runtime 8 GB by default, so the budget is ~3.2 GB** — read the figure
+the runtime reports (`docker info`), not the one the machine advertises. The example values below sum
+to well under the Linux figure, and are scaled down rather than letting the total drift up.
+
+Expressing the cap in compose:
+
+```yaml
+services:
+  some-service:
+    mem_limit: 1g          # compose v2 short form — the hard ceiling for this container
+    # deploy:               # the Swarm-style long form is only honoured with `--compose-file` under
+    #   resources:          # `docker stack deploy`; for `docker compose up` use `mem_limit` above.
+    #     limits: { memory: 1g }
+```
+
+The example stack's roles, sized to fit inside a ~40% budget with generous headroom, and to leave
+room for the developer's own stack beside it:
+
+| Role (example component) | `mem_limit` | Heap flag (≈ half) | Note |
+| --- | --- | --- | --- |
+| system of record (MariaDB) | `768m` | — (buffer pool, not a heap) | cap the InnoDB buffer pool below this in `command:` if the default is generous |
+| cache and job queue (Redis) | `256m` | `--maxmemory 192mb` | set `--maxmemory` under the cap so Redis evicts instead of being OOM-killed |
+| event transport (Kafka) | `1g` | `-Xmx512m` | JVM: cap is ~2× heap |
+| change propagation (Kafka Connect) | `768m` | `-Xmx384m` | JVM: cap is ~2× heap |
+| read model (Elasticsearch) | `1g` | `-Xms512m -Xmx512m` | JVM: cap is ~2× heap; the heaviest single service |
+
+That sums to ~3.6 GB — inside a 16 GB Linux machine's budget, but **over** the ~3.2 GB a default
+WSL2 VM on that same machine allows, which is exactly the trap: the figure to check is the
+runtime's.
+The point is the **relationship**: pick each `mem_limit` first from what the service tolerates, keep
+each JVM heap near half its cap, and check the total against the runtime's memory budget before
+committing — not the reverse. **General rule:** whatever components fill the roles, every one gets a
+`mem_limit`, JVM ones get a heap near half of it, and the sum is held to the conservative slice above.
+
+## Project name and volumes
+
+```yaml
+# e2e/docker/compose.yaml
+name: <project>-e2e   # NOT the default (the directory name), and NOT the dev project's
+```
+
+**The file sits under `e2e/docker/`, with everything it references by relative path beside it** —
+the `build:` contexts under `images/`, the init SQL under `initdb/`, any config a service mounts.
+Compose resolves those paths against this file's directory, so keeping them together lets the
+definition move as a unit; the scripts stay at `e2e/` root and pass `-f e2e/docker/compose.yaml`.
+
+- **Declare `name:`.** Without it, compose derives the project name from the directory, and two
+  compose files that happen to sit in similarly-named directories share containers, network and
+  volumes. Sharing volumes with the development stack is the worst case: the run inherits the last
+  session's rows, and fixed seed ids collide on insert.
+- **Named volumes persist between runs, and that is the point.** The operator's data has to survive a
+  restart, so `down.sh` never touches the volumes; `clean.sh` is the one command that drops them
+  ([runner-and-lifecycle.md](./runner-and-lifecycle.md)). A re-run also skips the image build and the
+  cluster's startup as a side benefit.
+- **`tmpfs` for the data directory is a trade, not a free speed-up.** It makes a store fast and always
+  empty — the change log the capture connector reads works there too — but *always empty* now means
+  the operator loses their session's work whenever the container restarts. Use it only for a store
+  whose contents are genuinely disposable within a session, never for the system of record.
+
+## The services
+
+Each heading names the **role** first and the component the example fills it with second.
+
+### System of record — example: a relational database with a row-format change log
+
+```yaml
+services:
+  mariadb:
+    image: mariadb:11.4   # pin the minor: the binlog format the connector reads must not move
+    mem_limit: 768m       # hard container cap (§ Memory); keep the buffer pool below it, next line
+    command: >
+      --log-bin=mysql-bin
+      --binlog-format=ROW
+      --binlog-row-image=FULL
+      --innodb-buffer-pool-size=384M
+      --expire-logs-days=1
+      --server-id=1
+    environment:
+      MARIADB_DATABASE: ${DATABASE_NAME}
+      MARIADB_ROOT_PASSWORD: ${DATABASE_PASSWORD}
+    ports: ['127.0.0.1:13306:3306']
+    volumes:
+      - 'e2e-db-data:/var/lib/mysql'
+      # e2e/docker/initdb — beside the compose file, because that is what './' resolves against.
+      # the account the capture connector reads the log with; runs once, on volume creation
+      - './initdb:/docker-entrypoint-initdb.d:ro'
+    healthcheck:
+      test: ['CMD', 'healthcheck.sh', '--connect', '--innodb_initialized']
+      interval: 5s
+      retries: 20
+```
+
+- **`--binlog-format=ROW` with `--binlog-row-image=FULL` is a requirement, not a preference.**
+  Without the full row image a change event does not carry the row's values, and the capture pipeline
+  delivers events the consumer cannot act on. A search would then return an empty document rather
+  than a missing one. **General rule:** the store must be configured to emit *whatever the change
+  propagation mechanism reads* — the equivalent switch is `wal_level=logical` plus a replication slot
+  on PostgreSQL, CDC enabled per table on SQL Server, an oplog-backed replica set for change streams,
+  and nothing at all where propagation is an outbox table the application writes itself.
+- **Pin the minor version.** A floating major tag can move the change-log format under the propagator
+  on a rebuild, breaking the pipeline for a reason that is not in the repository.
+- **The initdb directory runs once, when the volume is created.** Since the volume now survives
+  every `down.sh`, a changed SQL file there is applied only after someone runs `clean.sh`, never on
+  the next `up.sh`. Say so wherever these files are edited, because the symptom (a missing account,
+  an ungranted privilege) looks nothing like its cause.
+- **Short log expiry** (`--expire-logs-days=1`) — this environment has no reason to keep a week of
+  change log.
+- **`mem_limit` with the buffer pool sized under it.** The container cap alone stops the database
+  from taking the machine, but a database left to size its own buffer pool from *total* RAM will
+  size itself for the host, not the cap, and then keep hitting that limit — so set
+  `--innodb-buffer-pool-size` (the equivalent for another engine: `shared_buffers`, the cache size)
+  to a value comfortably below the `mem_limit`. **General rule:** a store that auto-sizes its cache
+  from host memory must be told the smaller figure explicitly, or the cap and the store disagree
+  about how much memory exists (§ Memory).
+
+### Cache and job queue — example: Redis
+
+```yaml
+  redis:
+    image: redis:7-alpine
+    mem_limit: 256m       # hard container cap (§ Memory)
+    # --maxmemory sits under the cap so Redis evicts rather than being OOM-killed at the cap
+    command: ['redis-server', '--save', '', '--appendonly', 'no', '--maxmemory', '192mb', '--maxmemory-policy', 'allkeys-lru']
+    ports: ['127.0.0.1:16379:6379']
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      retries: 20
+```
+
+- **Persistence off** (`--save '' --appendonly no`) — the one store that is allowed to forget.
+  Queued jobs are work *in flight*, not the operator's data: the durable state lives in the system of
+  record, and a job whose row is still there can be re-triggered. Keeping them across a restart mostly
+  means a worker waking up to process a job whose context has moved on. **General rule:** the roles
+  that must survive a restart are the ones holding authored state; the queue is not one of them, so
+  turn its durability off rather than reasoning about stale jobs later.
+- **`--maxmemory` set below the `mem_limit`, with an eviction policy.** Reach the `mem_limit` and the
+  container is OOM-killed outright; reach `--maxmemory` first and the cache evicts a key instead — a
+  graceful degradation rather than a dead service. Keep `--maxmemory` a margin under the cap so the
+  cache stays inside the container ceiling (§ Memory).
+
+### Event transport — example: Kafka in single-node mode
+
+```yaml
+  kafka:
+    image: <kraft-mode-kafka-image>
+    mem_limit: 1g         # hard container cap (§ Memory); heap below is ~half of it
+    environment:
+      KAFKA_HEAP_OPTS: '-Xms512m -Xmx512m'   # heap ≈ half the cap; JVM overhead lives in the rest
+      KAFKA_CFG_NODE_ID: '0'
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka:9093
+      # two ways in: Connect is a container and reaches the broker by service name; the test
+      # runner is on the host and reaches it through the published port
+      KAFKA_CFG_LISTENERS: INTERNAL://:9092,EXTERNAL://:19092,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:19092
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
+    ports: ['127.0.0.1:19092:19092']   # host port == the EXTERNAL listener port
+    healthcheck:
+      test: ['CMD-SHELL', 'kafka-topics.sh --bootstrap-server localhost:9092 --list']
+      interval: 5s
+      retries: 30
+```
+
+- **The published port must equal the external listener's port.** A broker answers the initial
+  connection with cluster metadata containing its *advertised* address, and the client then
+  reconnects to that. Map `127.0.0.1:19092:29092` while advertising `localhost:29092` and the client
+  connects, is told to go to `29092`, finds nothing there, and every produce and consume fails —
+  after a connection that looked fine. Change the listener port and the advertised port together,
+  and publish that same number. **General rule:** this applies to every component that answers with
+  its own address, not just to this broker — a clustered queue redirecting to a node name, a replica
+  set naming its members, a cluster publishing a `publish_address`. Find where the component states
+  its own address and make that the address the host can reach.
+- **Two listeners because there are two kinds of client.** One listener can advertise only one
+  address; a container client needs the service name, the host runner needs `localhost`. Any
+  component reached from both sides has the same two-audience problem, however it is configured.
+- **`KAFKA_CFG_CONTROLLER_LISTENER_NAMES` is required whenever `controller` is a role** — without it
+  the entrypoint aborts before the broker starts, because it cannot tell which listener the quorum
+  speaks on.
+- **Leave auto-creation off.** A topic the broker invents gets one partition, and **a partition
+  count cannot be reduced afterwards** — so a single accidental produce before the create step
+  permanently changes the topic's ordering guarantees. The runner creates topics explicitly.
+  **General rule:** wherever the transport can invent a channel on first use, turn that off and
+  create the channels in the runner, because an invented channel gets defaults you cannot take back.
+- **Heap set to about half the `mem_limit`.** The broker is a JVM, so its `mem_limit` has to cover the
+  heap *plus* the off-heap buffers and page cache it uses to move messages — set `KAFKA_HEAP_OPTS`
+  near half the cap and let the rest absorb that overhead, rather than sizing the heap to the whole
+  container and being OOM-killed under load (§ Memory).
+
+### Change propagation — example: a CDC connector in Kafka Connect
+
+```yaml
+  kafka-connect:
+    build: ./images/connect      # the capture connector plugin, baked in
+    mem_limit: 768m              # hard container cap (§ Memory); heap below is ~half of it
+    depends_on:
+      kafka: { condition: service_started }
+      mariadb: { condition: service_healthy }
+    environment:
+      KAFKA_HEAP_OPTS: '-Xms384m -Xmx384m'  # heap ≈ half the cap
+      BOOTSTRAP_SERVERS: kafka:9092         # in-network, not the published port
+      GROUP_ID: <project>-e2e-connect
+      CONNECT_REST_ADVERTISED_HOST_NAME: kafka-connect
+      CONFIG_STORAGE_TOPIC: _connect_configs
+      OFFSET_STORAGE_TOPIC: _connect_offsets
+      STATUS_STORAGE_TOPIC: _connect_status
+      KEY_CONVERTER_SCHEMAS_ENABLE: 'false'
+      VALUE_CONVERTER_SCHEMAS_ENABLE: 'false'
+    ports: ['127.0.0.1:18083:8083']   # only because the runner registers the connector over it
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -sf http://localhost:8083/connectors']
+      interval: 5s
+      retries: 40
+```
+
+- **The plugin is baked into an image, not downloaded at start.** A start-time download makes the
+  stack need the network and fail differently on a slow day, and where outbound access is restricted
+  it does not work at all.
+- **Its own storage topics per project.** Connector configuration and offsets live in Kafka, so two
+  stacks sharing them means one registers a connector the other did not ask for. A distinct
+  `GROUP_ID` (and separate broker, as here) keeps them apart. **General rule:** wherever the
+  propagation mechanism keeps its own state — replication slot, offset table, cursor file,
+  subscription name — that state needs a name of its own per stack, or the two stacks interfere with
+  each other.
+- **The connector registration API is published only because the runner is on the host.** It takes
+  no authentication — the `127.0.0.1` prefix keeps it off the network.
+- **A propagator that is not a service at all needs no block here.** An outbox poller or a dual-write
+  path lives inside the application, so it is started as one of the background processes instead
+  ([runner-and-lifecycle.md](./runner-and-lifecycle.md)) — and the ordering constraint (propagation
+  registered after the transport's channels and after the master rows) is unchanged.
+
+### Read model — example: a search cluster with an analyzer plugin
+
+```yaml
+  elasticsearch:
+    build: ./images/search       # the analyzer plugin the application relies on, baked in
+    mem_limit: 1g                # hard container cap (§ Memory); heap below is ~half of it
+    environment:
+      discovery.type: single-node
+      # heap ≈ half the mem_limit — the rest is JVM off-heap, Lucene buffers and page cache
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m'   # a fixture, not a workload; NOT the container's total
+      xpack.security.enabled: 'true'
+      ELASTIC_PASSWORD: ${ELASTICSEARCH_PASSWORD}
+    ports: ['127.0.0.1:19200:9200']
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -sf -u elastic:$$ELASTIC_PASSWORD http://localhost:9200/_cluster/health']
+      interval: 5s
+      retries: 40
+    volumes: ['e2e-search-data:/usr/share/elasticsearch/data']
+```
+
+- **A much smaller heap than the development stack, and a `mem_limit` on top of it.** The E2E stack
+  must be able to run *beside* the development one; a multi-gigabyte heap on both makes a developer
+  stop bringing it up. The heap flag is only half the story: it bounds the JVM heap, but Lucene's
+  off-heap buffers and the OS page cache push the container's real footprint to roughly double it,
+  so the search node is the heaviest single service and the one whose `mem_limit` — set to about
+  twice the heap — matters most to the budget (§ Memory).
+- **Leave authentication on.** Turning it off here means the credential path is never exercised,
+  and the first environment that has it enabled is the one that breaks.
+- **The analyzer plugin is baked in for the same reason as the connector plugin** — no network at
+  start, so the stack also comes up where outbound access is restricted. The same holds for any
+  extension the read model needs (a database extension for a materialized view, a tokenizer
+  dictionary, a language pack).
+- **This is the slowest service to become healthy.** Give its health wait the longest retry budget.
+- **A read model that is not a separate service still exists as a step.** A materialized view or a
+  denormalized table lives in the system of record, so it has no block here — but it still needs
+  creating before anything writes to it, a name of its own per run, and a backfill after seeding.
+
+### Edge — example: nginx in front of the application
+
+The service block for the edge, the configuration it mounts, and why it is the last service to
+become healthy are in [edge-and-proxy.md](./edge-and-proxy.md), where the rest of the proxy layer
+lives. Everything in this file still applies to it: a `127.0.0.1`-prefixed published port, a
+`mem_limit` like every other container, and a healthcheck the runner can poll.
+
+One caveat specific to it: **the container's healthcheck answers from inside the container's own
+namespace**, so it reports healthy while nothing outside can reach the edge. The runner therefore
+also polls the published port from the host — see
+[the health-wait section](./runner-and-lifecycle.md#waiting-on-health-never-on-sleep).
+
+## Healthchecks are the contract
+
+Every service declares its own healthcheck, and the runner only ever polls compose for the result
+([runner-and-lifecycle.md](./runner-and-lifecycle.md)). Two reasons:
+
+- **The service knows when it is ready; the runner does not.** "The port accepts a connection" is not
+  readiness for a database still initializing, or for a cluster that has not elected itself.
+- **`depends_on: condition: service_healthy` composes.** Connect must not start before the database
+  is genuinely up, or it registers against a server that then restarts, and the connector lands in a
+  failed state that no test explains.
+
+Use short intervals (5s) and a generous retry count for a fixture: a fast machine then starts fast,
+and a slow one still starts.

--- a/kit/skills/backend/hb-build-e2e-test-environment/references/edge-and-proxy.md
+++ b/kit/skills/backend/hb-build-e2e-test-environment/references/edge-and-proxy.md
@@ -1,0 +1,287 @@
+# The edge and the proxy layer
+
+The reverse proxy the browser actually connects to. How to copy its configuration from production,
+which side of the container boundary it belongs on, and what it can and cannot prove. Referenced
+from §5 of [SKILL.md](../SKILL.md).
+
+> **nginx is the example. The edge is the role.** Every rule here is about *the thing in front of
+> the application*. The nginx directives are one way to write it, and the Apache versions are in a
+> table below. Service names, ports and paths are **examples**, not values to copy.
+>
+> **This file applies only where production has an edge.** If it does not, skip all of it and do not
+> add a proxy here — a layer production does not run hides bugs just as effectively as a missing
+> one.
+
+## What only the edge can catch
+
+Each setting below works fine when the browser talks straight to the application. Each one breaks in
+production. An environment with no edge reports all of them as working.
+
+| Setting | Left at its default | What happens in production |
+| --- | --- | --- |
+| `Upgrade` / `Connection` headers | not forwarded | WebSocket and GraphQL subscriptions never connect. They time out with no error |
+| `client_max_body_size` | 1MB | uploads over 1MB fail with 413 |
+| `proxy_buffering` | on | a streamed response arrives all at once at the end, or gets cut off |
+| `proxy_read_timeout` | 60s | a slow request fails with 504 while the application is still working |
+| `X-Forwarded-For` / `-Proto` | unset | every client looks like the proxy, so per-client limits count everyone as one. Links fall back to `http` |
+| trailing `/` on `proxy_pass` | — | the path prefix is dropped or doubled, and a route that works locally returns 404 |
+| `try_files` for a single-page app | unset | a deep link or a reload returns 404. Only clicking through from the first page works |
+| cookie `Secure` / `SameSite` | depends where TLS ends | sign-in looks like it worked, then the session is gone on the next request |
+
+The first two reach production most often. Both stay hidden until someone uses that one feature.
+
+## Copy the configuration from production
+
+**Start with the production file. Do not write a new one.** This layer is worth having because it
+carries production's bugs. A file you write fresh has different bugs, so the edge is there and
+proves nothing.
+
+Change three things and nothing else:
+
+| Change | Why |
+| --- | --- |
+| Remove TLS termination — `listen 443 ssl`, the certificate paths, the redirect from `:80` | there is no certificate here, and the operator connects over loopback |
+| Point `proxy_pass` at the E2E application | this is the only address that differs |
+| Set `server_name` to `_` | you pick the stack by loopback port, not by host name. Host names would mean editing `/etc/hosts` on every machine |
+
+Copy everything else **as it is** — header forwarding, body size, timeouts, buffering, and the
+location blocks in their original order. Any other difference is a bug you will not catch.
+
+### When production's edge is a managed one
+
+A cloud load balancer, an API gateway or a CDN has no configuration file you can copy. Running a
+local nginx in its place is a rehearsal, not the same thing. Do it anyway — it still catches the
+header, body-size and buffering bugs — but be honest about the gap.
+
+| Do this | Not this |
+| --- | --- |
+| List the behaviours the product depends on, and reproduce those | Try to imitate the whole product |
+| Write down which ones you could not reproduce, and why | Leave the difference unrecorded |
+| Hand the rest to the deployment runbook, to check after release | Report the local run as end-to-end proof |
+
+The ones worth reproducing are almost always the same four: header forwarding, request body size,
+timeouts and buffering. The ones you usually cannot are the provider's own — WAF rules, request
+signing, edge caching, and how it behaves when it is overloaded.
+
+### Write down where the copy came from
+
+```nginx
+# derived-from: the deployment runbook's edge configuration chapter
+# derived-at:   2026-08-22
+# deltas:       TLS termination removed / upstream repointed to the E2E app / server_name relaxed
+```
+
+- **Update `derived-at` and rewrite `deltas` every time the production file changes.** A note
+  nobody updated does not tell you this is a copy. It tells you the two files are now different.
+- **Watch how long `deltas` gets.** Two or three lines is a copy. A list that keeps growing means
+  the copy is turning into a rewrite. Fix the production side instead — usually by moving whatever
+  differs into a variable or an included file that both can use.
+- **Name the production chapter, not a file path.** The runbook lives in the other repository, and
+  you cannot know its path from here.
+
+## The compose service
+
+The edge becomes healthy last. It has nothing to serve until the application answers.
+
+```yaml
+  edge:
+    image: nginx:1.27-alpine
+    depends_on:
+      app:
+        condition: service_healthy
+    volumes:
+      - ./nginx/e2e.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - '127.0.0.1:18080:80'
+    mem_limit: 64m
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '-O', '-', 'http://localhost/healthz']
+      interval: 5s
+      timeout: 3s
+      retries: 12
+```
+
+- **Mount the config read-only (`:ro`).** The container never writes it, so say so.
+- **Give it a `mem_limit` like every other service.** A proxy is small, but an uncapped container is
+  still uncapped ([§ Memory](./compose-definition.md#memory-cap-every-container-then-budget-against-the-runtimes-memory)).
+- **The container's own healthcheck is not enough.** It only sees the inside of the container. The
+  runner also polls `http://127.0.0.1:18080/` from the host, which is the side the operator uses.
+
+## The nginx configuration
+
+```nginx
+# derived-from: the deployment runbook's edge configuration chapter
+# derived-at:   2026-08-22
+# deltas:       TLS termination removed / upstream repointed to the E2E app / server_name relaxed
+
+upstream app {
+  server app:3000;
+}
+
+server {
+  listen 80;
+  server_name _;
+
+  # copied from production as it is — these values are the whole point
+  client_max_body_size 30m;
+  proxy_read_timeout   300s;
+
+  location /healthz {
+    access_log off;
+    return 200 "ok\n";
+  }
+
+  location / {
+    proxy_pass http://app;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # WebSocket / subscriptions
+    proxy_set_header Upgrade    $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+}
+```
+
+Three things go wrong here more than anything else.
+
+- **One `proxy_set_header` inside a `location` throws away all the inherited ones.** Set any header
+  in a `location` block and every header from the `server` block is gone. This is how a header
+  quietly stops being forwarded on one route while every other route is fine. No unit test can see
+  it.
+- **`$connection_upgrade` is a map you define, not a built-in.** Put it in the `http` block:
+  `map $http_upgrade $connection_upgrade { default upgrade; '' close; }`. Sending a plain
+  `Connection: upgrade` on every request breaks keep-alive for normal ones.
+- **A trailing `/` on `proxy_pass` changes the path.** `proxy_pass http://app;` passes the URI
+  through. `proxy_pass http://app/;` strips the matched `location` prefix. Copy whichever one
+  production uses.
+
+### The same settings in Apache
+
+| Purpose | nginx (the default here) | Apache httpd |
+| --- | --- | --- |
+| forward | `proxy_pass` | `ProxyPass` / `ProxyPassReverse` |
+| WebSocket | `proxy_set_header Upgrade` / `Connection` | `RewriteCond` + `ProxyPass ws://` (`mod_proxy_wstunnel`) |
+| request body size | `client_max_body_size` | `LimitRequestBody` |
+| upstream timeout | `proxy_read_timeout` | `ProxyTimeout` |
+| turn off buffering | `proxy_buffering off` | `flushpackets=on` / `proxy-sendchunked` |
+| original client address | `X-Forwarded-For` | `mod_remoteip` (`RemoteIPHeader`) |
+| single-page fallback | `try_files $uri /index.html` | `FallbackResource` |
+| compression | `gzip on` | `mod_deflate` |
+
+## Which side of the container boundary
+
+**Put the edge and the application on the same side. Both in containers, or neither.**
+
+```
+A — the edge is part of what you are checking
+  [client container ×N] → [edge container] → [app container]
+  one compose network, nothing crosses the boundary,
+  and the source addresses are really different
+
+B — no edge
+  [browser on the host] → [app process on the host]
+  nothing tests the proxy layer — write that down and pass the check on
+```
+
+Shape A also makes the stack portable. With all three in containers the host needs only a container
+runtime, and the stack behaves the same on Linux, macOS and WSL2.
+
+### What we measured when the boundary was crossed
+
+Someone built a stack with the application on the host and the edge in a container. They measured it
+on **WSL2 with Docker Desktop 29.5.2**. All four routes failed. The application was listening on
+`*:3900`, on every interface, the whole time — so "the application was not listening" explains none
+of it.
+
+| Route tried | Result |
+| --- | --- |
+| edge with `network_mode: host` | does not work. On Docker Desktop, "host" means the Docker VM, not WSL2. `proxy_pass 127.0.0.1` never reaches the application |
+| bridge network with a published port | **connects, and is useless as a check.** Requests from three different sources all arrived with `$remote_addr` set to `172.17.0.1`. A per-client rule passes even when the code counts every client as one |
+| host connecting to the container's IP | `EHOSTUNREACH`. WSL2's `eth0` was on `172.17.2.189/20`, which overlaps Docker's `172.17.0.0/16` |
+| container connecting to the application on the host | HTTP 000 on all four of `host.docker.internal`, the default gateway, `192.168.65.2`, and WSL2's own address |
+
+**The lesson is not that the machine was strange.** The shape was weak from the start, and this
+machine showed it. The `127.x` aliases they used to separate the sources also collapse on plain
+Linux, because loopback traffic to a published port goes through `docker-proxy`. It only works with
+`userland-proxy=false` *and* non-loopback addresses. Call it a quirk of one machine and someone
+builds the same thing again next time.
+
+There is a second reason this shape cannot work here. This skill binds the application to
+`127.0.0.1` only ([§4](../SKILL.md)), which closes the route anyway.
+
+### A published port hides who the client is
+
+**Moving the application into a container is not enough** if your check depends on who the client
+is. Traffic through a published port gets rewritten to the bridge gateway's address before the edge
+sees it. If you need clients to look different, put the clients inside the compose network too.
+That is why shape A has the client in a container.
+
+## Testing the edge on its own
+
+You can test the edge's configuration without the application. Put an echo server behind it and read
+the headers it received:
+
+```
+[client container ×N] → [edge container] → [echo container]
+```
+
+It is smaller than the full stack. It needs no seed data. It never crosses the container boundary.
+
+**Here is what it proves and what it does not:**
+
+| Question | Who answers it |
+| --- | --- |
+| does the edge add a real client address on the right, without a `location` block throwing away the inherited `proxy_set_header`? | **this test** — and nothing else can |
+| does the application read the right entry, counting from the right? | unit tests, which you already have |
+| do the two actually work together, so the behaviour really is per-client? | **neither one** |
+
+The echo server has no rate limiter, no session and no application logic. Nothing here reaches the
+behaviour those headers feed into. **You are joining up two separate tests, not running one test end
+to end.** Write it down that way. To close the gap you need the application on the same side, which
+is shape A.
+
+The gap this test *does* close is the dangerous one. A `proxy_set_header` that is in one `location`
+and missing from another cannot be caught by a unit test at all. In production it shows up as one
+route behaving differently from the rest.
+
+## How to check it works
+
+Treat these as intentions — the exact flags differ per tool. Run them **from the host**, because
+that is the side the operator uses.
+
+| What to check | How |
+| --- | --- |
+| the edge is serving | `curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:18080/` |
+| the path prefix survives | request a nested route, and compare the status with the same route on the application's own port |
+| `Upgrade` is forwarded | open the product's subscription or WebSocket feature in the browser **through the edge** and watch data arrive. A 101 in the access log confirms the handshake |
+| the body limit matches production | upload a file just under the limit and one just over, and look for 413 |
+| streaming is not buffered | request the streaming endpoint and check the first bytes arrive before the response finishes |
+| the forwarded address arrives | look in the application's log for the client's address, not the proxy's |
+
+**Do all of these for real.** Reading the configuration tells you what the file says. Only a request
+tells you what the edge does.
+
+## When you leave the edge out
+
+First, be clear which situation you are in. **If production has no edge, there is nothing to leave
+out** — the role does not exist for this product, and there is nothing to record. This section is
+about the other case: production has one, and you decided not to build it here.
+
+That is a fair choice — a demo, a deadline, a machine it will not run on. Making it in silence is
+not. Write this down next to the environment:
+
+- **what you measured** — the routes you tried and what each returned, as a table
+- **what you fixed in the product** instead of in the environment
+- **what a person still has to decide**, with the options
+- **the decision, and the date**
+- **who checks it instead** — usually the deployment runbook's post-release chapter
+
+The note is there so the next person does not spend a day working it out again on the same machine.
+
+**Do not leave a broken edge config and a spec that always fails.** A run that is red every time is
+a run nobody reads, and the failures that matter disappear into it.

--- a/kit/skills/backend/hb-build-e2e-test-environment/references/environment-and-ports.md
+++ b/kit/skills/backend/hb-build-e2e-test-environment/references/environment-and-ports.md
@@ -1,0 +1,201 @@
+# Environment values and ports
+
+The E2E stack's dedicated environment name and standalone env file, which values must differ from
+the other environments and why, and how host addresses differ from in-network ones. Referenced from
+§3 and §4 of [SKILL.md](../SKILL.md). `<stack-env>` stands for the environment name that belongs to
+the E2E stack alone — `live-local` is the recommended name.
+
+> **One example stack's keys.** `KAFKA_BROKERS`, `ELASTICSEARCH_BASE_URL`, `CDC_DATABASE_NAME` and
+> the rest are **illustrations**: each *role* ([SKILL.md §1](../SKILL.md)) needs its own address,
+> name and scratch space for the run. Map each row onto the keys the project actually reads.
+
+## A dedicated environment, and a standalone env file
+
+The stack runs under an environment name of its own (`NODE_ENV=<stack-env>`, recommended
+`live-local`) and reads its own committed `.env.<stack-env>` at the repository root. The name is
+derived from the real-dialect test environment (`live` in the backend testing convention): both
+select the same database engine, but `live` exists for running the unit suite against the real
+dialect, while `<stack-env>` describes a **running full stack**. A dedicated name means every
+command that carries `NODE_ENV=<stack-env>` — the application, the schema tooling, a seeder run by
+hand — resolves to the E2E stack's own values automatically, instead of relying on someone
+remembering to set overrides.
+
+Two rules govern the file:
+
+- **It is complete and standalone.** Every key the application, the tooling and the background
+  processes read must be present — the facade returns `null` for a missing key instead of throwing
+  (see the last section), so a gap surfaces as a confusing failure deep inside a service call.
+  When authoring the file, start from the key set of the fullest existing env file and set every
+  value deliberately.
+- **Shared values are independent copies, deliberately.** The database connection shape in
+  `.env.live` and in `.env.<stack-env>` may coincide today; they are still two environments' own
+  values, and each file is the source of truth for its own environment. Do not build one env file
+  out of another by reference, import or generation. When the stack gains a component or a key,
+  updating every environment's file is part of that change — a key added to only one of them shows
+  up as the `null` the other reads for it.
+
+The **groups of comments** below are what to reproduce in `.env.<stack-env>`; the key names inside
+them belong to the example stack:
+
+```bash
+# .env.<stack-env> — the E2E stack's own environment, committed at the repository root.
+
+# the E2E port block — only if this stack must run beside the developer's own (§ ports below)
+DATABASE_PORT=13306
+REDIS_PORT=16379
+KAFKA_BROKERS=127.0.0.1:19092
+ELASTICSEARCH_BASE_URL=http://127.0.0.1:19200
+KAFKA_CONNECT_URL=http://127.0.0.1:18083
+
+# a schema, an index and a topic namespace that belong to the E2E stack alone
+DATABASE_NAME=<project>_e2e_db
+# MUST equal DATABASE_NAME — see below. (No inline comments: some dotenv parsers keep them in the value)
+CDC_DATABASE_NAME=<project>_e2e_db
+SEARCH_INDEX_NAME=<index>_e2e
+KAFKA_CONSUMER_GROUP_ID=<consumer-group>-e2e
+
+# per-run scratch space, so uploads never land in the working tree
+FILE_STORAGE_PATH=e2e/.storage
+
+# a feature that needs a host-installed tool: decided explicitly, not by accident
+<FEATURE>_ENABLED=false
+
+# values the compose file substitutes into ${...} — reach compose via --env-file, see below
+DATABASE_PASSWORD=<development-grade>
+ELASTICSEARCH_PASSWORD=<development-grade>
+```
+
+Three things about this file that are not obvious:
+
+- **`docker compose` does not read `.env.<stack-env>` on its own.** For variable substitution it
+  reads the process environment and a `.env` sitting **next to the compose file** — so any `${...}`
+  the compose file interpolates has to reach it another way: point compose at the stack's file with
+  `--env-file .env.<stack-env>` in the runner, or export those values before invoking compose. A
+  password compose cannot see substitutes as an **empty string**, with only one warning line shown,
+  and the service starts with no password set: exactly the quiet half-built stack this skill is
+  about.
+- **Anything run by hand against the environment has to carry `NODE_ENV=<stack-env>`.** A seeder or
+  migration invoked under the wrong environment name talks to that environment's stack — the
+  disaster the dedicated name exists to prevent. Bake the name into the npm scripts (as the seed
+  scripts in [seed-data.md](./seed-data.md) do) so it cannot be forgotten.
+- **The file is committed, and a name beginning with `.env` may quietly prevent that.** Projects
+  routinely ignore `.env*`; check the repository's `.gitignore` before relying on the file being
+  tracked, because a silently untracked env file means the next developer's build reads `null` for
+  every key and fails somewhere deep. The file holds development-grade fixture values only, so
+  committing it is correct.
+
+## Exports still override the file
+
+The environment resolver merges the dotenv file first and the process environment last:
+
+```js
+// the resolver's merge — the exported variable wins
+const assignedEnv = {
+  ...this.loadedDotenv,
+  ...this.processEnv,
+}
+```
+
+- An exported variable **wins** over the same key in the file, for **everything that reads through
+  the facade** — the application, the schema tooling, the seeders. Useful for a one-off tweak
+  (a different port for a single run) without editing the committed file.
+- The same precedence is a **trap**: a stray variable left exported in the shell silently overrides
+  the committed value, with no warning. When the stack behaves as if the file said something else,
+  check the shell's environment first.
+- Ordinary dotenv loaders do the opposite (the file leaves an existing variable alone, and the
+  variable likewise leaves alone any value the file *did* set into the same object). Verify the
+  direction in the resolver you actually have before relying on it; here it is the merge above.
+
+## The values that must differ, and which of them your project actually needs
+
+Two questions decide the list (§3 of [SKILL.md](../SKILL.md)): **does this stack run beside the
+developer's own**, and **may a build destroy or pollute what the developer already has**. The first
+question owns the port block; the second owns every name. Even when both are answered no — the E2E
+stack *replaces* the developer's stack rather than coexisting with it, and that stack is itself
+disposable — the dedicated `.env.<stack-env>` still exists; the answers only decide whether its
+values may coincide with the development environment's.
+
+The left column names **what kind of value** it is; the key in parentheses is what the example stack
+calls it.
+
+| Value | What goes wrong when it is left equal to the development environment's |
+| --- | --- |
+| **the port block** (every `*_PORT` / `*_URL` / `*_BROKERS`) | the environment silently talks to the developer's own stack, and every screen shows that data instead of the seeded one |
+| **the system of record's name** (`DATABASE_NAME` — a schema, database or namespace) | the schema step **drops and recreates** — pointed at the development database, a build destroys a day of work |
+| **every identity a derived name is built from** (`CDC_DATABASE_NAME`) | the example's change topic is named `<prefix>.<database>.<table>`, so a stale value makes the consumer subscribe to topics nothing ever writes to. Nothing errors; nothing ever propagates, and the screen simply never updates. This is the single most confusing failure in this environment — and it recurs in any stack where a channel, slot, subscription or stream name is **composed** out of another value |
+| **the read model's name** (`SEARCH_INDEX_NAME` — an index, view, table or key prefix) | the run **writes into** whatever it names, and the backfill step writes *every* row — so a stale name pollutes the developer's read model, and a screen can show a document this environment never created. (Setup itself only creates: a read model that already exists is left as it is, which is exactly why a stale name is not caught) |
+| **the object storage location** (`FILE_STORAGE_PATH` — a directory, bucket or key prefix) | uploaded and derived files land in the working tree, so the run pollutes the repository and two runs see each other's files |
+
+**A subscriber identity of its own** is worth adding too (`KAFKA_CONSUMER_GROUP_ID` here, a
+replication slot name, a subscription name, a durable-consumer name elsewhere): if a run is ever
+pointed at a shared transport, a shared identity means two subscribers split the stream and each sees
+half its events.
+
+## Host addresses vs in-network addresses
+
+The same service has **two addresses**, and which one a value needs depends on **who reads it**. The
+rows are the example stack's values; the rule — *host process → `127.0.0.1` + published port,
+container process → service name + container port* — holds for every component:
+
+| Value | Read by | Address |
+| --- | --- | --- |
+| `DATABASE_HOST` / `DATABASE_PORT` | the application and tooling, on the **host** | `127.0.0.1` + the published port (`13306`) |
+| `KAFKA_BROKERS` | the consumer, on the **host** | `127.0.0.1:19092` |
+| `ELASTICSEARCH_BASE_URL`, `KAFKA_CONNECT_URL` | the runner and application, on the **host** | `127.0.0.1` + published port |
+| `CDC_DATABASE_HOST` / `CDC_DATABASE_PORT` | the **connector, inside a container** | the service name (`mariadb`) and the **container's** port (`3306`) |
+| Connect's own `BOOTSTRAP_SERVERS` | the **connector, inside a container** | `kafka:9092` |
+
+- **The capture connector's database port stays `3306` even when the host publishes `13306`.** Inside
+  the compose network there is no port remapping — `127.0.0.1` there means the connector's own
+  container, and the published port does not exist.
+- **Only the in-network values live in the compose file**; the host-facing ones live in
+  `.env.<stack-env>`. Mixing the two is the second most common wiring mistake after the broker's
+  advertised port.
+
+## The port block
+
+One offset applied to every role the project has — the components named here are the example's:
+
+| Role (example component) | Development | Test stack |
+| --- | --- | --- |
+| system of record (relational database) | `127.0.0.1:3306` | `127.0.0.1:13306` |
+| cache and job queue (Redis) | `127.0.0.1:6379` | `127.0.0.1:16379` |
+| event transport (Kafka) | `127.0.0.1:29092` | `127.0.0.1:19092` |
+| read model (search cluster) | `127.0.0.1:9200` | `127.0.0.1:19200` |
+| change propagation (Connect / capture API) | `127.0.0.1:8083` | `127.0.0.1:18083` |
+
+- **`127.0.0.1` is part of the mapping, not a comment.** `ports: ['13306:3306']` binds every
+  interface on the machine, which puts an unauthenticated database, an unauthenticated queue and an
+  unauthenticated connector-registration API on whatever network the machine is attached to. With the
+  prefix they are reachable from this machine only.
+- **No `ports:` at all for a service the host does not reach.** Container-to-container traffic uses
+  the compose network. Add a published port only when a host process — the build script, the
+  application, a developer's browser or inspection command — connects to it, and note in a comment
+  which one does.
+- **A service that advertises its own address is the exception to free remapping**: its published port
+  must equal the port it binds and advertises, because the client is redirected to that advertised
+  address after connecting. The broker is the example; a clustered queue or a replica set that names
+  its own members behaves the same way ([compose-definition.md](./compose-definition.md)).
+- **Passwords stay development-grade and never go into the repository in any other form.** A fixture
+  password committed beside a loopback-only stack is acceptable; the same value reused for anything
+  reachable is not.
+
+## A missing key reads as `null`
+
+The environment facade wraps its hash in a proxy that returns `null` for a key it does not have,
+rather than `undefined` or an error:
+
+```js
+get (target, key) {
+  if (!Reflect.has(target, key)) {
+    return null
+  }
+
+  return Reflect.get(target, key)
+}
+```
+
+So a variable the env file never defined does not fail at startup — it becomes `null` and surfaces
+much later, as a request to `null/_search`, a connection to port `null`, or a file written to a path
+built from `null`. When the environment behaves strangely, **check that every key the code path
+reads is actually present** before looking at the wiring.

--- a/kit/skills/backend/hb-build-e2e-test-environment/references/runner-and-lifecycle.md
+++ b/kit/skills/backend/hb-build-e2e-test-environment/references/runner-and-lifecycle.md
@@ -1,0 +1,330 @@
+# The runner and the environment's lifecycle
+
+The one command that builds the environment, loads it, starts everything and hands it to the
+operator — its step order, the reason each step sits where it does, and how the environment is torn
+down. Referenced from §7 and §8 of [SKILL.md](../SKILL.md). Commands are the recommended shape and
+the script names are **illustrative examples**; adapt them to your project. `<stack-env>` stands for
+the E2E stack's own environment name — `live-local` is the recommended name.
+
+> **The steps are named after roles, illustrated by one example stack.** "Create the search index"
+> means *create the read model*; "create the change-log topics" means *create the transport's
+> channels*; "register the capture connector" means *start change propagation, however your project
+> propagates*. A role the project does not have deletes its step and every step that depended on it;
+> a role the example does not name (a mail catcher, an identity stub) adds one. What does **not**
+> change is the **order** — and the reason column is why.
+
+## The interface
+
+```bash
+e2e/up.sh                 # rebuild: clean.sh, then start.sh, then seed.sh
+e2e/up.sh --start-only    # start without touching data at all (delegates to start.sh)
+
+e2e/start.sh              # bring the stack and the processes up. no data operation
+e2e/seed.sh               # load the seed set into a stack that is already up
+e2e/clean.sh              # delete the data in every store
+e2e/down.sh               # stop the processes and the stack, keep the data
+```
+
+Scripted, because the value of this environment is that **it is not assembled by hand**. Nine manual
+commands in a README become eight commands run and one forgotten, and the forgotten one is usually
+the channel creation — whose absence looks like a product bug on screen.
+
+**Each command owns one intention, and its effect on the data is fixed:**
+
+| Command | Stack | Data | Processes |
+| --- | --- | --- | --- |
+| `start.sh` | up | untouched | started |
+| `seed.sh` | must already be up | **loaded** | untouched |
+| `clean.sh` | taken down | **deleted, everywhere** | stopped first |
+| `down.sh` | down | untouched | stopped |
+| `up.sh` | rebuilt | **deleted, then loaded** | started |
+| `up.sh --start-only` | up | untouched | started |
+
+- **Nothing here inspects the data to pick a branch.** No script asks "is this already seeded", keeps
+  a record of what it did, or reasons about a state it did not create. Such a check has to define what
+  "seeded" means, store that definition somewhere outside the data it describes, and be wrong at the
+  worst possible moment — a load that died halfway looks loaded, a hand-emptied table looks fresh.
+  **The operator knows which of these five things they want.** The command they type says so.
+- **`up.sh` is a composition, not a fifth behaviour.** It is `clean.sh` → `start.sh` → `seed.sh` and
+  contains no logic of its own. Typing it *is* the request to rebuild from nothing, so it drops
+  without asking — that is what building the environment means. `--start-only` runs `start.sh` and
+  nothing else.
+- **There is no "skip the clean but still seed" mode.** Seed rows carry fixed ids, so loading the set
+  onto rows that already exist collides on insert. The two useful intentions are *rebuild* and
+  *start*, and each has a command; anything between them is a request to corrupt the set.
+- **`down.sh` is not a wipe.** Stopping and destroying are different intentions, and the operator who
+  types `down.sh` at the end of the day means the first one. `clean.sh` is the only script that
+  deletes, and deleting is all it does — not even the abort trap may call it.
+- Nothing in this lifecycle is tied to `npm run test`, which builds nothing and starts nothing.
+
+## Which script a step belongs to
+
+**A step goes in `seed.sh` if it depends on data, and in `start.sh` if it does not.** That single rule
+decides every borderline case, including the ones that look like infrastructure:
+
+- Creating the read model and creating the transport's channels are **provisioning**: they describe
+  shapes, not contents, so they belong to `start.sh` and run create-if-absent.
+- Registering change propagation belongs to **`seed.sh` when its configuration is derived from data** —
+  in the example the capture connector's table list comes from the master rows, so registering it
+  before those rows exist produces a connector watching nothing. Where the configuration is static,
+  it is provisioning and moves to `start.sh`.
+- The backfill belongs to `seed.sh`: it is the step that puts *this load's* rows into the read model.
+- Put a data-derived step in `start.sh` and `up.sh --start-only` on an empty environment fails for a
+  reason that has nothing to do with starting — exactly the confusion this skill exists to prevent.
+
+## The step order
+
+The order within each script is dependency, not preference. Every step in `start.sh` is **safe to run
+again**, so `start.sh` against a stack that is already up succeeds instead of half-failing; `seed.sh`
+is written for a single application to an empty schema and is not re-runnable, by design.
+
+### `start.sh` — the stack, the provisioning, the processes
+
+| # | Step (role) | Example | Why here |
+| --- | --- | --- | --- |
+| 1 | start every service | `docker compose -f e2e/docker/compose.yaml up -d --build` | — |
+| 2 | wait for **every** service's healthcheck | compose's own health status | a later step against a half-started service fails in a way that reads like a code bug |
+| 3 | create the **read model** if absent | create the search index | must exist before anything writes into it — equally true of a materialized view or a denormalized table. Create-if-absent, never recreate: recreating would be a deletion, and deletions belong to `clean.sh` |
+| 4 | create the **transport's channels** if absent | create the change-log topics | the transport does not auto-create, and **some channel properties (a partition count) cannot be reduced later** — so the channels must exist, in their final shape, before anything produces |
+| 5 | register **change propagation**, if its configuration is static | register a connector whose watch list is fixed | after the channels, because it produces to them. If the configuration is derived from data, this step is not here — it is in `seed.sh` |
+| 6 | start the background processes the product needs, recording their PIDs | the worker daemon and the change-log consumer | nothing propagates without them; the middleware being up is not enough. After the channels exist, or a subscriber exits on startup |
+| 7 | start the **application** (and the UI's own server, if it is served separately), recording their PIDs | `npm run start` | there is no UI to operate until this runs |
+| 8 | bring the **edge** up, once the application answers | the reverse proxy in front of the app | it has nothing to serve before then, and a proxy started first turns a slow application into a confusing 502. It holds no data, so `clean.sh` has nothing to do for it |
+| 9 | wait until the edge answers **from the host**, then **print the hand-over** and clear the abort trap | poll the published edge port | starting is finished only when someone can actually open it — and only a poll from outside proves that |
+
+Every step is idempotent, because `start.sh` runs against a stack that may already be up, may have
+just been cleaned, or may hold a full session's data. It never learns which — it does not need to.
+
+### `seed.sh` — the schema and everything that depends on it
+
+| # | Step (role) | Example | Why here |
+| --- | --- | --- | --- |
+| 1 | verify the stack is up and healthy | the same health wait | seeding against a half-started store fails in a way that reads like a code bug. `seed.sh` **starts nothing**: if the stack is down it says to run `start.sh` |
+| 2 | create the schema, with the **same collation settings as production** | create database | a different collation changes string comparison, and the environment then behaves unlike every other one |
+| 3 | apply migrations | `sequelize-cli db:migrate` | before rows exist, and it is also what lets a long-lived environment follow the code |
+| 4 | seed the **E2E master** set | `db:seed:<stack-env>-master` | the metadata is what later steps derive from: which tables are propagated, which fields are in the read model |
+| 5 | seed the **E2E fixture** set | `db:seed:<stack-env>` | after master, because fixtures reference master ids |
+| 6 | generate the binary files the seeds refer to | write stand-in files under the storage path | after seeding, because it reads the seeded rows |
+| 7 | register **change propagation** when its configuration is **derived from data** | register the capture connector, whose table list comes from the master rows | after the master seeds, or it watches nothing |
+| 8 | backfill the read model | reindex every row | propagation only carries changes made **after** it was wired up, so the rows just seeded are missing from the read model without this |
+
+**`seed.sh` is written for one application to an empty schema.** Run against a schema that already
+holds the set, it collides on the fixed ids and stops — which is the correct answer: the operator
+meant `up.sh`. Do not add `IGNORE`, upserts or existence checks to make it survive that; smoothing it
+over trades a loud, accurate failure for rows that silently differ from the set the file describes.
+
+**Step 8 has an alternative worth knowing.** Some propagation mechanisms can load the existing rows
+themselves — in the example, setting the capture's snapshot mode to *initial* instead of
+*schema-only*, so seeded rows arrive through the pipeline rather than through a backfill. Prefer
+whichever mode production runs, because an environment should exercise the path production uses; where
+that is the change-only mode, the backfill step is not optional.
+
+**The steps that move with the stack** are `start.sh` 3-5 and `seed.sh` 7-8: they exist because the
+example has a read model fed asynchronously through a transport. A product whose read path is served
+straight from the system of record drops all five, and what remains keeps its order.
+
+### `up.sh` — the composition
+
+```bash
+# e2e/up.sh — no logic of its own beyond the flag
+if [ "${1:-}" = '--start-only' ]; then
+  exec e2e/start.sh
+fi
+
+e2e/clean.sh
+e2e/start.sh
+e2e/seed.sh
+```
+
+- **Clean before start, seed after.** `clean.sh` takes the stack down, so it has to run first;
+  `seed.sh` needs the services healthy, so it has to run last. The order is forced, not chosen.
+- **Seeding after the processes are already running is deliberate.** The consumer is up while the rows
+  land, so the seeded data propagates through the real pipeline rather than only through the backfill
+  — the environment exercises the path production uses, and the backfill at the end covers whatever
+  was missed.
+- **`--start-only` delegates rather than branching.** One `exec` and no duplicated steps: the flag
+  cannot drift away from the script it stands for.
+
+## Cleaning: every store, in one command, processes first
+
+`clean.sh` exists so that deleting is something the operator *asks for*. What makes it hard is that
+the data is not in one place:
+
+| Role | What `clean.sh` has to remove | What is left behind if it is forgotten |
+| --- | --- | --- |
+| system of record | the schema and its rows | — |
+| read model | the index / view / table and its contents | screens answer with documents whose rows are gone — **deleted data on screen, which reads as a product bug** |
+| event transport | the channels, their retained messages, **and the consumer offsets** | the next run replays old change events, or the consumer resumes from an offset in a channel that was recreated |
+| change propagation | the registered connector and its stored offsets / slot / cursor | propagation resumes from a position that no longer means anything, and captures nothing |
+| cache and job queue | queued and delayed jobs | a worker starts and immediately processes jobs about rows that no longer exist |
+| object storage | the generated files | orphan files accumulate, and a re-load's stand-ins mix with the previous run's |
+- **A partial clean is worse than none.** Every row above describes a stack that starts cleanly and
+  behaves wrongly. If the script cannot reach one of these stores, it must say so rather than report
+  success.
+- **Stop the processes first.** A consumer or worker still running while the stores are emptied
+  repopulates them from the messages it is holding, and the environment ends up in a state neither
+  clean nor loaded. `clean.sh` calls the same stop the `down.sh` path uses, then deletes.
+- **Prefer dropping the volumes to emptying the stores one by one.** `docker compose down --volumes`
+  cannot half-clean: it removes every store the compose file owns in a single operation. Per-store
+  deletion through each service's API is faster on a big environment, but it is a list that has to be
+  maintained as the stack grows — and the failure mode of forgetting an entry is silent. Whatever the
+  mechanism, **anything outside the volumes still has to be removed explicitly**: the object storage
+  directory on the host, and the process logs if they would otherwise mislead the next session.
+- **Cleaning does not re-load, and does not restart.** `clean.sh` leaves nothing running and prints
+  the two ways forward: `up.sh` to come back with the seed set, `start.sh` to come back deliberately
+  empty.
+
+## Waiting on health, never on sleep
+
+```bash
+COMPOSE_FILE=e2e/docker/compose.yaml   # the scripts always name the definition explicitly
+HEALTH_ATTEMPT_LIMIT=90
+HEALTH_ATTEMPT_INTERVAL_SECONDS=2
+
+function waitForHealthy () {
+  local service=$1
+  local attempt=0
+
+  echo -n "waiting for ${service} "
+
+  # compose reports each container's own healthcheck result; this only watches it
+  until [ "$(docker compose -f "${COMPOSE_FILE}" ps --format '{{.Health}}' "${service}")" = 'healthy' ]; do
+    attempt=$((attempt + 1))
+
+    if [ "${attempt}" -gt "${HEALTH_ATTEMPT_LIMIT}" ]; then
+      echo ''
+      echo "${service} did not become healthy. try: docker compose -f ${COMPOSE_FILE} logs ${service}" >&2
+
+      exit 1
+    fi
+
+    echo -n '.'
+    sleep "${HEALTH_ATTEMPT_INTERVAL_SECONDS}"
+  done
+
+  echo ' ok'
+}
+```
+
+- **A fixed `sleep 30` is a race**: it passes on a fast machine, fails on a loaded one, and wastes
+  half a minute when everything was ready in five seconds.
+- **Failing names the next command.** The message says which service and which log to read; a script
+  that just says "timed out" makes every developer rediscover `docker compose logs`.
+- **Whichever service is slowest sets the budget** — a search or database cluster that elects itself,
+  usually. One limit generous enough for it is simpler than a per-service budget.
+
+## The application and the background processes are part of the environment
+
+Whatever processes actually move data — the worker daemon and the change-log consumer in the example,
+an outbox poller or a scheduler elsewhere — plus the application itself, which is what there is to
+operate. Start all of them from the script and own their lifetime:
+
+```bash
+# the script names are the example's; the shape — one line per process, PID appended — is the point
+mkdir -p "${LOG_DIR}"
+
+NODE_ENV=<stack-env> npm run job:daemon > "${LOG_DIR}/daemon.log" 2>&1 &
+echo $! >> "${PID_FILE}"
+
+NODE_ENV=<stack-env> npm run cdc:consumer > "${LOG_DIR}/consumer.log" 2>&1 &
+echo $! >> "${PID_FILE}"
+
+NODE_ENV=<stack-env> npm run start > "${LOG_DIR}/app.log" 2>&1 &
+echo $! >> "${PID_FILE}"
+```
+
+- **Record the PIDs in a file, not just a shell variable.** `down.sh` is a different process from
+  `up.sh` and has no other way to find them; a PID file under `e2e/` (git-ignored) is what connects
+  the two.
+- **Wait until each is actually working, not merely launched.** Poll for the readiness signal each one
+  prints, or for its effect — a consumer group registered on the broker, the application answering on
+  its port. A process that has started is not yet a process that has joined the group.
+- **Capture their output to files.** When something does not appear on screen, the answer is in one of
+  these logs; a build that discarded them forces a rebuild to find out why.
+- **A subscriber cannot start before the channel it subscribes to exists** — in the example the
+  consumer exits complaining that the broker does not host the topic-partition. If `start.sh` step 4
+  was skipped, this is where it shows up, whatever the transport is.
+
+## Hand over at the end
+
+The last thing `start.sh` prints — and therefore the last thing `up.sh` prints — is what the
+operator needs to start:
+
+```bash
+cat <<EOF
+
+  the environment is up.
+
+    open        ${APP_BASE_URL}
+    logs        ${LOG_DIR}/{app,daemon,consumer}.log
+    seed        e2e/seed.sh                  # loads the set into an empty schema
+    stop        e2e/down.sh                  # keeps the data
+    wipe        e2e/clean.sh                 # deletes it, everywhere
+
+EOF
+```
+
+- **An environment nobody can find their way into is not finished.** The URL, the logs and the exits
+  are the minimum; add whatever else a first-time operator would otherwise have to ask someone for.
+- **Print the exits side by side, labelled by consequence.** `down.sh` and `clean.sh` differ only in
+  whether the afternoon's work survives; a hand-over that lists one command called "tear down" invites
+  the wrong one.
+- **`start.sh` does not know whether there is data**, and does not try to find out — so it lists
+  `seed.sh` as an available action rather than reporting a state. An operator looking at empty screens
+  has the command right in front of them.
+- **Say where the sign-in accounts come from** — they are seed rows ([seed-data.md](./seed-data.md)),
+  so the hand-over only has to point at them, not restate them.
+
+## Abort on failure, stay up on success
+
+```bash
+set -euo pipefail
+
+function abort () {
+  # only reached when start.sh did not complete.
+  # stop what was started — never clean: deleting data is not this script's decision to make.
+  e2e/down.sh
+}
+
+trap abort EXIT
+
+# ... the start.sh steps ...
+
+printHandover
+
+trap - EXIT   # it succeeded: leave everything running
+```
+
+- **Trap while starting, clear the trap at the end.** A run that died at the provisioning step must
+  not leave containers and Node processes behind for the next attempt to inherit — but a run that
+  succeeded must leave exactly that, because that is the result.
+- **The abort path stops; it does not wipe.** A failed run that also deleted the data would turn a
+  recoverable problem into a lost afternoon. If `seed.sh` is what failed, the schema is left
+  half-loaded and the operator is told so — `clean.sh` then `up.sh` is the way out, and it is their
+  call, not the script's.
+- **Without `-e`, a failed seeding step is followed by a hand-over of a half-loaded environment**, and
+  the operator discovers it screen by screen. Without `pipefail` a failure inside a pipeline is hidden
+  by the success of the last command.
+- **`down.sh` stops the processes before the containers.** A worker whose queue vanished spends its
+  shutdown retrying a connection and produces a page of noise around the real failure.
+- **`down.sh` keeps the volumes; `clean.sh` is what drops them.** That is what makes `start.sh` after
+  a `down.sh` return the operator to the environment they left. `clean.sh` is also the answer when a
+  container-level thing (the database's init directory, the broker's stored connector config) needs
+  rebuilding, because those only re-run on volume creation.
+- **Read connection values out of the env file** rather than restating them in the scripts: two places
+  saying different things is how a setup script rots. Read the key, fall back to a documented default.
+
+## The CI stance
+
+**This is a developer's environment, not a pull-request check.** A stack of containers, an image build
+and a real propagation wait turn a two-minute check into a long one, and the failure modes (a slow
+runner, an image registry hiccup) are not about the code.
+
+- Keep the fast check exactly as it is: the unit suite on the local file database. Nothing in `e2e/`
+  is discovered by it, so this environment cannot slow that workflow down or make it need Docker.
+- If a scheduled job is wanted, let it run **`clean.sh`, `up.sh`, then `down.sh`** in a workflow of its
+  own — the signal is "the environment still builds *from nothing*", which is worth having daily, not
+  hourly. CI is the one place that should always start clean, because there is no operator's state to
+  protect there.
+- CI runs the same scripts. That is the point of having them: the environment CI builds is the
+  environment a developer builds.

--- a/kit/skills/backend/hb-build-e2e-test-environment/references/seed-data.md
+++ b/kit/skills/backend/hb-build-e2e-test-environment/references/seed-data.md
@@ -1,0 +1,145 @@
+# Seed data for the E2E environment
+
+The two seeder directories the E2E stack owns, why they are separate from the unit-test fixtures, how
+their ids are allocated, and the artifacts a seeder cannot carry. Referenced from §6 of
+[SKILL.md](../SKILL.md). `<stack-env>` stands for the E2E stack's own environment name —
+`live-local` is the recommended name, giving `live-local-master/` and `live-local/`; ids,
+directory names and values are **illustrative examples**.
+
+> Everything here is about the **system of record's rows** and is the least stack-dependent part of the
+> skill: the tooling shown is Sequelize's CLI and the read model is a search index, but the rules
+> below hold for any store and any seeding tool.
+
+## Two directories of its own
+
+| Directory | Holds | Applied by | Corresponds to |
+| --- | --- | --- | --- |
+| `sequelize/seeders/<stack-env>-master/` | the master / metadata rows the stack requires to run, **re-exported** from the production master, plus E2E-only master samples | `db:seed:<stack-env>-master` | the dev-master set |
+| `sequelize/seeders/<stack-env>/` | the operational rows the environment is filled with, including the accounts the operator signs in with | `db:seed:<stack-env>` | the development set |
+
+```json
+{
+  "db:seed:<stack-env>-master": "export NODE_ENV=<stack-env>; sequelize-cli db:seed:all --seeders-path sequelize/seeders/<stack-env>-master --debug",
+  "db:seed:<stack-env>": "export NODE_ENV=<stack-env>; sequelize-cli db:seed:all --seeders-path sequelize/seeders/<stack-env> --debug"
+}
+```
+
+- **The master directory is named `<stack-env>-master`, never `master-<stack-env>`.** In the
+  project's seeder convention, `master-*` is the release-split **production** master namespace
+  (`master-000001/`, `master-000002/`, …), applied in ascending order by `db:seed:prod` — a
+  directory named into that pattern gets classified as a production release, and can be picked up by
+  the production seed run. The suffix form keeps the environment name first, pairing
+  `<stack-env>-master/` with `<stack-env>/` the way `dev-master/` pairs with `development/`.
+- **Write seeders for a single application to an empty schema.** Every row carries an explicit id,
+  so applying the set to a database that already holds it collides on insert — and that collision is
+  the intended behaviour, not a gap to close. It is the environment saying *you meant `up.sh`*,
+  which cleans first. Adding upserts, `IGNORE` or existence checks to make the set survive a second
+  application gains nothing and gives up the guarantee that the rows in the database are the rows in
+  the file ([runner-and-lifecycle.md](./runner-and-lifecycle.md)).
+- The environment name is set inside the script, so forgetting an export cannot apply the seeders to
+  the wrong database.
+- The directory is chosen by `--seeders-path`, exactly as the existing seed sets do; the seeder file
+  format stays the same (skeleton, `TimestampSeedsSupplier`, explicit ids, `up`/`down` — follow the
+  project's seeder convention).
+- **A file skeleton stays identical to every other seeder.** Only the *directory* says which
+  environment the rows are for.
+
+## Why not reuse the unit-test fixtures
+
+The two sets are used by tools that need opposite shapes:
+
+| | unit-test fixtures | E2E rows |
+| --- | --- | --- |
+| shape | exhaustive — every status, every branch, every null | minimal and **pipeline-shaped**: a few rows that will actually flow end to end |
+| size | as large as coverage needs | as small as possible; every row becomes an entry in the read model and a change to propagate |
+| churn | edited whenever a unit test needs a new case | edited only when the pipeline's shape changes |
+
+Sharing one set couples them: a row added to satisfy a validator's edge case becomes another document
+in the index and another line on a screen; a row reshaped for the pipeline breaks a unit test in a
+different directory. **Separate directories make it obvious what a change can break** — and the split
+is the reason the E2E build never applies the development set.
+
+## Master rows are re-exported, never copied
+
+Some master ids end up **inside a derived artifact** — an id written into a read-model entry (a search
+document in the example), a key a mapping or a view definition is built from. If those ids differ
+between environments, a read model built in one environment cannot be read or compared in another, and
+rebuilding it silently produces entries that do not match the metadata.
+
+So the stack's master set **references** the production master rather than restating it:
+
+```js
+'use strict'
+
+/*
+ * Re-export of the production master (the source of truth is
+ * sequelize/seeders/<production-master-dir>/<same-name>.cjs).
+ * The stack environment must load exactly the production master rows, so the data is
+ * referenced, never copied.
+ */
+
+module.exports = require('../<production-master-dir>/<same-name>.cjs')
+```
+
+- **Keep the filename identical** to the file being re-exported, so the two are obviously a pair and
+  the run order matches.
+- **Copy-paste is the failure mode this prevents.** A copied master file diverges the first time a
+  column is added to only one of them, and the symptom appears as a search result missing a field —
+  nowhere near the seeder.
+- **Stack-only master samples** (rows production creates through an admin screen rather than seeding)
+  belong here too, as their own files with their own ids.
+
+## Ids come from a reserved band
+
+Follow the project's existing id rule — every row carries an **explicit** id, blocks are 10,000 wide
+— but allocate the stack's blocks from a **band of their own**, starting above every block the other
+seed sets already occupy:
+
+| Seed set | Id band | Example bases |
+| --- | --- | --- |
+| unit-test fixtures (the project's ordinary set) | the blocks the project's seeder convention already allocates | `100000`, `110000`, `120000`, … |
+| **E2E fixtures (`<stack-env>/`)** | **a band of their own, above all of those** | `800000`, `810000`, `820000`, … |
+| E2E master samples (`<stack-env>-master/`) | the same band, above their parent's block | |
+
+- **A row's origin is then readable from its id.** An id from the E2E band, seen on a screen or in a
+  log, says immediately which seed set put it there — worth a lot when the same table is filled by
+  two sets in two environments.
+- **The two sets cannot collide on primary key** even if both are somehow applied to one database, so
+  the mistake surfaces as unexpected *rows* rather than as an insert failure halfway through.
+- **Foreign-key columns still hold an id from the referenced table's block**, and the band applies to
+  the referenced block too — an E2E row points at E2E rows, not at unit-test rows.
+- Re-exported production master files keep the **production** ids (small and meaningful). The band
+  applies only to rows this set introduces.
+
+## Seeds insert rows, not files
+
+A seeder cannot carry a binary: committing one means maintaining it, and the real assets often
+cannot be committed at all. So the rows say a file is present — a status, a size, a page or item
+count — while the bytes are not on disk, and every request for the file answers 404.
+
+A screen that opens such a record then breaks for a reason that has nothing to do with the code.
+**The build therefore has a step that generates the artifacts the seeds promise**, after seeding and
+before the environment is handed over:
+
+- Generate from the rows, so the two always match — read the seeded records and write a stand-in for
+  each.
+- **Write only what the application actually serves** (the derived artifacts the screens or the API
+  hand back). There is no original file for it to reproduce.
+- **Make the stand-in obviously synthetic** — a placeholder that is unmistakable at a glance — so
+  nobody takes a fixture for real data on a screen.
+- **Write it under the per-run storage path** (`FILE_STORAGE_PATH` is overridden for the run), not
+  into the working tree.
+- **Safe to run again**: rewrite every file from scratch rather than skipping existing ones.
+
+## Keep the set pipeline-shaped
+
+A row earns its place here by covering a **path**, not a branch. When adding rows, prefer:
+
+- **One complete chain** over many partial ones — a record that has everything the pipeline needs to
+  produce a read-model entry, so a single row exercises the whole path.
+- **Rows that make propagation visible** — distinct, recognizable text, so it is obvious at a glance
+  whether something arrived rather than something being counted.
+- **A deliberate negative** — one record that must *not* reach the read model (unsynced column,
+  excluded category), so the filter's effect is visible too. Without one, propagating everything
+  looks exactly like the filter working.
+- **Nothing added just because a unit test wanted it.** That row belongs in the other set.

--- a/kit/skills/backend/hb-build-e2e-test-environment/references/windows-runner.md
+++ b/kit/skills/backend/hb-build-e2e-test-environment/references/windows-runner.md
@@ -1,0 +1,146 @@
+# Running the environment from Windows
+
+**Opt-in. Read this only if someone has actually asked for Windows-native scripts.** The default is
+Ubuntu or WSL2, the `.sh` scripts are the real ones, and you need none of this to build the
+environment. Referenced from the machine assumptions in [SKILL.md](../SKILL.md).
+
+## Why there is a default at all
+
+Two sets of scripts means making every change twice. Sooner or later one of them gets missed. It
+fails like this: *"the environment comes up ninety percent of the way, but only on Windows"* — which
+is exactly what this skill exists to prevent. So write the second set only when someone has decided
+they need it, and let them carry the cost.
+
+**First, look for a way to avoid it.** Anything you move into a container stops depending on the OS.
+`docker compose` behaves the same everywhere. Only the host-side scripts differ. A stack in shape A
+— client, edge and application all in containers
+([edge-and-proxy.md](./edge-and-proxy.md)) — barely needs host-side scripts at all. That is the real
+fix.
+
+## What differs per machine
+
+| | Linux / WSL2 | macOS | Plain Windows |
+| --- | --- | --- | --- |
+| bash | 4 or later | **3.2** — no `declare -A`, `mapfile`, `${x,,}` | none |
+| core tools | GNU | **BSD** — `sed -i` needs an argument, and there is no `timeout`, `date -d` or `grep -P` | none |
+| memory ceiling | the machine's | the Docker VM's share | the WSL2 VM's share, **half the machine by default** |
+| bind-mount speed | native | slower, through VirtioFS | very slow under `/mnt/c`. Keep the repository on the Linux side |
+| line endings | LF | LF | CRLF sneaks in through `core.autocrlf` |
+| `/etc/hosts` | stays as you left it | stays as you left it | WSL2 rewrites it by default |
+
+The macOS column is why the scripts target bash 3.2 with no GNU-only options, even though nobody
+chooses 3.2 on purpose.
+
+## Why plain Windows cannot run the `.sh` scripts
+
+**The problem is the host-side scripts, not the stack.** Everything compose starts behaves the same
+on every OS. The five scripts are what will not run: `up`, `start`, `seed`, `clean` and `down`.
+
+| What they use | For | On plain Windows |
+| --- | --- | --- |
+| shell syntax | `set -euo pipefail`, `trap ... EXIT`, `[[ ]]` | no bash. PowerShell has close equivalents, so this is a rewrite, not a port |
+| background start, and the PID | starting the application and daemons, saving PIDs, stopping them in `down.sh` | `Start-Process` and `Stop-Process` work, but **Windows has no SIGTERM**. You can only force a kill |
+| `trap ... EXIT` | making sure a failed build leaves nothing half-built | `try/finally` is close, but does not cover as much as `EXIT` |
+| host commands | `curl` to wait for health, `grep` / `sed` / `awk` for logs | `curl.exe` exists. `wget` is an alias for `Invoke-WebRequest` with different arguments. The rest are missing |
+| file modes | config permissions, the executable bit | NTFS has neither, and `chmod` does nothing |
+| line endings | scripts, and configs mounted into containers | CRLF shows up inside the container as `bash\r: bad interpreter` |
+
+**The second row is the one you cannot write your way around.** `down.sh` stops the processes before
+the containers, and that only helps if the stop is graceful. Where you can only force a kill, a
+worker dies holding its connections and the ordering buys you nothing. Say so, rather than letting
+it look the same.
+
+**Git Bash mostly works, and fails quietly.** MSYS rewrites paths on their way to `docker` (turn it
+off with `MSYS_NO_PATHCONV=1`), and processes and signals are still Windows'. Worth knowing about.
+Not a setup to support.
+
+## What to require, if you do write them
+
+- **PowerShell 7 or later.** Windows PowerShell 5.1 handles `Invoke-WebRequest` and errors
+  differently, so it is out of scope. Say this at the top of every script.
+- **The operator's commands do not change.** `up.ps1`, `start.ps1`, `seed.ps1`, `clean.ps1` and
+  `down.ps1` — same names, same jobs, same closing message as the `.sh` scripts. One intention, one
+  command, on either OS.
+- **The `.sh` scripts stay the real ones.** Add a step there, then mirror it in the `.ps1` scripts
+  **in the same change**. Never one without the other.
+- **Write down the differences you cannot remove**, at the top of the script and in the closing
+  message. Never let it behave differently in silence.
+- **Ship nothing you have not run.** Record which Windows build and which PowerShell version you
+  tested on. A script nobody has run is not finished — the same rule as checking from the side that
+  uses it.
+
+## The same job, in each shell
+
+| Job | POSIX (the real one) | PowerShell 7 |
+| --- | --- | --- |
+| stop on the first failure | `set -e` | `$ErrorActionPreference = 'Stop'`, plus checking `$LASTEXITCODE` after **every** native command |
+| fail when a pipe fails | `set -o pipefail` | **nothing equivalent.** Split the pipeline into steps and check `$LASTEXITCODE` at each one |
+| clean up on abort | `trap ... EXIT` | `try { } finally { }` |
+| start in the background, keep the PID | `cmd >log 2>&1 & echo $!` | `Start-Process -PassThru -RedirectStandardOutput -RedirectStandardError`, then `$p.Id`. **The two streams cannot go to one file**, so keep two logs per process |
+| stop a process | `kill` (SIGTERM) | `Stop-Process` (forced). For a graceful stop, give the application its own signal — a file, an endpoint, a queue message |
+| wait for health | `curl` in a loop | `Invoke-WebRequest -UseBasicParsing` in a loop, catching connection failures with `try/catch` |
+| measure a deadline | count elapsed seconds | `[Diagnostics.Stopwatch]` |
+| find the script's folder | a path relative to the script | `$PSScriptRoot` |
+
+## What one script looks like
+
+```powershell
+#Requires -Version 7.0
+# The real version is start.sh. Change both in the same commit.
+# Difference we cannot remove: stop is a forced kill, because Windows has no SIGTERM.
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$root = Split-Path -Parent $PSScriptRoot
+$logs = Join-Path $PSScriptRoot 'logs'
+New-Item -ItemType Directory -Force -Path $logs | Out-Null
+
+try {
+  docker compose -f (Join-Path $PSScriptRoot 'docker/compose.yaml') up -d
+  if ($LASTEXITCODE -ne 0) { throw 'compose up failed' }
+
+  # wait for health from the host — the side that will use it
+  $deadline = [Diagnostics.Stopwatch]::StartNew()
+  while ($true) {
+    try {
+      Invoke-WebRequest -UseBasicParsing 'http://127.0.0.1:18080/healthz' | Out-Null
+      break
+    } catch {
+      if ($deadline.Elapsed.TotalSeconds -gt 120) {
+        throw 'the edge never answered. docker compose logs edge'
+      }
+      Start-Sleep -Seconds 2
+    }
+  }
+
+  $app = Start-Process -PassThru -FilePath 'node' -ArgumentList 'server/index.js' `
+    -RedirectStandardOutput (Join-Path $logs 'app.out.log') `
+    -RedirectStandardError  (Join-Path $logs 'app.err.log')
+  $app.Id | Set-Content (Join-Path $logs 'app.pid')
+}
+catch {
+  & (Join-Path $PSScriptRoot 'down.ps1')   # never clean.ps1
+  throw
+}
+
+Write-Host "open http://127.0.0.1:18080/  |  logs: e2e/logs  |  stop: e2e/down.ps1"
+```
+
+Notice the two log files for one process, the deadline measured with a stopwatch, the health check
+made from the host, and the abort path calling `down`, never `clean`. Those are the same rules the
+`.sh` scripts follow.
+
+## Recording what you tested
+
+Keep this next to the scripts, and update it whenever they change:
+
+```
+Verified on: Windows 11 23H2 / PowerShell 7.4.6 / Docker Desktop 29.5.2
+Date:        2026-08-22
+Scope:       up / start / seed / clean / down, full rebuild from nothing
+Not covered: graceful shutdown — Stop-Process is a forced kill
+```
+
+A note with no version and no date is not a record. If nobody can say which build it ran on, it has
+not been tested.

--- a/kit/skills/backend/hb-constant-definition/SKILL.md
+++ b/kit/skills/backend/hb-constant-definition/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: hb-constant-definition
+description: >
+  Define application constants the Renchan way: one constant (one category) per file, ALWAYS as
+  two files — a CommonJS master constants/<name>.cjs (the single source of truth) plus an ESM
+  bridge app/constants/<name>.js that re-exports it. Use this skill whenever the user asks to add
+  or change a constant — an enum-like value set, a status/category hash, or a master-data id/name
+  table.
+---
+
+# Constant Definition
+
+A skill for defining **application constants**. There is **one rule and no case-by-case judgment**:
+every constant is defined as **two files** — a CommonJS **master** and an ESM **bridge**. Deciding
+per-constant whether a seeder will ever need it is error-prone, so you skip that decision and always
+provide both.
+
+> This skill states a **general, project-independent rule** — a refined best practice, not a
+> description of any one project's current code, so it need not match a given repo's existing
+> notation. The directory and value names in it (`constants/`, `app/constants/`, `memberRankConstants`,
+> …) are **illustrative fakes**; use your project's own names. The two-file rule exists because
+> application code is **ESM** (`import` / `export`) while seeders are **CommonJS** (`.cjs`, loaded with
+> `require`), so a shared constant must be readable from both.
+
+## Grand principle: one category per file, always defined as a `.cjs` master + a `.js` bridge
+
+A constant file holds **exactly one category** of values (one hash / one set). For every constant you
+create **both** of these, with the **same base name**:
+
+| File | Module system | Role |
+| --- | --- | --- |
+| `constants/<name>.cjs` (repo root) | CommonJS | **Master — the single source of truth.** The actual values. |
+| `app/constants/<name>.js` | ESM | **Bridge — a pure re-export** of the `.cjs` via the custom `require`. |
+
+- **Why always both (no per-constant decision).** Master data — ids + names that both **seed rows**
+  and **app logic** must agree on — is one source of truth read from two module systems: seeders
+  `require` the `.cjs` directly; ESM app code reaches it through the bridge. Predicting up front which
+  constants a seeder will *eventually* need is tricky and gets it wrong, so define the pair every
+  time. The cost is one trivial six-line bridge; the payoff is any consumer can read any constant.
+- **The `.cjs` is the only copy of the values.** The `.js` bridge never restates them — it just
+  crosses the module boundary. Two hand-maintained copies drift; keep exactly one.
+- **Why one category per file.** A category maps to a predictable file name. This mirrors the
+  "one file, one class" and "vertical over horizontal" principles — a grab-bag `constants.js` forces
+  every reader to scan an unrelated pile.
+
+**Comment language**: the `js` examples here use English comments. In the constant files you
+generate, keep structural comments in English and write any domain notes in whatever language the
+project uses for domain prose — match the surrounding files.
+
+## 1. Where the two files live
+
+| Directory | Module system | Holds |
+| --- | --- | --- |
+| `constants/` (repo root) | CommonJS (`.cjs`) | The **master** — the file seeders `require` directly. |
+| `app/constants/` | ESM (`.js`) | The **bridge** — the file app code imports. |
+
+- **App code always imports the bridge**: `import MEMBER_RANK_CONSTANT_HASH from '../constants/memberRankConstants.js'`. App code never reaches into the root `constants/*.cjs` itself.
+- **Seeders always `require` the master**: `require('../../../constants/memberRankConstants.cjs')` — because seeders are written in CommonJS.
+
+## 2. The `.cjs` master (source of truth)
+
+`'use strict'` + `module.exports = { ... }`, a single SCREAMING_SNAKE category. This is the file the
+values actually live in.
+
+```js
+// Good: constants/memberRankConstants.cjs — the single source of truth (CommonJS)
+'use strict'
+
+module.exports = {
+  MEMBER_RANK: {
+    BRONZE: {
+      ID: 1,
+      NAME: 'Bronze',
+      IS_ACTIVE: true,
+      DISPLAY_ORDER: 10,
+    },
+    SILVER: {
+      ID: 2,
+      NAME: 'Silver',
+      IS_ACTIVE: true,
+      DISPLAY_ORDER: 20,
+    },
+    // ...
+  },
+}
+```
+
+## 3. The `.js` bridge
+
+Import the custom `require` from the project's globals module, `require` the sibling `.cjs`, and
+`export default` it. **Same base name** as the `.cjs`. This is the whole file — never more:
+
+```js
+// Good: app/constants/memberRankConstants.js — thin ESM bridge over the .cjs master
+import {
+  require,
+} from '../globals/_.js'
+
+const MEMBER_RANK_CONSTANT_HASH = require('../../constants/memberRankConstants.cjs')
+
+export default MEMBER_RANK_CONSTANT_HASH
+```
+
+- **`require` here is the custom one** — `createRequire(import.meta.url)`, re-exported from the
+  project's globals module (here `../globals/_.js`). It lets an ESM file load a `.cjs`; there is no
+  native `require` in ESM.
+- The bridge is a **pure re-export** — no reshaping, no merging, no extra keys. If you find yourself
+  transforming the value in the bridge, that logic belongs elsewhere.
+- The two consumers then read the **one** source:
+
+```js
+// seeder (.cjs) — requires the master directly
+const { MEMBER_RANK } = require('../../../constants/memberRankConstants.cjs')
+
+// app (ESM) — imports the bridge
+import MEMBER_RANK_CONSTANT_HASH from '../constants/memberRankConstants.js'
+```
+
+```js
+// Avoid: stopping at an ESM-only definition (no .cjs master)
+export default { MEMBER_RANK: { /* ... */ } } // a seeder (.cjs) cannot import this; always add the .cjs master
+```
+
+## 4. Naming
+
+- **File**: camelCase, named after the category (`memberRankConstants`, `userPermission`). The `.cjs`
+  master and its `.js` bridge share the **same base name**.
+- **Exported constant**: `SCREAMING_SNAKE_CASE` (`MEMBER_RANK_CONSTANT_HASH`, `USER_PERMISSION`). A
+  `_HASH` / `_CONSTANTS` suffix is common for a lookup hash but not mandatory — name it for the
+  category, not the type, and follow the Renchan naming rules (no forbidden suffixes such as
+  `info` / `data` / `list`).
+- **One category per file** — if tempted to add a second, unrelated set, make another pair of files.
+
+## Finishing checklist
+
+- [ ] **Both files exist** with the same base name: `constants/<name>.cjs` (master) **and** `app/constants/<name>.js` (bridge).
+- [ ] The values live **only** in the `.cjs`; the `.js` is a pure re-export via the custom `require` (no reshaping, no duplication) ([§3](#3-the-js-bridge)).
+- [ ] The file holds **one category**, exported SCREAMING_SNAKE (default export).
+- [ ] App code imports the `.js`; seeders `require` the `.cjs` ([§1](#1-where-the-two-files-live)).

--- a/kit/skills/backend/hb-cookie-authentication/SKILL.md
+++ b/kit/skills/backend/hb-cookie-authentication/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: hb-cookie-authentication
+description: "Cookie-based authentication for a renchan backend, per actor: the credential and token models (password hash, access + rotating refresh tokens with reuse detection), the refresh-token HttpOnly cookie, the signIn / signUp / signOut / renewAccessToken resolvers, and the engine's public-operation policy. Use when adding cookie auth to an actor/role. Boundary: models, migrations and seeders follow their own conventions; this replaces the older access-token-only flow."
+metadata:
+  author: OpenReachTech
+  version: "2026.08.18"
+---
+
+# Cookie Authentication (Backend)
+
+Use this skill when adding cookie-based authentication to a renchan backend — storing an actor's credential and tokens, the sign-in / sign-out / renew operations, the refresh-token cookie, and deciding which operations are public.
+
+An authenticated actor (a role such as `user`, `customer`, `admin`, or `tenant`) keeps its password as a hash and authenticates with two tokens: a short-lived **access token** the client sends as a header, and a long-lived **refresh token** kept in the DB and handed to the browser as an **HttpOnly cookie**. `signIn` issues both; `renewAccessToken` reads the cookie, rotates the refresh token (detecting reuse of a retired one), and returns a fresh access token; `signOut` revokes the series and clears the cookie. Only `renewAccessToken` and `signOut` authenticate by the cookie — every other operation authenticates by the access-token header.
+
+You build this **per actor**, on top of the boilerplate's base classes — it is not shipped in the boilerplate; each app builds it for the actors its spec declares. Design the actor entity and its profile first with [[hb-database-design]] / [[hb-sequelize-model]]; this skill adds the credential, tokens, operations, and cookie to it. It says what the auth cluster contains and how the pieces fit — writing each piece follows its own convention ([[hb-sequelize-model]], [[hb-sequelize-seeder]], [[hb-mutation-resolver]], [[hb-type-interface]]), and the engine is [[hb-graphql-server-engine]].
+
+> **This replaces the older access-token-only flow.** In the old flow the access token was the durable credential — stored on the client and sent on every request, with no refresh cookie. Here the access token is short-lived and held only in memory on the client; durability comes from the refresh cookie. Do not mix the two: when this skill applies, there is no long-lived access token. The frontend half is [[hf-cookie-authentication]].
+
+> Snippets throughout use `<Actor>` for the role being authenticated — substitute your own (`Member`, `Operator`, `Account`, …). Not every app has a "customer"; the reference implementation these snippets are drawn from happens to use `Customer` and `Admin`.
+
+## Core
+
+| Topic | Description | Reference |
+| --- | --- | --- |
+| Environment & config | Step-by-step setup: the `cookie` dependency, the `AUTH_*` env vars + facade, the per-actor cookie-name constant, and the engine's refresh-token cookie config | [environment](references/environment.md) |
+| Token & credential models | Per actor: the password-hash model and the access / refresh token models, with `sessionKey` rotation columns and the backup mixin | [token-models](references/token-models.md) |
+| Migrations | The create-table migrations for the credential and token tables | [migrations](references/migrations.md) |
+| Session clerk | `SessionClerk` — the injected orchestrator over the token tables (`saveSession` / `rotateSession` / `revokeSession` / `findRefreshToken`), returning throwable-save result objects | [session-clerk](references/session-clerk.md) |
+| Refresh-token cookie | The HttpOnly cookie clerk and reading / setting the cookie in the GraphQL context | [cookie-context](references/cookie-context.md) |
+| Auth resolvers | `signIn` / `signUp` / `signOut` / `renewAccessToken` — token issue, rotation, and reuse detection | [resolvers](references/resolvers.md) |
+| Auth-filter policy | `schemasToSkipFiltering` + `generateFilterHandler` — which operations are public (cookie) vs header-guarded | [auth-filter](references/auth-filter.md) |
+| Error codes | The `Unauthenticated` and `RefreshTokenReused` codes and where they are thrown | [error-codes](references/error-codes.md) |
+| Dev-login seeder | A development seeder so `npm run dev` can sign in against real data | [dev-login-seeder](references/dev-login-seeder.md) |

--- a/kit/skills/backend/hb-cookie-authentication/references/auth-filter.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/auth-filter.md
@@ -1,0 +1,55 @@
+# Auth-filter policy
+
+The engine decides which operations are public and how the rest authenticate. Set this on the audience's `*GraphqlServerEngine` ([[hb-graphql-server-engine]]).
+
+## Public operations
+
+The auth operations skip the header filter. `renewAccessToken` runs when the access token is already expired, so it cannot require the header; `signIn` / `signUp` authenticate by credentials; `signOut` and `renewAccessToken` authenticate by the refresh **cookie** inside the resolver ([cookie-context](./cookie-context.md)).
+
+```js
+get schemasToSkipFiltering () {
+  return [
+    'signUp',
+    'signIn',
+    'renewAccessToken',
+    'signOut',
+
+    'healthCheck', // fully public
+  ]
+}
+```
+
+## Everything else — the access-token header
+
+Every operation not on that list goes through the filter, which authenticates by the `x-renchan-access-token` header. The context resolves the actor from the header token; the filter then checks the visas:
+
+```js
+generateFilterHandler () {
+  return async ({ information, context }) => {
+    const schema = information.fieldName
+
+    if (context.canResolve({ schema })) {
+      return // a skip-list operation
+    }
+
+    if (!context.hasAuthenticated()) {
+      throw this.errorHash.Unauthenticated.create()
+    }
+
+    if (!context.hasAuthorized()) {
+      throw this.errorHash.Unauthorized.create()
+    }
+
+    // ... schema-permission check ...
+  }
+}
+```
+
+## Resolving the actor from the header
+
+The context turns the header access token into the actor entity, and the visa issuers read that:
+
+- `Context.findUser({ accessToken, ... })` — look the access token up and return the actor entity (or `null`).
+- `visaIssuers.hasAuthenticated` — `userEntity !== null`.
+
+So the access token is only ever a header credential; the refresh token is only ever a cookie credential, and only for the two skip-listed operations.

--- a/kit/skills/backend/hb-cookie-authentication/references/cookie-context.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/cookie-context.md
@@ -1,0 +1,53 @@
+# Refresh-token cookie
+
+The refresh token reaches the browser only as an `HttpOnly` cookie, so no page script can read it. All cookie logic lives in `RefreshTokenExpressCookieClerk` (`server/graphql/contexts/tools/`), not on the context — the context stays a plain DTO. A session resolver builds a clerk from the `context` it receives in `resolve()`; every other resolver never touches it.
+
+```js
+const cookieClerk = RefreshTokenExpressCookieClerk.create({ context })
+
+cookieClerk.saveRefreshTokenCookie({ refreshToken }) // sign-in / renew
+cookieClerk.clearRefreshTokenCookie()                // sign-out, or not-found
+const presented = cookieClerk.extractRefreshToken()  // renew / sign-out only
+```
+
+## Config comes from the engine
+
+Cookie name, lifetime, `secure`, `sameSite`, `httpOnly` are read from the engine config the context carries, so they change in one place — the engine. The path is the engine's GraphQL endpoint, so the cookie stays off every other route.
+
+```js
+get refreshTokenCookieConfig () {
+  return this.context.config.refreshTokenCookie
+}
+
+get refreshTokenCookiePath () {
+  return this.context.config.graphqlEndpoint // cookie scoped to this endpoint only
+}
+```
+
+The engine supplies that config per audience — the cookie name differs per actor ([auth-filter](./auth-filter.md) for where it is set):
+
+```js
+static buildRefreshTokenCookieConfig () {
+  return {
+    ...this.refreshTokenCookieConfig,
+    name: REFRESH_TOKEN_COOKIE.<ACTOR>.NAME,
+  }
+}
+```
+
+## Clearing must match the write
+
+Clearing presents the same attributes as the write, minus the lifetime. The write uses the attributes plus `maxAge`; clearing uses the attributes alone. A mismatch leaves the browser holding the original cookie, and the session appears to survive sign-out.
+
+```js
+buildRefreshTokenCookieOptionHash () {
+  return {
+    ...this.buildRefreshTokenCookieAttributeHash(), // httpOnly, secure, sameSite, path
+    maxAge: this.refreshTokenMaxAgeMilliseconds,
+  }
+}
+```
+
+## Reading is not authenticating
+
+`extractRefreshToken()` only reads the value. **Only `renewAccessToken` and `signOut` may treat it as a credential** — every other operation authenticates by the access-token header ([auth-filter](./auth-filter.md)).

--- a/kit/skills/backend/hb-cookie-authentication/references/dev-login-seeder.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/dev-login-seeder.md
@@ -1,0 +1,22 @@
+# Dev-login seeder
+
+Removing the sample actor domain also removes the seeder that let `npm run dev` sign in. An app that adds cookie auth needs a **development** seeder (the `development/` directory, not `master/`) that inserts at least one actor with a known password, so a developer — and the E2E sign-in flow — can log in. Write it with [[hb-sequelize-seeder]] for the mechanics (directory choice, id-block numbering, `TimestampSeedsSupplier`).
+
+For one actor, the seeder inserts the whole credential cluster ([token-models](./token-models.md)):
+
+- the entity row (`<actor>s`),
+- its secret row (`<actor>_secrets`) with the sign-in `email`,
+- its password-hash row (`<actor>_password_hashes`).
+
+The stored `password_hash` **must be produced by the same enciphering `verifiesPassword` compares against** — insert a pre-hashed digest of a known dev password, not the plaintext, or the login never matches.
+
+```js
+// pseudo — one dev <actor> whose password is a known, obviously-fake dev value
+// password_hash = <digest of 'password-dev-0001' via the project's Encipher>
+// bulkInsert:
+//   <actor>s                → id, ...
+//   <actor>_secrets         → <actor>_id, email: '<actor>-dev-0001@example.com'
+//   <actor>_password_hashes → <actor>_id, password_hash, saved_at
+```
+
+Keep every seeded value unique and obviously fake (the seeder convention). Do **not** seed tokens — access and refresh tokens are created by signing in ([session-clerk](./session-clerk.md)); the seeder only provides the credential to sign in with.

--- a/kit/skills/backend/hb-cookie-authentication/references/environment.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/environment.md
@@ -1,0 +1,64 @@
+# Environment & config
+
+Set these up once per project, before (or alongside) building the auth cluster. Steps:
+
+## 1. Dependency
+
+The cookie clerk ([cookie-context](./cookie-context.md)) parses and writes cookies with the `cookie` package. Add it:
+
+```
+npm install cookie
+```
+
+## 2. Auth env vars
+
+Cookie attributes and the refresh-token lifetime are environment-driven, so they change per deploy with no code change. Add to each `.env.*` (left empty in the boilerplate; each app fills them):
+
+```
+AUTH_REFRESH_TOKEN_TTL_DAYS=
+AUTH_COOKIE_SECURE=
+AUTH_COOKIE_SAME_SITE=
+AUTH_COOKIE_PATH=
+AUTH_COOKIE_DOMAIN=
+```
+
+Declare them on the env-facade typedef (`app/globals/env.js` + `env.cjs`) and read them **through the facade** (`env.AUTH_*`), never `process.env` directly. The refresh-token model reads the TTL from it, with a fallback default:
+
+```js
+static get ttlDays () {
+  return Number(env.AUTH_REFRESH_TOKEN_TTL_DAYS)
+    || DEFAULT_REFRESH_TOKEN_TTL_DAYS // 14
+}
+```
+
+The access-token lifetime is **not** env-driven — it is a fixed short module constant (15 minutes) in the access-token model ([token-models](./token-models.md)).
+
+## 3. Cookie-name constant, per actor
+
+Each actor's refresh cookie has its own name so audiences never collide. Define it as a constant ([[hb-constant-definition]]) — a CommonJS master under `constants/` plus its ESM bridge:
+
+```js
+// constants/authConstants.cjs
+REFRESH_TOKEN_COOKIE: {
+  <ACTOR>: {
+    NAME: '<actor>_refresh_token',
+  },
+}
+```
+
+## 4. Engine cookie config
+
+The engine assembles the cookie config the context and clerk read — env-driven attributes plus the per-actor name ([cookie-context](./cookie-context.md), [auth-filter](./auth-filter.md)):
+
+```js
+static buildRefreshTokenCookieConfig () {
+  return {
+    ...this.refreshTokenCookieConfig, // secure / sameSite / httpOnly / lifetimeDays, from env
+    name: REFRESH_TOKEN_COOKIE.<ACTOR>.NAME,
+  }
+}
+```
+
+## 5. TLS
+
+`AUTH_COOKIE_SECURE=true` requires HTTPS — over plain HTTP the browser drops a `Secure` cookie, so dev usually runs it off. It pairs with serving the frontend same-origin ([[hf-cookie-authentication]]).

--- a/kit/skills/backend/hb-cookie-authentication/references/error-codes.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/error-codes.md
@@ -1,0 +1,24 @@
+# Error codes
+
+Two codes make the cookie flow legible to the frontend ([[hf-cookie-authentication]]), on top of the engine's standard hash. Codes follow the dotted `<class>.<id>.<seq>` convention, spread over `super.errorCodeHash` in the resolver.
+
+```js
+// RenewAccessTokenMutationResolver
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    // This op skips filtering, so it raises Unauthenticated itself — reusing the engine's own
+    // code so the client sees the same "sign in again" signal.
+    Unauthenticated: '102.X000.001',
+
+    RefreshTokenReused: '205.M003.001',
+  }
+}
+```
+
+- **`Unauthenticated` = `102.X000.001`** — the engine's standard code. Header-guarded operations get it from the filter ([auth-filter](./auth-filter.md)); `renewAccessToken` skips the filter, so it raises the same code itself when the refresh cookie is missing, expired, or unavailable.
+- **`RefreshTokenReused` = `205.M003.001`** — a spent refresh token was presented again (a leak). `renewAccessToken` revokes the whole series and throws this; the frontend treats it as a hard sign-out, no retry.
+- **`IncorrectSecret` = `202.M002.001`** — `signIn` throws this for a wrong email *or* password, one code for both so it never reveals which was wrong.
+
+The engine's `standardErrorCodeHash` owns `Unauthenticated` / `Unauthorized` / `DeniedSchemaPermission` (all `102.X000.*`); the filter throws those for header-guarded operations, so the auth resolvers only add what is theirs.

--- a/kit/skills/backend/hb-cookie-authentication/references/migrations.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/migrations.md
@@ -1,0 +1,18 @@
+# Migrations
+
+One create-table migration per credential / token table, written with the standard migration shape (`MigrationAttributeFactory`, a `COLUMN_NAME` map, snake_case `field:`, `addIndex`). See the migration convention for the skeleton; this reference is only the auth-specific columns and indexes.
+
+Tables, per actor (`<Actor>` shown):
+
+- `<actor>_password_hashes` (+ `<actor>_password_hashes_bk` backup) — `<actor>_id`, `password_hash`, `saved_at`.
+- `<actor>_access_tokens` — `<actor>_id`, `access_token`, `session_key`, `generated_at`, `expired_at`.
+- `<actor>_refresh_tokens` — `<actor>_id`, `token_hash`, `session_key`, `used_at`, `revoked_at`, `generated_at`, `expired_at`.
+
+Auth-specific points:
+
+- **Unique index on the token digest** (`token_hash`) and on `access_token` — each is the lookup key, and the unique index makes a duplicate impossible.
+- **Index `session_key`** on both token tables — rotation and revocation query by series.
+- Foreign keys (`<actor>_id`) are plain `BIGINT` columns with an index and **no** DB-level `references` constraint — the renchan convention.
+- The `_bk` backup table mirrors the source columns; it pairs with the password-hash model's backup mixin ([token-models](./token-models.md)).
+
+The columns map one-to-one to the model attributes ([token-models](./token-models.md)) — camelCase attribute ↔ snake_case column via `underscored: true`. Add or change a column in the migration and the model together.

--- a/kit/skills/backend/hb-cookie-authentication/references/resolvers.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/resolvers.md
@@ -1,0 +1,97 @@
+# Auth resolvers
+
+Four mutations, all thin: each wires `SessionClerk` ([session-clerk](./session-clerk.md)) and `RefreshTokenExpressCookieClerk` ([cookie-context](./cookie-context.md)). Write them with [[hb-mutation-resolver]]; this reference is only the auth wiring. Both clerks are reached through getter seams (`SessionClerkCtor`, `RefreshTokenExpressCookieClerkCtor`) so tests substitute them.
+
+## signIn
+
+Verify the password, start a session, set the cookie **after** the write commits, return only the access token.
+
+```js
+const passwordHashEntity = await this.findPasswordHashByEmail({ email })
+
+if (!passwordHashEntity) {
+  throw this.errorHash.IncorrectSecret.create()
+}
+
+const isValidPassword = await passwordHashEntity.verifiesPassword({ password })
+
+if (!isValidPassword) {
+  throw this.errorHash.IncorrectSecret.create() // same code for wrong email or password
+}
+
+const result = await this.createSessionClerk()
+  .saveSession({
+    userId: passwordHashEntity.<Actor>Id,
+    now: context.now,
+  })
+
+if (result.hasError()) {
+  throw new Error(result.extractErrorMessage())
+}
+
+// Only after the transaction committed — a cookie for a rolled-back session would leave the
+// client holding a refresh token no row backs.
+this.createCookieClerk({ context })
+  .saveRefreshTokenCookie({ refreshToken: result.credentialPair.refreshToken })
+
+return {
+  accessToken: result.credentialPair.accessTokenEntity.accessToken,
+}
+```
+
+## renewAccessToken
+
+Authenticate from the **cookie** (the access token is usually expired when this runs, so the op skips filtering — [auth-filter](./auth-filter.md)). Rotate; a **used** token presented again is a leak → revoke the series and report reuse.
+
+```js
+const refreshTokenEntity = await sessionClerk.findRefreshToken({
+  refreshToken: cookieClerk.extractRefreshToken(),
+})
+
+if (!refreshTokenEntity) {
+  cookieClerk.clearRefreshTokenCookie()
+
+  throw this.errorHash.Unauthenticated.create()
+}
+
+if (refreshTokenEntity.isUsed()) {
+  return this.handleReusedToken({ context, refreshTokenEntity }) // revoke series + RefreshTokenReused
+}
+
+if (!refreshTokenEntity.isAvailable({ pointsAt: context.now })) {
+  cookieClerk.clearRefreshTokenCookie()
+
+  throw this.errorHash.Unauthenticated.create()
+}
+
+const result = await sessionClerk.rotateSession({ refreshTokenEntity, now: context.now })
+// ... on success: set the new cookie, return the fresh accessToken
+```
+
+## signOut
+
+Authenticate from the cookie, revoke the whole series, clear the cookie. **Idempotent** — a missing or unmatched cookie still clears the cookie and returns success, because signing out is never an error.
+
+```js
+const refreshTokenEntity = await sessionClerk.findRefreshToken({
+  refreshToken: cookieClerk.extractRefreshToken(),
+})
+
+const result = await this.revokeSeries({ context, refreshTokenEntity }) // null when nothing matched
+
+if (result?.hasError()) {
+  throw new Error(result.extractErrorMessage())
+}
+
+cookieClerk.clearRefreshTokenCookie()
+
+return {
+  isSignedOut: true,
+}
+```
+
+## signUp
+
+Creates the actor together with its secret (email) and password hash. The profile fields are the app's own design; the auth-specific part is enciphering the password into the password-hash table (the same enciphering `verifiesPassword` compares against — [token-models](./token-models.md)). It may start a session like `signIn`, or leave the actor to sign in afterward.
+
+All four operations are public — they are listed in `schemasToSkipFiltering` ([auth-filter](./auth-filter.md)).

--- a/kit/skills/backend/hb-cookie-authentication/references/session-clerk.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/session-clerk.md
@@ -1,0 +1,41 @@
+# Session clerk
+
+`app/session/SessionClerk.js` is the single window over the token tables — every find / save / update / delete across the access and refresh token tables. Resolvers depend only on it and never touch the tables. The **token models are injected**, so both audiences share one implementation.
+
+```js
+const sessionClerk = SessionClerk.create({
+  AccessTokenModel: <Actor>AccessToken,
+  RefreshTokenModel: <Actor>RefreshToken,
+})
+```
+
+## Throwable-save, result objects
+
+Each public write self-resolves a transaction and returns a **result object** rather than throwing — a throw rolls the transaction back and comes back as `result.error`. Naming the error is left to the resolver.
+
+- `saveSession({ userId, now })` → `SavingSessionResult` — starts a new series (access + refresh pair). `result.credentialPair` is `{ accessTokenEntity, refreshTokenEntity, refreshToken }`, where `refreshToken` is the plaintext for the cookie.
+- `rotateSession({ refreshTokenEntity, now })` → `SavingSessionResult` — spends the presented refresh row (`usedAt`) and issues the next pair in the same `sessionKey`.
+- `revokeSession({ sessionKey, now })` → `RevokingSessionResult` — revokes every refresh token in the series and deletes its access tokens.
+- `findRefreshToken({ refreshToken })` → the row, looked up by digest, or `null`.
+
+```js
+const result = await sessionClerk.saveSession({
+  userId,
+  now: context.now,
+})
+
+if (result.hasError()) {
+  throw new Error(result.extractErrorMessage())
+}
+
+// result.credentialPair.refreshToken → hand to the cookie clerk
+// result.credentialPair.accessTokenEntity.accessToken → the response body
+```
+
+## Rotation detects reuse
+
+Rotation spends the presented row guarded on `usedAt: null`, so presenting a spent row again updates nothing. The resolver reads `refreshTokenEntity.isUsed()` and treats a used row as a leak ([resolvers](./resolvers.md)). Revocation is keyed on `sessionKey`, so it takes down the whole series at once.
+
+## Transactions and seams
+
+Every write takes an optional `transaction`: pass one to join an outer transaction (the caller then decides rollback via `result.hasError()`), or omit it to self-resolve one here. The clerk builds tokens through a `SessionCredentialGenerator` (token, digest, session-key) defaulted in its factory — real callers get real behavior; tests substitute the injected models and the generator seam.

--- a/kit/skills/backend/hb-cookie-authentication/references/token-models.md
+++ b/kit/skills/backend/hb-cookie-authentication/references/token-models.md
@@ -1,0 +1,125 @@
+# Token & credential models
+
+An authenticated actor's credential and session live in a small cluster of tables, kept apart from the actor's profile. For an actor `<Actor>`:
+
+- `<Actor>` — the entity (its profile fields are the app's own design; see [[hb-database-design]]).
+- `<Actor>Secret` — the sign-in identifier (`email`), kept apart from the profile.
+- `<Actor>PasswordHash` — the password digest; verifies a candidate password.
+- `<Actor>AccessToken` — the short-lived token (15 min), sent on the `x-renchan-access-token` header.
+- `<Actor>RefreshToken` — the long-lived token; stored only as a digest, delivered as an `HttpOnly` cookie.
+
+Each is a normal renchan model ([[hb-sequelize-model]]); this reference is only the auth-specific shape.
+
+## The rotation columns (refresh token)
+
+`sessionKey` is the **series**; `usedAt` / `revokedAt` / `expiredAt` drive rotation and reuse detection. Only the **digest** is stored (`tokenHash`, unique) — a dump of the table is not a set of usable sessions.
+
+```js
+// <Actor>RefreshToken.createAttributes — the auth-specific columns
+<Actor>Id: {
+  type: DataTypes.BIGINT,
+  allowNull: false,
+},
+tokenHash: {
+  type: DataTypes.STRING(191),
+  allowNull: false,
+  unique: true, // the digest, never the token; the lookup key
+},
+sessionKey: {
+  type: DataTypes.STRING(191),
+  allowNull: false, // the series a rotation keeps
+},
+usedAt: {
+  type: DataTypes.DATE,
+  allowNull: true, // set when spent on rotation
+},
+revokedAt: {
+  type: DataTypes.DATE,
+  allowNull: true, // set on sign-out or reuse
+},
+generatedAt: {
+  type: DataTypes.DATE,
+  allowNull: false,
+},
+expiredAt: {
+  type: DataTypes.DATE,
+  allowNull: false,
+},
+```
+
+`<Actor>AccessToken` mirrors this but has no `usedAt` / `revokedAt` (an access token is deleted, not flagged) and carries the `accessToken` value (unique) plus the same `sessionKey`.
+
+## Store the digest, hand back the plaintext
+
+The token models never store the plain token. `buildWithGeneratedAttributes` takes the plain refresh token and stores only its digest through `hashToken`; the plaintext is returned by the clerk for the cookie.
+
+```js
+static buildWithGeneratedAttributes ({
+  userId,
+  sessionKey,
+  refreshToken,
+  generatedAt,
+  expiredAt = this.createExpiredAt({ generatedAt }),
+}) {
+  return this.build({
+    <Actor>Id: userId,
+    sessionKey,
+    tokenHash: this.hashToken({ token: refreshToken }), // only the digest is persisted
+    generatedAt,
+    expiredAt,
+    usedAt: null,
+    revokedAt: null,
+  })
+}
+```
+
+## State reads live on the model
+
+Availability and reuse are model methods, so a resolver never re-implements the rules:
+
+```js
+isUsed () {
+  return this.get('usedAt') !== null // presented again after this ⇒ reuse
+}
+
+isAvailable ({ pointsAt }) {
+  return !this.isUsed()
+    && !this.isRevoked()
+    && !this.isExpired({ pointsAt })
+}
+```
+
+## Audience-neutral foreign-key read
+
+The shared `SessionClerk` ([session-clerk](./session-clerk.md)) holds the token model without knowing the actor, so expose the concrete foreign key through `extractUserId()`:
+
+```js
+extractUserId () {
+  return this.get('<Actor>Id') // the Admin model returns AdminId
+}
+```
+
+## Password hash
+
+`<Actor>PasswordHash` stores `passwordHash`, uses the backup mixin (history), and verifies a candidate through the enciphered compare — never a plain equality:
+
+```js
+static get Mixins () {
+  return [BackupMixinModel]
+}
+
+static get BackupModel () {
+  return this._.<Actor>PasswordHashesBk
+}
+
+async verifiesPassword ({ password }) {
+  const passwordHash = this.get('passwordHash')
+
+  if (!passwordHash) {
+    return false
+  }
+
+  return Encipher.create()
+    .compare(password, passwordHash)
+}
+```

--- a/kit/skills/backend/hb-database-design/SKILL.md
+++ b/kit/skills/backend/hb-database-design/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: hb-database-design
+description: >
+  Decide the logical shape of a renchan database schema — the design choices made before writing a
+  migration or model. Use this skill whenever the user asks how to model a table, whether to
+  normalize or denormalize, how to represent a status or category, which column type to pick, how
+  to store times, how to scale reads as data grows, how to version a master table, or how to keep
+  a table's update history. Writing the migration and the model are separate conventions.
+---
+
+# Database Design
+
+A skill for the **schema-design decisions** that come *before* the mechanics: what tables and
+columns should exist, how they relate, and what each column's type and meaning is. The physical
+declaration (migration files, DataTypes, indexes) is written by `hb-sequelize-migration`; the logical
+declaration on top (model attributes, associations) by `hb-sequelize-model`. This skill decides
+**what** to put in them and **why**. The individual conventions are split across the detail files
+below — consult them as needed.
+
+## Grand principle: the database holds canonical, normalized truth
+
+The database is the **single source of truth**, and it stores that truth in its **canonical,
+non-redundant** form. Anything that is *derived* (aggregates, search indexes), *presentational*
+(timezone, human-readable labels), or *volatile / large* (files, dynamic blobs) is kept **out of
+the normalized core** and lives in a separate structure or in another layer. Every rule in the
+detail files is this principle applied to one kind of data.
+
+- **Why**: when the canonical tables stay minimal and non-redundant, each fact lives in exactly one
+  place, so responsibility boundaries are clear and the structure stays flexible as requirements
+  change — which keeps the schema stable over the project's long life. The moment derived or
+  presentational data leaks into the core, that data drifts out of sync, makes the schema rigid,
+  and every later change has to reconcile duplicates.
+- **When a rule and performance conflict, do not compromise the core** — add a separate, additive,
+  rebuildable structure (a summary table, a search DB) beside it. Never fix a query-speed concern
+  by corrupting the write model.
+
+This skill is design-level. Whenever a decision needs to be *written*, cross to `hb-sequelize-migration`
+(column types, `DATE(3)`, `TEXT('medium')`, `JSON`, no DB foreign-key constraint, indexes) and
+`hb-sequelize-model` (attributes, timestamps, and the Mixins that implement versioning and archiving).
+Code comments in the examples are English, matching those sibling skills.
+
+## Detail files
+
+- [normalization.md](./references/normalization.md) — normalize to 3NF; when reads grow, add a
+  `summary_` table or a search DB instead of denormalizing the core
+- [datetimes.md](./references/datetimes.md) — separate business datetimes from the ORM's audit
+  timestamps; store every datetime as UTC at millisecond precision (`DATE(3)`)
+- [master-tables.md](./references/master-tables.md) — model a status / category as a master table +
+  key column (not free strings, rarely `ENUM`); version a master table (a price list) by splitting
+  the version table from its rows
+- [column-types.md](./references/column-types.md) — pick a column's type from the shape of its data
+  (`JSON` / `TEXT` / `TEXT('medium')`); keep files in external storage and store only a reference
+- [update-history.md](./references/update-history.md) — retain a table's update log with the archive
+  pattern (`BackupMixinModel` + a `*_bk` table)

--- a/kit/skills/backend/hb-database-design/references/column-types.md
+++ b/kit/skills/backend/hb-database-design/references/column-types.md
@@ -1,0 +1,92 @@
+# Column types (choosing a type, and where files go)
+
+Choosing a column's type from the shape of the data it holds, and why file bytes never live in the
+database. Referenced from [SKILL.md](../SKILL.md). The concrete DataTypes and how to write them
+belong to `hb-sequelize-migration`.
+
+## Pick the column type from the shape of the data
+
+Type each column to what it actually holds:
+
+| Data | Type | Note |
+| --- | --- | --- |
+| Genuinely dynamic / schemaless values | `JSON` | only for values never queried or joined relationally |
+| URL | `TEXT` | not `STRING(n)` — real URLs have no reliable length bound |
+| Long content (article body, description) | `TEXT('medium')` (MEDIUMTEXT) | size the column to the content |
+| Datetime | `DATE(3)` (UTC) | [datetimes.md](./datetimes.md) |
+| Status / category | master-table key column | [master-tables.md](./master-tables.md) |
+
+- **Why `JSON` only for truly dynamic data**: `JSON` is the right home for a value whose structure
+  varies per row and is never the target of a relational query (a settings blob, a captured
+  third-party payload). It is the **wrong** home for data that has a fixed shape and relationships —
+  stuffing normalizable rows into a `JSON` column hides them from joins, indexes, and constraints
+  and directly violates the
+  [grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth).
+  Normalize relational facts into tables; reserve `JSON` for the genuinely schemaless.
+- **Why URL as `TEXT`**: URLs (signed storage links, tracking-laden redirects) routinely exceed any
+  `STRING(n)` you would guess, and a too-short limit truncates silently and corrupts the reference.
+  `TEXT` removes the guess.
+- **Why long content as `TEXT('medium')`**: plain `TEXT` can be too small for real article bodies;
+  choose the width from the expected content rather than discovering the ceiling in production.
+
+```
+-- Good: type matches the data's shape
+settings_json  JSON            -- per-row dynamic structure, never queried relationally
+avatar_url     TEXT            -- unbounded in practice
+body           TEXT('medium')  -- long article content
+```
+
+```
+-- Avoid: normalizable relations hidden inside JSON, and a length-capped URL
+tags_json      JSON            -- should be a tags table + join (queryable, constrained)
+avatar_url     STRING(255)     -- silently truncates a long signed URL
+```
+
+## Default integer columns to INTEGER / BIGINT; use SMALLINT only with a specific reason
+
+For an integer column, default to `INTEGER` (and `BIGINT` for ids and anything that accumulates over
+the table's life). Do **not** reach for `SMALLINT` (or `TINYINT`) to "save space" unless there is a
+**specific, permanent bound** on the value that guarantees it can never outgrow the narrow range.
+
+- **Why**: the storage a narrower integer saves is negligible (a few bytes per row), but the
+  overflow it invites is not. A column sized to today's guessed range silently caps out when the
+  data grows past it (`SMALLINT` tops out at 32767 signed), and widening it afterwards is an
+  `ALTER TABLE` on a live table. Ranges almost always grow beyond the original estimate — the same
+  reasoning that discourages `ENUM` in [master-tables.md](./master-tables.md). Defaulting to
+  `INTEGER` removes the guess; `BIGINT` is already the id convention (`hb-sequelize-migration`).
+- **Exception**: use `SMALLINT` only when the domain is **inherently and permanently bounded** (a
+  value that is by definition 0–100, a fixed small code set) *and* the narrower type usefully
+  documents that bound. That is a reason, not a micro-optimization — the default remains `INTEGER`.
+
+```
+-- Good: default width; ids and counters never run out of range
+quantity     INTEGER
+CustomerId   BIGINT      -- id convention
+```
+
+```
+-- Avoid: narrowed "to save space" — overflows once the count passes 32767
+view_count   SMALLINT    -- silently caps; widening later is an ALTER on a live table
+```
+
+## Keep files out of the database; store a reference
+
+Never store a file's bytes in the database. Put the file in **external object storage** (S3, GCS,
+etc.) and keep only a **reference** in the DB — the storage key or URL, as `TEXT` (above).
+
+- **Why**: file bytes are large and volatile and are not relational truth (the
+  [grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth)).
+  Storing them in a column bloats the table, slows every backup / replication / dump, and pushes
+  binary delivery through the app tier. A reference keeps the canonical tables small and lets the
+  storage service (and a CDN) do what it is good at; the DB stays the index of *where* the file is,
+  not the file.
+
+```
+-- Good: the DB records where the file lives, not the file
+documents (id, OwnerId, storage_key TEXT, content_type, byte_size, uploaded_at)
+```
+
+```
+-- Avoid: binary content in the row
+documents (id, OwnerId, file_blob BLOB)   -- bloats backups, slows replication, wrong tier for delivery
+```

--- a/kit/skills/backend/hb-database-design/references/datetimes.md
+++ b/kit/skills/backend/hb-database-design/references/datetimes.md
@@ -1,0 +1,88 @@
+# Datetimes (business time vs audit time, UTC, precision)
+
+How to model time columns: which datetimes are the framework's and which are the business's, and
+how every datetime is stored. Referenced from [SKILL.md](../SKILL.md). The physical `DATE(3)` column
+is written per `hb-sequelize-migration`; the model side per `hb-sequelize-model`.
+
+## Separate business datetimes from the ORM's audit timestamps
+
+`created_at` / `updated_at` / `deleted_at` are **audit columns managed by the ORM** — the
+application does **not** read or write them. When business logic needs a creation / update /
+registration time to display or to reason about, add a **dedicated, well-named column**:
+`generated_at`, `modified_at`, `registered_at`, etc. (`DATE(3)`, per the UTC rule below, named per
+the `_at` / `_on` rule below).
+
+- **Why**: the audit columns' timing is not an operational guarantee — a data backfill during a
+  migration rewrites `updated_at` without any business event happening, and the framework, not your
+  code, supplies their values. Depending on them for business meaning couples your logic to
+  framework operations and breaks silently on the next migration. A dedicated column states its
+  intent in its name and is safe to read, write, sort, and expose.
+- This is the same split enforced from the schema side by `hb-sequelize-model` (do not put timestamp
+  columns in model attributes) and `hb-sequelize-migration` (timestamps come from the shared
+  `...factory.TIMESTAMPS` preset). This skill decides *whether you need a business time column at
+  all*; those skills declare it.
+
+```
+-- Good: audit columns are the framework's; business time is its own named column
+articles (id, title, registered_at, created_at, updated_at)
+--                        ^ business: when the author registered it (app reads/writes)
+--                                         ^ audit: framework-managed (app never touches)
+```
+
+```
+-- Avoid: reusing created_at as "registered at" for display
+articles (id, title, created_at)   -- a migration backfill silently changes the displayed date
+```
+
+## Suffix a datetime column `_at`, a date-only column `_on`
+
+A column that carries a **time of day** ends with `_at` (`modified_at`, `trashed_at`,
+`expired_at`). A column whose meaning stops at the **calendar date** ends with `_on` (`billed_on`,
+`due_on`). A value that has a range is **two columns**, each keeping the suffix — `modified_at_from`
+and `modified_at_to`, never one column carrying both ends.
+
+- **Why**: the suffix is the only place a column states its granularity. Without it (`modified_from`)
+  every reader must open the migration to learn whether a time component exists, and a date-only
+  value compared against an instant is off by up to a day — a bug that only surfaces near midnight.
+  The same name travels unchanged into the model attribute and the SDL field, so one rename covers
+  all three layers.
+- `_from` / `_to` mark **the two ends of a range**. A single column meaning "in effect from this
+  moment" is not a range end: name it for the instant it holds — `effective_at`, not
+  `effective_from`.
+- This is the column-side form of the shared naming convention's `At` / `On` rule; the model
+  attribute and the GraphQL field carry the camelCase form of the same name.
+
+```
+-- Good: granularity is in the name; a range is two columns
+files    (id, modified_at, trashed_at, ...)        -- instants
+invoices (id, billed_on, due_on, ...)              -- calendar dates
+-- a search filter over modified_at spans two columns / two inputs:
+--   modified_at_from, modified_at_to
+```
+
+```
+-- Avoid: granularity unstated, or a single instant named as a range end
+files        (id, modified, ...)         -- date or instant? open the migration to find out
+invoices     (id, billed_at, ...)        -- carries a time of day the business never means
+price_tables (id, effective_from, ...)   -- one instant wearing a range-end suffix
+```
+
+## Store datetimes as UTC with millisecond precision
+
+Every datetime column is **UTC** and typed `DATETIME(3)` (Sequelize `DATE(3)`, written per
+`hb-sequelize-migration`), which keeps time to the **millisecond**. Timezone conversion is the
+**application layer's** responsibility, never the database's.
+
+- **Why (UTC)**: a timezone is a *presentational* concern (the
+  [grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth)), so
+  it does not belong in the canonical store. One unambiguous instant per row means comparisons,
+  sorting, and range queries are always correct, and the data survives being served to clients in
+  any region or migrated across environments (dev SQLite / staging MySQL / live MariaDB). Mixing
+  local times in the DB makes every `ORDER BY time` and `BETWEEN` subtly wrong.
+- **Why (ms precision)**: high-frequency writes within the same second must still order
+  deterministically; second precision collapses them and makes "latest row" ambiguous.
+
+```
+-- Good: UTC instant, millisecond precision; the app renders it in the user's timezone
+DataTypes.DATE(3)   // stored as UTC DATETIME(3)
+```

--- a/kit/skills/backend/hb-database-design/references/master-tables.md
+++ b/kit/skills/backend/hb-database-design/references/master-tables.md
@@ -1,0 +1,117 @@
+# Master tables (status / category sets, and versioned masters)
+
+How to model a fixed-ish set of reference values (statuses, categories) as data, and how to version
+a master table that changes over time (a price list). Referenced from [SKILL.md](../SKILL.md). The
+entity's key column is written per `hb-sequelize-migration`; the versioning mixin per `hb-sequelize-model`.
+
+## Model status / category with a master table + a key column, not free strings
+
+Do not store a status or category as a free-form string on the entity. Create a **master table**
+(`order_statuses`) that defines the set, and give the entity a **key column** that maps to it
+(the FK-like `OrderStatusId`, or a stable string key resolved against the master). Reserve `ENUM`
+for sets that are **clearly closed and small**.
+
+- **Why (not strings)**: free strings drift — `'active'`, `'Active'`, `'ACTIVE'` all appear, and a
+  status carries no metadata (display label, sort order, an "is active" flag). A master table makes
+  the set **queryable, extendable, and consistent**: adding a status is one row, and each status can
+  carry the metadata the app needs — a system key, a display name, a display order, an active flag
+  ([the standard columns below](#give-every-reference-master-table-the-standard-columns)). The status
+  is *config data*, presentational and operational — exactly what the
+  [grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth) keeps
+  out of ad-hoc columns.
+- **Why (ENUM discouraged)**: statuses and categories almost always grow as the project runs, and
+  adding an `ENUM` value requires an `ALTER TABLE` migration and still cannot hold metadata. `ENUM`
+  is acceptable **only** when the set is genuinely fixed and tiny (a value that will not grow), and
+  the metadata of a master table would be overkill. When unsure, use the master table — it is the
+  reversible choice.
+- The entity's key column is an **FK-like column** (uppercase-initial `OrderStatusId`, **no DB
+  foreign-key constraint**); follow the FK-like-column rule in `hb-sequelize-migration`.
+- **Name the master table for the classification it holds, in the plural: `*_statuses` for a status
+  set, `*_categories` for a classification set — never `*_types`.** The entity's key column follows
+  the table (`OrderStatusId`, `GranteeCategoryId`; not `GranteeTypeId`). `type` is prohibited as a
+  suffix because it collides with the JSDoc type annotation, so a reader cannot tell whether the
+  name means a JavaScript type or a business classification; the shared naming convention states
+  the rule and its one exception (a word borrowed verbatim from an external standard, such as
+  `mimeType`). The name chosen here propagates to the model, the FK-like column, and the GraphQL
+  field, so getting it wrong is a three-layer rename later.
+
+```
+-- Good: the set of statuses is data in a master table; the entity references it by key
+order_statuses (id, name, display_name, display_order, is_active)  -- e.g. (1, 'ordered', 'Ordered', 1, true)
+orders         (id, OrderStatusId, ...)                            -- maps to a master row; add a status = one row
+```
+
+```
+-- Avoid: a free string that drifts and carries no metadata
+orders (id, status VARCHAR(32), ...)   -- 'active' / 'Active' / 'ACTIVE' accumulate; unqueryable set
+```
+
+## Give every reference master table the standard columns
+
+A status / category master table (the enumerable set of reference values from the previous section)
+carries a fixed set of columns beyond `id`: the **system key**, a **user-facing label**, a
+**display order**, and an **active flag**.
+
+| Column | Role |
+| --- | --- |
+| `id` | primary key — what the entity's FK-like key column references |
+| `name` | **system key**: the stable identifier the application binds to (`'ordered'`). Machine-facing, unique, never renamed once referenced |
+| `display_name` | **user-facing label** shown in the UI (`'Ordered'`). Free to reword or localize without touching logic |
+| `display_order` | the order in which to present the set in the UI |
+| `is_active` | whether the entry is currently selectable / in use |
+
+- **Why split `name` from `display_name`**: application logic must key off a value that never
+  changes — the system key `name`. The label users see (`display_name`) is presentational and
+  changes often (wording, localization). If code keys off the display label, every rename or
+  translation silently breaks a lookup; keeping the two separate lets the UI text move freely while
+  logic stays pinned to the stable key. This is the metadata the master-table pattern in the
+  previous section exists to hold.
+- **Why `display_order` is a column, not code**: presentation order is data. A column lets the set
+  be reordered without a deploy; hardcoding the order in the app couples a presentation tweak to a
+  release.
+- **Why `is_active` instead of deleting a row**: retiring a value by flag keeps the row — and
+  therefore every historical reference to it (an order pointing at a now-discontinued status) —
+  valid. Deleting the master row would orphan those references (there is no DB foreign-key
+  constraint to stop it; integrity is the app's job, per `hb-sequelize-migration`). Filter to
+  `is_active = true` when offering choices, and keep inactive rows for history.
+- Put a UNIQUE index on `name` — it is the real key of the set; see `hb-sequelize-migration`.
+
+```
+-- Good: system key, display label, order, and active flag are all columns
+order_statuses (id, name, display_name, display_order, is_active)
+-- (1, 'ordered',   'Ordered',   1, true)
+-- (2, 'cancelled', 'Cancelled', 2, false)   -- retired: kept for history, no longer offered
+```
+
+## Version a master table by splitting the version from its rows
+
+A master table that manages **many records as one unit that changes over time** — a price list, a
+rate table, a fee schedule — should be **versioned**. Model it as **two separate tables**: a
+**version table** (one row per published version, carrying the version key, e.g. an
+`effective_at` datetime — the instant the version takes effect, so it is `_at`, not `_from`) and
+the **master-rows table** (the actual records, each belonging to a version). Read the version
+effective at a given time; never edit a published version's rows in
+place — publish a new version instead. This is the versioned form of the master-table idea above.
+
+- **Why**: a price list is not one record, it is a *snapshot of many records that must change
+  together and stay auditable*. Editing the rows in place destroys the history — you can no longer
+  answer "what was the price on date X", and an order placed last month that refers to "the price
+  list" silently starts reading this month's numbers. Splitting the **immutable rows of each
+  version** from the **"which version applies" axis** keeps every published version intact and makes
+  activating a new one a single, reversible act. It is the
+  [grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth)
+  again: the canonical rows are immutable truth; the current-version selection is a separate concern.
+- **Mechanics**: renchan implements exactly this with `SuiteVersionMixinModel` — the version table
+  `hasMany` the master ("suite") rows, `versionKey` (e.g. `effectiveAt`) selects the version in
+  effect, and `findCurrentSuite()` reads it. See the mixin catalog in `hb-sequelize-model`.
+
+```
+-- Good: the version and its rows are separate tables; a new version is a new set of rows
+price_tables      (id, effective_at, ...)                          -- version table (one row per version)
+price_table_rows  (id, PriceTableId, product_key, amount, ...)     -- master rows, immutable per version
+```
+
+```
+-- Avoid: one flat table edited in place
+price_list (id, product_key, amount)   -- no history; "which price applied when" is unanswerable
+```

--- a/kit/skills/backend/hb-database-design/references/normalization.md
+++ b/kit/skills/backend/hb-database-design/references/normalization.md
@@ -1,0 +1,40 @@
+# Normalization and scaling reads
+
+Third normal form as the default table shape, and how to add read capacity when data grows without
+denormalizing the canonical tables. Referenced from [SKILL.md](../SKILL.md); this is the direct
+application of its
+[grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth) to
+redundancy.
+
+## Normalize to third normal form; denormalize only as a separate, additive structure
+
+Design every table to **third normal form (3NF)** by default: each non-key column depends on the
+whole key and nothing but the key, and no fact is stored in two places. When read performance
+degrades as data grows, **do not** denormalize the canonical tables — add a **separate** structure
+beside them:
+
+- a **summary / read-model table**, named with a **`summary_` prefix** (`summary_order_listings`),
+  rebuilt from the canonical tables; or
+- an external **search database** (Elasticsearch, etc.) for full-text or faceted search.
+
+- **Why**: normalization keeps the responsibility boundaries sharp and the structure flexible (the
+  [grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth)). A
+  denormalized column copied into the core (e.g. a customer's name cached onto every order row) has
+  two owners: it drifts the instant the source changes, and it freezes the schema because now two
+  places must be updated together. Putting the derived data in a **separate, prefixed, rebuildable**
+  table (or a search DB) keeps the canonical tables as the sole source of truth — the summary can be
+  dropped and regenerated at any time without data loss.
+- The `summary_` prefix / a distinct search DB is a **signal**: "this is derived, not
+  authoritative." Never let application writes treat a summary row as the source of truth.
+
+```
+-- Good: canonical stays normalized; the fast read path is a separate, rebuildable table
+orders            (id, CustomerId, OrderStatusId, ordered_at, ...)   -- canonical truth
+customers         (id, name, ...)                                    -- canonical truth
+summary_order_listings (id, OrderId, customer_name, status_label, ...) -- derived, rebuildable
+```
+
+```
+-- Avoid: customer_name copied onto the canonical table "to make the listing query fast"
+orders (id, CustomerId, customer_name, ...)   -- drifts when the customer is renamed; two owners
+```

--- a/kit/skills/backend/hb-database-design/references/update-history.md
+++ b/kit/skills/backend/hb-database-design/references/update-history.md
@@ -1,0 +1,35 @@
+# Update history (the archive pattern)
+
+How to retain a table's change history without bloating the live table. Referenced from
+[SKILL.md](../SKILL.md). The mixin that implements this is written per `hb-sequelize-model`.
+
+## Keep a table's update log with the archive pattern
+
+When you need to retain the **update history** of a table, use the **archive pattern** as the base
+pattern: keep the live table holding only the **current** row, and on every save **append** a copy
+of the row's business attributes — as a new generation — to a **parallel archive table**. Do not
+keep history by piling every revision into the live table (a `is_current` flag, per-row version
+numbers).
+
+- **Why**: the live table stays small and single-purpose — "the current state" — so ordinary
+  queries need no "and it's the current one" filter and its indexes/constraints stay simple. The
+  full history lives in an **append-only** companion that never complicates the main table. Folding
+  current and historical rows into one table bloats it, slows every query, and muddies uniqueness
+  constraints. History is a separate, additive structure (the
+  [grand principle](../SKILL.md#grand-principle-the-database-holds-canonical-normalized-truth)),
+  exactly like the summary tables in [normalization.md](./normalization.md).
+- **Mechanics**: renchan implements the archive pattern with `BackupMixinModel` + a `*_bk` table
+  (e.g. `customer_orders` → `customer_orders_bk`): on `afterSave` it appends the business attributes
+  (excluding `id` / `created_at` / `updated_at` / `deleted_at`) plus a `saved_at` generation marker.
+  Pass the mixin from the live model; see the mixin catalog in `hb-sequelize-model`.
+
+```
+-- Good: live table = current state; archive table = append-only generations
+customer_orders     (id, CustomerId, OrderStatusId, ...)          -- current row only
+customer_orders_bk  (id, CustomerOrderId, ...business attrs, saved_at)  -- one appended row per save
+```
+
+```
+-- Avoid: history crammed into the live table
+customer_orders (id, ..., version_no, is_current)   -- every query filters is_current; table bloats
+```

--- a/kit/skills/backend/hb-execution-placement-pattern/SKILL.md
+++ b/kit/skills/backend/hb-execution-placement-pattern/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: hb-execution-placement-pattern
+description: >
+  Decide where a piece of processing (especially a write / state change) should be implemented in
+  a web system: as a synchronous GraphQL / REST API operation, or as a renchan-job-bullmq
+  background worker triggered from an API handler, from a post-worker after the response, or on a
+  schedule. Use this skill whenever the user is turning a requirement into an implementation and
+  needs to choose the execution location, including where an external-integration write belongs.
+---
+
+# Execution Placement Pattern (deciding where processing lives)
+
+A skill for deciding, the moment you receive a requirement, **where that processing should be
+implemented**. Before diving into the implementation details (how to write the job, how to write the
+resolver, etc.), first lock down the "placement". Once the placement is decided, you can hand it off
+to the individual implementation skills (`hb-renchan-job-bullmq`, etc.).
+
+## Grand principle: write processing lives in only two places — "API" or "Worker"
+
+In a web system, **processing that changes state (writes)** only ever happens in one of two places.
+Every requirement must resolve into this binary choice. The deciding axis is **how heavy / how
+long-running the processing is**.
+
+| Placement | Execution model | What it holds |
+| --- | --- | --- |
+| **API** | Responds **synchronously** to the request | Things that are **light and finish quickly** |
+| **Worker** | Runs **asynchronously** in the background | Things that are **heavy and take time** |
+
+- **Why only two places**: a write can only originate from "an external request (API)" or "processing
+  the system drives on its own (Worker)". Creating a third place scatters responsibility, monitoring,
+  and retry paths so they can no longer be traced.
+- **Why split by weight**: a request must return quickly. If you run heavy processing inside the API,
+  the response never comes back and it times out; if it is cut off midway, it cannot recover. Push it
+  to a Worker and the API can respond immediately, while retries, progress notifications, and scaling
+  work independently.
+- **When the boundary is unclear, lean toward Worker.** Why: if "probably fast" processing turns out
+  slow at production data volumes, an API implementation becomes a timeout incident. A Worker does not
+  break when it gets slow. As a rule of thumb, anything involving external I/O, AI calls, large record
+  counts, or file generation counts as the heavy side.
+
+> Read-only (non-state-changing) processing is not the main subject of this skill. As a rule it just
+> returns synchronously via the API (GraphQL query / REST GET) and is not turned into a Worker.
+
+## Decision flow
+
+1. **Is it a write?** If read-only, return it via an API query / GET and you're done.
+2. **Is it light & short-lived?** → **API** ([1](#1-put-it-in-the-api-light-short-lived)).
+3. **Is it heavy / time-consuming / uncertain due to external dependencies?** → **Worker** ([2](#2-put-it-in-a-worker-heavy-time-consuming)).
+4. **What triggers the Worker?**
+   - User actions, external integrations, etc. — **request-based** → enqueue from inside the API handler ([2.1](#21-request-based)).
+   - A side effect unrelated to the main processing, run **after the response** → dispatch from a **post-worker** ([2.2](#22-post-worker)).
+   - Automatic, by time / interval → **schedule-based** ([2.3](#23-schedule-based)).
+
+| Nature of the processing | Placement | Concretely |
+| --- | --- | --- |
+| Light, short-lived, needs a synchronous response | **API** | GraphQL resolver / REST renderer |
+| Heavy, time-consuming, **request-based** | **Worker (API-triggered)** | renchan-job-bullmq (enqueue from resolver/renderer) |
+| A **side effect** unrelated to main processing, run **after the response** | **Worker (post-worker-triggered)** | post-worker only dispatches (e.g. sending an email after signup) |
+| Heavy, **automatic by interval/time** | **Worker (scheduled)** | renchan-job-bullmq (cron / interval scheduler) |
+
+## 1. Put it in the API (light, short-lived)
+
+The API has two families: **GraphQL** and **REST API**. Choose based on the caller in the requirement.
+
+- **GraphQL** — resolvers under `server/graphql/resolvers/<role>/actual/{mutations,queries}/`.
+  Ordinary reads/writes from your own frontend default to this.
+- **REST API (renderer)** — renderers under `server/restfulapi/renderers/v1/{post,get}/*Renderer.js`.
+  Use for file uploads, endpoints hit by external systems, and non-GraphQL clients.
+
+Rule of thumb for what goes here: simple CRUD against the DB, input validation, and short
+aggregations/updates that complete within a single request.
+
+- **Why the API**: for short processing where the user waits for the result immediately, responding
+  synchronously is the shortest path. Turning it into a job instead introduces the complexity of
+  enqueue → progress notification → polling/subscription, which isn't worth it.
+
+```js
+// Good: a short DB update is handled synchronously inside the resolver and returned immediately
+const updated = await context.share.transaction(async tx => this.updateProfile({ input, tx }))
+return { profile: updated }
+```
+
+```js
+// Avoid: running even heavy processing synchronously inside the resolver → the response never returns and times out
+const content = await generateContentWithAi({ accessToken }) // takes tens of seconds
+return { content }
+```
+
+## 2. Put it in a Worker (heavy, time-consuming)
+
+Workers are implemented with **`@openreachtech/renchan-job-bullmq`**. Place the Manifest / Worker /
+Dispatcher under `app/jobs/<kebab-name>/`. Follow the
+`hb-renchan-job-bullmq` skill for how to write them.
+
+They split into three kinds by trigger ([2.1](#21-request-based) request-based /
+[2.2](#22-post-worker) post-worker / [2.3](#23-schedule-based) schedule).
+**In all three, the shape is the same: "the real work is in the Worker, the trigger is elsewhere"** —
+don't put logic beyond dispatch in the trigger.
+
+### 2.1 Request-based
+
+The pattern of **enqueuing from inside the API handler**. Triggered by a user action or external
+integration, the API (resolver / renderer) **only enqueues and responds immediately**, while the real
+work is handled by a Worker in the Daemon. Progress is returned via a subscription or similar.
+
+- Examples (this repo): heavy AI content generation = `app/jobs/content-generation-internal` /
+  `app/jobs/content-generation-public-lp`; report email sending = `app/jobs/send-report-email`.
+  They enqueue with `dispatchJob` from a resolver/renderer.
+
+- **Why enqueue**: running heavy processing inside the API means it can't return. Enqueue instead and
+  the API can respond immediately, while the Worker side handles retry / progress notification /
+  concurrency control. **The API side sticks to "just enqueuing"** (no real work).
+
+```js
+// Good: heavy processing is enqueued and the response returns immediately (the real work is in the Worker)
+await context.share.jobDispatcherProvider.dispatchJob({
+  DispatcherCtor: ContentGenerationPublicLpJobDispatcher,
+  body: {
+    accessToken,
+  },
+})
+return { accepted: true }
+```
+
+### 2.2 post-worker
+
+renchan's **post-worker** (`BaseGraphqlPostWorker`) is the mechanism for **running side effects
+unrelated to the API's main processing, after the response**. It fires as an `onResolved` hook per
+GraphQL operation, running after the main resolver has returned.
+
+**A post-worker holds only the dispatch to the Worker. Don't put complex logic here** (the real work
+always belongs on the Worker side).
+
+- **Why dispatch only**: a post-worker is a thin hook that runs after the response. If you write heavy
+  processing or complex logic here, logic accumulates in a place where **neither retry, progress
+  notification, nor monitoring apply**, and failures get swallowed. Keep it to dispatch and the real
+  work rides on the Worker's machinery (retries, observability), while the post-worker stays
+  predictably thin — "just enqueuing" (the same principle as "the trigger only enqueues" in
+  [2.1](#21-request-based)).
+- **Choosing between 2.1 and this**: if **the user is requesting** that processing (waits for the
+  result, or it's part of the response), enqueue inside the handler ([2.1](#21-request-based)). If you
+  only want to run a **side effect unrelated to the main processing** afterward without making the
+  response wait, use a post-worker.
+- Example: dispatch **sending a welcome email after signup** from a post-worker (the signup response
+  isn't kept waiting; the email send is streamed to a Worker afterward).
+- Current state of this repo: the server engine has `postWorkersPath: null` (not wired). To use it,
+  set the engine's `postWorkersPath` and place a post-worker that extends `BaseGraphqlPostWorker`.
+
+```js
+// Good: a post-worker only dispatches (the real work of the side effect is on the Worker side)
+/** @override */
+async onResolved ({ variables, context, response: { output, error } }) {
+  if (error) {
+    return
+  }
+
+  await context.share.jobDispatcherProvider.dispatchJob({
+    DispatcherCtor: SendWelcomeEmailJobDispatcher,
+    body: {
+      customerId: output.customer.id,
+    },
+  })
+}
+```
+
+```js
+// Avoid: writing email-body assembly or sending logic directly in the post-worker
+//   → real work accumulates in a post-response place where failures get swallowed, and neither retry nor monitoring apply. Put the real work in the Worker.
+```
+
+### 2.3 Schedule-based
+
+Processing that starts **automatically by time / interval** rather than from a user. Register a cron /
+interval scheduler (`*CronJobScheduler.js` / `*IntervalJobScheduler.js`,
+`hb-renchan-job-bullmq` skill).
+
+- Example (this repo): cleaning up expired sessions = `app/jobs/purge-expired-content-sessions`
+  (`PurgeExpiredContentSessionsCronJobScheduler.js`).
+
+- **Why a scheduler**: periodic batches, cleanups, reminders, re-aggregations, and the like need to
+  run even without an external request. They don't ride the API path, so start them from a scheduler.
+
+```js
+// Avoid: substituting a periodic cleanup with "an admin presses a button and the resolver runs a long loop"
+//   → forgotten presses, double execution, and timeouts occur. Put periodic processing in a scheduler.
+```
+
+## 3. Placement of external integrations
+
+Integrations with external systems must also ride on one of the two places above (API / Worker).
+Organize them by direction.
+
+- **inbound (receiving calls from outside)**: **often a REST API (renderer)**, but **not necessarily**
+  (it can be received via GraphQL). Choose the receiving method based on the other system's
+  constraints. If the processing after receiving is heavy, the renderer sticks to enqueuing and hands
+  the real work to a Worker ([2.1](#21-request-based)).
+  - Example: `server/restfulapi/renderers/v1/post/IntegrationReportPostRenderer.js`.
+- **outbound (calling an external API)**: call it via the rocket-client Launcher
+  (`hb-external-api-client` skill).
+  External calls are slow and uncertain, so call them from a Worker if they would block the user's
+  response.
+
+- **Why "not necessarily REST"**: the integration method (REST / GraphQL / Webhook, etc.) is usually
+  decided by the other system and won't always match our default (REST renderer). **The receiving
+  method follows the other party's spec, and the placement (API or Worker) follows this skill's weight
+  criterion** — decide the two axes separately.
+
+## Finishing checklist
+
+- [ ] Is this processing a **write**? (If a read, return it via query/GET and you're done.)
+- [ ] Did you resolve it into the binary of **light → API / heavy → Worker**, leaning toward Worker when unsure?
+- [ ] If placing it in the API, did you choose **GraphQL resolver** or **REST renderer** based on the caller?
+- [ ] If placing it in a Worker, did you choose one of **request-based (enqueue)** / **post-worker** / **schedule-based** by trigger?
+- [ ] For the request-based case, does **the API side only enqueue** (no real work written in the resolver/renderer)?
+- [ ] If running a side effect unrelated to main processing after the response, did you write **only a dispatch in the post-worker** and keep the real work in the Worker?
+- [ ] For external integrations, did you decide the **receiving method (other party's constraints)** and the **placement (weight criterion)** separately?

--- a/kit/skills/backend/hb-external-api-client/SKILL.md
+++ b/kit/skills/backend/hb-external-api-client/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: hb-external-api-client
+description: >
+  Implement a client for an external HTTP/REST API using
+  `@openreachtech/mentsu-rocket-client` (the Launcher / Payload / Capsule three-class
+  structure). Use this skill whenever the user asks to add or change an external API
+  integration — a new service client, a new API operation, request/response key
+  conversion, authorization headers, or wrapping a vendor SDK — under
+  `app/<serviceName>Client/`. For the raw source guide see the doc linked at the bottom.
+---
+
+# External API Client
+
+How to implement a client for an external HTTP/REST API with `@openreachtech/mentsu-rocket-client`
+(rocket-client from here on). One external request is split across three classes —
+**Launcher / Payload / Capsule**. The conventions are divided into the detail files listed at the
+bottom; read the one that matches what you are doing.
+
+## First principle: confine every difference from the external API to Payload / Capsule (anti-corruption layer)
+
+Every convention in this skill follows from one goal: **an external API's interface differences must
+stay out of application code.** Key names, value formats, paths, authentication and response shapes
+of an external API can all change, and they disagree with our own naming conventions anyway. Confine
+those differences to **a single layer (the anti-corruption layer)** so the caller (a resolver or a
+job) never has to know about them.
+
+- **Differences on the way in** (key names, value formats, path, query, authentication) belong to
+  **`Payload`**.
+- **Differences on the way out** (response key names, nesting, missing fields) belong to
+  **`Capsule`'s `extractXxx()`**.
+- The caller only builds a `Payload` and pulls values out of a `Capsule`. **If the external API's raw
+  shape reaches the caller, this layer has failed.**
+- **Why**: without this layer — or with a thin one — every change to the external API forces edits in
+  resolvers and jobs, and the reach of a change becomes impossible to see. Collecting the differences
+  in one place is what keeps a spec change contained to `Payload` / `Capsule`. When an individual
+  rule leaves you unsure, decide it by extending this principle: which class owns this difference?
+
+## Cross-cutting rules (they apply to every layer)
+
+### HTTP goes through the native `fetch` only — no axios, no HTTP client of your own
+
+In the direct-HTTP pattern, communication is handled by the **Node.js native `fetch`** built into
+`BaseLauncher`. **Do not add another HTTP client module such as axios**, and do not implement an HTTP
+client or Fetcher class of your own. Wrap an SDK only when the vendor publishes an official one
+([sdk-wrapper.md](./references/sdk-wrapper.md) — an interim implementation).
+
+- **Why**: because the transport is centralized in `BaseLauncher`, retries, error conversion and
+  swapping in a stub for tests all take effect in one place. If each client brings its own axios, that
+  benefit is gone and the transport ends up implemented differently per operation.
+
+### Decide failure with `capsule.hasError()`, not `try-catch`
+
+`launchRequest()` catches `fetch` exceptions and body-parse failures internally and returns the
+`Capsule` for the corresponding error kind. The caller **writes no `try-catch`** and decides failure
+from the returned `capsule.hasError()`.
+
+- **Why**: funnelling missing authentication, invalid input, network failure, parse failure and a
+  status >= 400 into one path — the "error `Capsule`" — is this module's design. A caller that adds
+  `try-catch` on top handles errors through two channels, the caught exception and the `Capsule`, and
+  a case will fall through the gap.
+
+### Return `null` (or an empty array) for a missing value, never `undefined`
+
+When an `extractXxx()` or a getter cannot produce a value, return **`null`** — or an **empty array**
+for something that returns an array, or whatever the intended default is — not `undefined`.
+
+- **Why**: `undefined` cannot be told apart from "undefined behaviour / not implemented yet". `null`
+  (or an empty array) states the intent: the value was looked for and was not there. Details in
+  [capsule.md](./references/capsule.md).
+
+### Write comments in code in English
+
+Comments in the real code you generate (`.js`) — `//`, `/* */`, JSDoc — are written in **English**, to
+match the rest of the codebase. The ```js``` blocks in this skill are real code too, so their JSDoc
+and comments are shown in English as well.
+
+### Naming, and one class per file
+
+**One class per file**, with a single `export default`. Name a derived launcher
+`<Operation>Launcher`, and the payload and capsule `<Operation>Payload` / `<Operation>Capsule`, so the
+operation is readable from the name. Pick the verb of a retrieval method by where the value comes
+from (`fetch~` = external API, `find~` = the database, `extract~` = pulled out of a `Capsule`). The
+remaining general coding conventions are in [conventions.md](./references/conventions.md).
+
+## Detail files
+
+- [architecture.md](./references/architecture.md) — the whole picture (the three classes, the data flow, directory layout, the classes the module provides)
+- [launcher.md](./references/launcher.md) — Launcher (base and derived / direct HTTP, the members of `BaseLauncher`)
+- [payload.md](./references/payload.md) — Payload (input definition, `method`/`pathname`, schema, key conversion)
+- [capsule.md](./references/capsule.md) — Capsule (the response wrapper, `extractXxx()`, null guards)
+- [authorization.md](./references/authorization.md) — authentication (`AuthorizationBuilderCtor` / `authorizationApiKey`)
+- [sdk-wrapper.md](./references/sdk-wrapper.md) — the SDK-wrapping pattern (an interim implementation that overrides `launchRequest()`)
+- [usage.md](./references/usage.md) — the implementation steps, and use from the caller (resolver / job), DI and hooks
+- [testing.md](./references/testing.md) — unit tests for Payload / Capsule / Launcher
+- [conventions.md](./references/conventions.md) — the naming and coding convention checklist
+
+> This skill was made from the repository's external API client implementation guide. For reference
+> material — rocket-client's own export list, its type definitions, examples of existing clients — see
+> the "reference files" section at the end of that guide.

--- a/kit/skills/backend/hb-external-api-client/references/architecture.md
+++ b/kit/skills/backend/hb-external-api-client/references/architecture.md
@@ -1,0 +1,127 @@
+# Architecture (the whole picture: three classes, data flow, layout)
+
+The whole picture of rocket-client: how one request is split across **Launcher / Payload / Capsule**,
+the data flow between them, the directory layout, and the classes the module provides for you to swap
+in. Referenced from [SKILL.md](../SKILL.md). For how to write each individual layer, see
+[launcher.md](./launcher.md) / [payload.md](./payload.md) / [capsule.md](./capsule.md).
+
+## Split the responsibilities across three classes
+
+One external API request is always implemented in these three layers. All of them are `import`ed from
+`@openreachtech/mentsu-rocket-client`.
+
+| Layer | Base class | Role | Granularity |
+| :-- | :-- | :-- | :-- |
+| **Launcher** | `BaseLauncher` | Runs the request. Has `fetch` built in; `launchRequest()` covers sending through to producing the `Capsule` | Per service (base) plus per API operation (derived) |
+| **Payload** | `BasePayload` | The input definition of one request. Holds method / path / query / body / authentication / key and value conversion | Per API operation |
+| **Capsule** | `BaseCapsule` | The response wrapper. Provides `body` / `statusCode` / `hasError()`, and pulls values out with `extractXxx()` | Per API operation |
+
+- **Per service** (say, some SaaS's REST API) there is **one** **base launcher**
+  (`Base<Service>Launcher`) holding `clientConfig` (base URL and so on).
+- **Per API operation** (say, creating a document) there is **one set** of `Payload` / `Capsule` plus
+  the **derived launcher** (`<Operation>Launcher`) that ties them together.
+- **Why this granularity**: connection settings (base URL, credentials) are shared across the service,
+  so they are collected in the base; input and output differences vary per operation, so they are
+  split per operation. Adding a new operation is then "add three derived files" and nothing about the
+  existing operations changes.
+
+## Data flow: the caller only assembles and hands over
+
+The caller builds a `Payload` and calls `launcher.launchRequest({ payload })` — that is all.
+`launchRequest()` (provided by `BaseLauncher`) then runs this flow.
+
+```
+caller
+  │  pathParameterHash / query / body / optionHash
+  ▼
+Launcher.createPayload({ ... })            ← shortcut for Payload.create()
+  │  payload
+  ▼
+launcher.launchRequest({ payload, hooks })  ← provided by BaseLauncher
+  │
+  ├─ payload.hasAuthorization()        ─ false ─▶ Capsule (no-authorization error)
+  ├─ payload.hasInvalidParameterHash() ─ true  ─▶ Capsule (invalid-input error)
+  ├─ hooks.beforeRequest(payload)      ─ true  ─▶ Capsule (aborted-by-hooks)
+  │
+  ├─ payload.createFetchRequest({ baseUrl })   ← assembles path, query, body, headers
+  │        │ Request
+  │        ▼
+  │  BaseLauncher.fetch(request)               ← native fetch (exceptions swallowed into null)
+  │        │ Response | null
+  │        ▼
+  │  ResponseBodyParser.parseBody()            ← JSON parsing by default
+  │
+  ├─ network failure ─▶ Capsule (network error)
+  ├─ parse failure   ─▶ Capsule (response-body-parse error)
+  └─ success         ─▶ Capsule (holding rawResponse / body)
+  │
+  ▼
+hooks.afterRequest(capsule)
+  │
+  ▼
+capsule.hasError() / capsule.extractXxx()   ← the caller pulls values out
+```
+
+- Before sending, the `Payload` **validates itself** with `hasAuthorization()` and
+  `hasInvalidParameterHash()`, and on invalid input returns an error `Capsule` without calling `fetch`.
+- `fetch` exceptions and body-parse failures are caught inside `BaseLauncher` and converted into the
+  `Capsule` for the corresponding error kind. **That is why the caller decides failure with
+  `capsule.hasError()` rather than `try-catch`**
+  ([SKILL.md](../SKILL.md#decide-failure-with-capsulehaserror-not-try-catch)).
+
+## Directory layout
+
+| What | Where | Example |
+| :-- | :-- | :-- |
+| Implementation | `app/<serviceName>Client/` | `app/documentApiClient/` |
+| Tests | `tests/__tests__/app/<serviceName>Client/` | `tests/__tests__/app/documentApiClient/` |
+
+The files for one operation (the service base plus the operation's three):
+
+```
+app/documentApiClient/
+  BaseDocumentApiLauncher.js      ← base launcher (clientConfig = BASE_URL, fetch, …)
+  CreateDocumentLauncher.js       ← derived launcher (ties Payload / Capsule together)
+  CreateDocumentPayload.js        ← input definition (method / pathname / schema / authentication)
+  CreateDocumentCapsule.js        ← output extraction (extractXxx)
+```
+
+- **Why separate files**: one class per file is a repository-wide convention
+  ([conventions.md](./conventions.md)). The base launcher and the derived launcher are separate files
+  too, so that what is shared across the service (connection settings) and what is specific to the
+  operation (tying Payload/Capsule together) are kept in separate files.
+
+## The classes the module provides (swapped in from `Payload` / `Capsule` / `Launcher`)
+
+The behaviour of a `Payload` or a `Capsule` is swapped by returning one of the classes below from the
+corresponding getter. All of them are exported from `@openreachtech/mentsu-rocket-client`.
+
+| Kind | Class | Purpose | Where it is used |
+| :-- | :-- | :-- | :-- |
+| Core | `BaseLauncher` / `BasePayload` / `BaseCapsule` | The base classes of the three layers | The `extends` of each layer |
+| Authentication | `BearerAuthorizationBuilder` / `BasicAuthorizationBuilder` (base `BaseAuthorizationBuilder`) | How the `Authorization` header is produced | The payload's `AuthorizationBuilderCtor` ([authorization.md](./authorization.md)) |
+| Request key conversion | `SnakeCasedKeyRequestQuery` / `SnakeCasedKeyRequestBody` | Internal camelCase → outgoing snake_case | The payload's `RequestQueryCtor` / `RequestBodyCtor` ([payload.md](./payload.md)) |
+| Response key conversion | `CamelCasedKeyResponseBody` (base `ResponseBody`) | Incoming snake_case → internal camelCase | The capsule's `ResponseBodyCtor` ([capsule.md](./capsule.md)) |
+| Body formatting | `JsonRequestBodyStringifier` / `NdjsonRequestBodyStringifier` (base `BaseRequestBodyStringifier`) | How the request body is stringified | Payload |
+| Response parsing | `JsonResponseBodyParser` / `BlobResponseBodyParser` (base `BaseResponseBodyParser`) | How the response body is parsed | The launcher's `ResponseBodyParser` (JSON by default) |
+| Constants | `REST_METHOD` / `LAUNCH_ABORTED_REASON` | The HTTP method enum / the abort-reason enum | The payload's `method`, and so on |
+
+- The scalars used in `querySchema` / `bodySchema` (`TextScalar` / `KeywordScalar` / `IntegerScalar` /
+  `DatetimeScalar`, …) are `import`ed from **`@openreachtech/mentsu-schema`**, not from rocket-client.
+- **Installing**: `npm install @openreachtech/mentsu-rocket-client` — it is published to npmjs.com,
+  so no registry configuration or authentication is required.
+
+## The two transport patterns
+
+A launcher that calls an external API comes in two patterns, depending on the transport. The way
+differences are absorbed (input in the `Payload`, output in the `Capsule`) is the same in both; **only
+the transport step differs**.
+
+| Pattern | Transport | When to use | Implementation |
+| :-- | :-- | :-- | :-- |
+| **Direct HTTP** (default) | The `fetch` built into `BaseLauncher` | No vendor SDK / hitting REST directly | Nothing extra to implement. Define `clientConfig` / `Payload` / `Capsule` ([launcher.md](./launcher.md)) |
+| **SDK wrapping** | The SDK the vendor provides | An official SDK/client exists | The launcher holds the SDK and overrides `launchRequest()` ([sdk-wrapper.md](./sdk-wrapper.md) — an interim implementation) |
+
+- A new REST integration is **direct HTTP** by default. SDK wrapping is an **interim
+  implementation** until rocket-client supports it properly, so use it only where an SDK is
+  provided.

--- a/kit/skills/backend/hb-external-api-client/references/authorization.md
+++ b/kit/skills/backend/hb-external-api-client/references/authorization.md
@@ -1,0 +1,105 @@
+# Authorization
+
+How the `Authorization` header is decided. Authentication is a difference on the way in, so it is
+**confined to the `Payload`** ([payload.md](./payload.md)). Referenced from [SKILL.md](../SKILL.md).
+
+The `Authorization` header is decided by the payload's `AuthorizationBuilderCtor` and
+`authorizationApiKey` — or by the per-request `optionHash`.
+
+## Pick the implementation by how the credential is held
+
+| How the credential is held | Implementation |
+| :-- | :-- |
+| **A key shared across the service** (an API token in `env`, …) | Return `BearerAuthorizationBuilder` from `AuthorizationBuilderCtor` and `env.XXX` from `authorizationApiKey`. The header is generated for you |
+| **A per-request token** (a user's access token, …) | Set `AuthorizationBuilderCtor`, leave `authorizationApiKey` as `null`, and pass `optionHash.headers.Authorization` when building the payload |
+| **Basic authentication** | Return `BasicAuthorizationBuilder` from `AuthorizationBuilderCtor` and `'user:pass'` from `authorizationApiKey` (it is Base64-encoded for you) |
+| **No authentication** | Override nothing (`AuthorizationBuilderCtor` defaults to `null`) |
+
+## Declare a service-wide key with `AuthorizationBuilderCtor` plus `authorizationApiKey`
+
+For an operation authenticated with an API token from `env`, implement two getters on the payload. The
+builder assembles the header string (`Bearer xxx`), so do not write `headers` by hand.
+
+- **Why**: turning the generation scheme (Bearer / Basic) and the key into declarations confines the
+  header-assembly difference to the payload. Written by hand, you risk a missing `Bearer ` prefix or
+  a forgotten Base64 encoding.
+
+```js
+import {
+  env,
+} from '../globals/_.js'
+
+import {
+  BasePayload,
+  BearerAuthorizationBuilder,
+  REST_METHOD,
+} from '@openreachtech/mentsu-rocket-client'
+
+export default class FindDocumentsPayload extends BasePayload {
+  /** @override */
+  static get method () {
+    return REST_METHOD.GET
+  }
+
+  /** @override */
+  static get pathname () {
+    return '/v1/projects/[projectId]/documents'
+  }
+
+  /**
+   * get: AuthorizationBuilder constructor.
+   *
+   * @override
+   * @returns {typeof BearerAuthorizationBuilder}
+   */
+  static get AuthorizationBuilderCtor () {
+    return BearerAuthorizationBuilder
+  }
+
+  /**
+   * get: authorization API key.
+   *
+   * @override
+   * @returns {string}
+   */
+  static get authorizationApiKey () {
+    return env.DOCUMENT_API_TOKEN
+  }
+}
+```
+
+## Pass a per-request token through `optionHash.headers.Authorization`
+
+For a token that changes per request, such as a user's access token, set `AuthorizationBuilderCtor` on
+the payload but leave `authorizationApiKey` as `null`, and pass the header through `optionHash` when
+building the payload.
+
+- **Why keep `AuthorizationBuilderCtor`**: so that "make a missing token an error", below, takes effect.
+
+```js
+const payload = FindDocumentsPayload.create({
+  pathParameterHash: {
+    projectId: 'fake-project-id-001',
+  },
+  query: {
+    keyword: 'fake-keyword-001',
+    limit: 20,
+  },
+  optionHash: {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  },
+})
+```
+
+## To make a missing token an error, always set `AuthorizationBuilderCtor`
+
+When `AuthorizationBuilderCtor` is `null` (the default), `hasAuthorization()` is always `true` — no
+validation. To have a missing token treated as a "no-authorization error `Capsule`", set
+`AuthorizationBuilderCtor`.
+
+- **Why**: with no builder set, rocket-client reads that as "no authentication needed" and skips the
+  check. Omitting the builder on an operation that does need authentication sends the `fetch` without a
+  token and leaves you relying on the external API's 401 — the benefit of validating before sending is
+  gone. Do not omit the builder where authentication is required.

--- a/kit/skills/backend/hb-external-api-client/references/capsule.md
+++ b/kit/skills/backend/hb-external-api-client/references/capsule.md
@@ -1,0 +1,130 @@
+# Capsule (the response wrapper, extracting values)
+
+How to write a capsule that extends `BaseCapsule`. It is what `launchRequest()` returns, and
+**differences in response shape — key names, nesting, missing fields — are confined here**
+([SKILL.md](../SKILL.md#first-principle-confine-every-difference-from-the-external-api-to-payload--capsule-anti-corruption-layer)).
+The input side is in [payload.md](./payload.md). The capsule for the SDK-wrapping pattern is in
+[sdk-wrapper.md](./sdk-wrapper.md).
+
+## The main members `BaseCapsule` provides
+
+| Member | Role |
+| :-- | :-- |
+| `get body` | The normalized response body (after `bodySchema` / `ResponseBodyCtor`). `null` when there is none |
+| `get statusCode` | The HTTP status code. `null` when there is none |
+| `hasError()` | `true` on any error: authentication, input, network, parse, or status (>= 400) |
+| `getErrorMessage()` | The error-code string for the error kind. `null` when there is no error |
+| `isPending()` | `true` before sending (when `payload` is `null`) |
+
+- The caller **decides failure with `hasError()`** and writes no `try-catch`
+  ([SKILL.md](../SKILL.md#decide-failure-with-capsulehaserror-not-try-catch)).
+
+## When the response is snake_case, swap `ResponseBodyCtor` for the Camel one
+
+Returning `CamelCasedKeyResponseBody` from `static get ResponseBodyCtor ()` converts incoming
+snake_case keys into internal camelCase. `this.body` is then read with the converted keys.
+
+- **Why**: even when the external API returns `document_id`, the application stays consistent with
+  `documentId`. Confining the incoming naming difference to the capsule lets everything from
+  `extractXxx()` onward be written in our own conventions only.
+
+## `extractXxx()` always guards against null, and returns `null` / an empty array when the value is missing
+
+Add one `extractXxx()` per value you want out of the response.
+
+- `this.body` **can be `null`** (on a network or parse failure, for instance). **Always guard with
+  optional chaining** or equivalent before returning a value.
+- When the value cannot be produced, return **`null`** — or an **empty array** for something that
+  returns an array — never `undefined`
+  ([SKILL.md](../SKILL.md#return-null-or-an-empty-array-for-a-missing-value-never-undefined)).
+- **Why the null guard is required**: forget it and an error `Capsule` (whose `body` is `null`) throws a
+  `TypeError` at `this.body.documentId`, which breaks the design of deciding failure with
+  `hasError()`. Extraction guarantees a safe default even when the request failed.
+- **Why not `undefined`**: `undefined` cannot be told apart from "undefined behaviour / not implemented
+  yet". `null` (or an empty array) states the intent to the caller: the value was looked for and was
+  not there.
+
+```js
+import {
+  BaseCapsule,
+  CamelCasedKeyResponseBody,
+} from '@openreachtech/mentsu-rocket-client'
+
+/**
+ * @extends {BaseCapsule<*, *>}
+ */
+export default class CreateDocumentCapsule extends BaseCapsule {
+  /**
+   * get: ResponseBody constructor (snake_case -> camelCase).
+   *
+   * @override
+   * @returns {typeof CamelCasedKeyResponseBody}
+   */
+  static get ResponseBodyCtor () {
+    return CamelCasedKeyResponseBody
+  }
+
+  /**
+   * Extract created document ID.
+   *
+   * @returns {string | null}
+   */
+  extractDocumentId () {
+    return this.body?.documentId
+      ?? null
+  }
+}
+```
+
+```js
+// Bad: no null guard, and it returns undefined
+extractDocumentId () {
+  return this.body.documentId // TypeError when body is null (breaks on an error Capsule)
+}
+```
+
+Extracting an array — an empty array when missing, reshaped to our own keys:
+
+```js
+import {
+  BaseCapsule,
+  CamelCasedKeyResponseBody,
+} from '@openreachtech/mentsu-rocket-client'
+
+/**
+ * @extends {BaseCapsule<*, *>}
+ */
+export default class FindDocumentsCapsule extends BaseCapsule {
+  /** @override */
+  static get ResponseBodyCtor () {
+    return CamelCasedKeyResponseBody
+  }
+
+  /**
+   * Extract documents.
+   *
+   * @returns {Array<{
+   *   documentId: string
+   *   title: string
+   * }>}
+   */
+  extractDocuments () {
+    return this.body?.documents
+      ?.map(document => ({
+        documentId: document.documentId,
+        title: document.title,
+      }))
+      ?? []
+  }
+}
+```
+
+- The `map` **reshapes to only the keys the application needs**. Extra keys and nesting the external
+  API returns are not passed to the caller unchanged — that is the confinement. Iterate with `map`,
+  not `for` or `forEach` ([conventions.md](./conventions.md)).
+
+## Normalize response values with `bodySchema` (optional)
+
+Declaring `static bodySchema` makes the declared keys subject to value normalization (normalizing a
+datetime string, say). Use it when you want the values shaped into something the application handles
+more easily. `extractXxx()` works whether or not it is declared.

--- a/kit/skills/backend/hb-external-api-client/references/conventions.md
+++ b/kit/skills/backend/hb-external-api-client/references/conventions.md
@@ -1,0 +1,68 @@
+# Conventions (the naming and coding checklist)
+
+The naming and coding conventions for writing an external API client: the repository-wide coding
+conventions plus the items specific to this module. Referenced from [SKILL.md](../SKILL.md). The
+cross-cutting rules that matter most — `fetch` only, decide failure with `hasError()`, return `null`,
+comments in English — are in [SKILL.md](../SKILL.md).
+
+## Class layout and naming
+
+- **One class per file**, with a single `export default`.
+- Class names are Upper CamelCase. Name a derived launcher `<Operation>Launcher`, and the payload and
+  capsule `<Operation>Payload` / `<Operation>Capsule`, so **the operation is readable from the name**.
+  The base launcher is `Base<Service>Launcher`.
+- **Why include the operation**: one service carries several operations, and without names like
+  `CreateDocumentLauncher` / `FindDocumentsLauncher` there is no telling which file is which API.
+
+## Method names are "verb + object", and retrieval verbs differ by source
+
+A retrieval method's prefix distinguishes where the value comes from.
+
+| Prefix | Source |
+| :-- | :-- |
+| `fetch~` | Retrieved from the external API |
+| `find~` | Retrieved from the database |
+| `extract~` | Pulled out of a capsule ([capsule.md](./capsule.md)) |
+
+- **Why distinguish them**: retrieval is not one thing — failure means something different, and is
+  handled differently, depending on whether the source is the external API, the database or a capsule.
+  A consistent prefix makes the kind of I/O readable from the method name alone, and makes it plain at a
+  glance that `extract~` performs no external communication.
+
+## A constructor only assigns; defaults belong in the factory
+
+- A `constructor` **only assigns** the values it was given. No default-value construction, no logic.
+- Defaults belong in `create()` (the factory method), and a getter only returns the field.
+- **Why**: collecting defaults in the factory is what lets a test swap a dependency in, as in
+  `create({ sdkClient })` ([sdk-wrapper.md](./sdk-wrapper.md) /
+  [usage.md](./usage.md#di-inject-a-stub-launcher)). Logic in the `constructor` removes that seam.
+
+## Control flow and data conversion
+
+- **No single-character variables** — use a meaningful name (`document`, `functionCall`).
+- Avoid `for` / `forEach` / `switch` / `else if`; write **`map` / `filter` / `reduce` and early
+  returns**. Reshape an array in `extractXxx()` with `map`
+  ([capsule.md](./capsule.md#extractxxx-always-guards-against-null-and-returns-null--an-empty-array-when-the-value-is-missing)).
+- **Why**: a declarative conversion (`map`/`filter`) makes the input-to-output correspondence easy to
+  read, and holding no intermediate state leaves less room for bugs. Readability is everything in code
+  that absorbs differences, so avoid imperative loops.
+
+## Notation
+
+- **One property per line in an object literal** — the sample code in this skill included.
+- Return **`null`** for a missing value, never `undefined` — or an empty array, or whatever the intended
+  default is
+  ([SKILL.md](../SKILL.md#return-null-or-an-empty-array-for-a-missing-value-never-undefined)).
+- Members are ordered: constructor → factory → static getter → static method → instance getter →
+  instance setter → instance method. Keep methods that call one another near each other.
+- **Why fix the order**: when every class is ordered the same way, a reviewer's eye goes straight to
+  what is specific to this class. When the order varies per class, a deliberate difference and an
+  omission look alike.
+
+## No additional HTTP client (restated)
+
+**HTTP communication goes through Node.js's native `fetch` as a rule.** In the direct-HTTP pattern use
+the `fetch` built into `BaseLauncher` and implement no HTTP client of your own. **Do not add another
+HTTP client module such as axios.** Wrap an SDK only where the SDK owns the external communication
+([sdk-wrapper.md](./sdk-wrapper.md) — an interim implementation). The reasoning is in
+[SKILL.md](../SKILL.md#http-goes-through-the-native-fetch-only--no-axios-no-http-client-of-your-own).

--- a/kit/skills/backend/hb-external-api-client/references/launcher.md
+++ b/kit/skills/backend/hb-external-api-client/references/launcher.md
@@ -1,0 +1,138 @@
+# Launcher (base and derived, direct HTTP)
+
+How to write a launcher that extends `BaseLauncher`. This file covers the **direct-HTTP pattern**,
+where the built-in `fetch` handles the transport. To wrap an SDK instead, see
+[sdk-wrapper.md](./sdk-wrapper.md). Referenced from [SKILL.md](../SKILL.md); the whole picture is in
+[architecture.md](./architecture.md).
+
+## Do not implement an HTTP client of your own
+
+A launcher **only declares the connection settings (`clientConfig`) and the `Payload` / `Capsule` it
+uses**. The transport is the Node.js native `fetch` built into `BaseLauncher`, so do not import axios
+and do not write an HTTP client or Fetcher class of your own
+([SKILL.md](../SKILL.md#http-goes-through-the-native-fetch-only--no-axios-no-http-client-of-your-own)).
+
+- **Why**: the design collects the transport, retries, error conversion and stub-swapping for tests
+  into the single place that is `BaseLauncher`. A launcher that brings its own transport breaks that,
+  and the transport ends up implemented differently per operation.
+
+```js
+// Bad: bringing in an HTTP client of your own, or axios
+import axios from 'axios'
+
+export default class CreateDocumentLauncher extends BaseDocumentApiLauncher {
+  async launchRequest ({ payload }) {
+    const response = await axios.post(/* ... */) // throws away BaseLauncher's fetch flow
+    // ...
+  }
+}
+```
+
+## Base launcher: one per service, holding `clientConfig`
+
+For each service (each external API) create one abstract base, `Base<Service>Launcher`, holding
+`clientConfig` (the connection settings). Every operation's derived launcher extends it.
+
+- `static get clientConfig ()` (override, **required**): returns `{ BASE_URL: ... }`. It becomes the
+  default `config` for `create()` and is used as `baseUrl` (= `config[baseUrlKey]`, the default key
+  being `'BASE_URL'`).
+- Take the base URL, credentials and the like **from environment variables (`env`)**. Never hard-code
+  the values.
+- When the response is not JSON, override `static get ResponseBodyParser ()` with
+  `BlobResponseBodyParser` or another parser (the default is `JsonResponseBodyParser`).
+- `static get fetch ()` returns the native `fetch` by default. **This is what tests replace**
+  ([testing.md](./testing.md)).
+- **Why environment variables**: a base URL or an API token differs per environment (development /
+  staging / live) and is also a secret. Going through `env` absorbs the difference between
+  environments and keeps the secret out of the repository.
+
+```js
+import {
+  env,
+} from '../globals/_.js'
+
+import {
+  BaseLauncher,
+} from '@openreachtech/mentsu-rocket-client'
+
+export default class BaseDocumentApiLauncher extends BaseLauncher {
+  /**
+   * get: client configuration.
+   *
+   * @override
+   * @returns {{
+   *   BASE_URL: string
+   * }}
+   */
+  static get clientConfig () {
+    return {
+      BASE_URL: env.DOCUMENT_API_BASE_URL,
+    }
+  }
+}
+```
+
+## Derived launcher: one per API operation, tying `Payload` / `Capsule` together
+
+It extends the base launcher and declares the `Payload` / `Capsule` this operation uses. It holds no
+logic — it returns two getters and nothing else.
+
+- `static get Payload ()` (override, **required**): returns this operation's `Payload` class.
+- `static get Capsule ()` (override, **required**): returns this operation's `Capsule` class.
+- **Why only getters**: the send flow (validate → `fetch` → parse → build the `Capsule`) lives
+  entirely in `BaseLauncher`. The derived class works by declaring which input definition and which
+  output wrapper to use. Adding logic here breaks the first principle — differences stay confined to
+  Payload/Capsule.
+
+```js
+import BaseDocumentApiLauncher from './BaseDocumentApiLauncher.js'
+
+import CreateDocumentPayload from './CreateDocumentPayload.js'
+import CreateDocumentCapsule from './CreateDocumentCapsule.js'
+
+export default class CreateDocumentLauncher extends BaseDocumentApiLauncher {
+  /**
+   * get: Payload class.
+   *
+   * @override
+   * @returns {typeof CreateDocumentPayload}
+   */
+  static get Payload () {
+    return CreateDocumentPayload
+  }
+
+  /**
+   * get: Capsule class.
+   *
+   * @override
+   * @returns {typeof CreateDocumentCapsule}
+   */
+  static get Capsule () {
+    return CreateDocumentCapsule
+  }
+}
+```
+
+## `create()` adopts `clientConfig` when the argument is omitted
+
+`BaseLauncher.create()` adopts `this.clientConfig` as `config` when called without arguments. The
+caller gets a launcher carrying the connection settings assembled from environment variables with
+nothing but `CreateDocumentLauncher.create()`.
+
+- **Why**: so the caller never has to assemble the connection settings. The caller only cares which
+  service and which operation — that is, which class — and never writes the base URL handover again.
+  The steps for swapping it out through DI are in
+  [usage.md](./usage.md#di-inject-a-stub-launcher).
+
+## The main members `BaseLauncher` provides
+
+| Member | Kind | Role |
+| :-- | :-- | :-- |
+| `static create({ config })` | factory | Builds a launcher (`config` defaults to `clientConfig`) |
+| `static createPayload({ pathParameterHash, query, body, optionHash })` | static | Shortcut for `this.Payload.create(...)` |
+| `launchRequest({ payload, hooks })` | instance | The entry point from sending the request through to building the `Capsule` |
+| `get baseUrl` | getter | `config[baseUrlKey]` |
+
+- The argument of `launchRequest()` is an **object** (`{ payload }`). Passing it positionally
+  (`launchRequest(payload)`) leaves `payload` as `undefined` and the pre-send validation rejects the
+  request, so watch for that.

--- a/kit/skills/backend/hb-external-api-client/references/payload.md
+++ b/kit/skills/backend/hb-external-api-client/references/payload.md
@@ -1,0 +1,176 @@
+# Payload (the input definition, where differences are confined)
+
+How to write a payload that extends `BasePayload`. **Every interface difference from the external API
+— method, path, query and body key names, value formats, authentication — is confined here**
+([SKILL.md](../SKILL.md#first-principle-confine-every-difference-from-the-external-api-to-payload--capsule-anti-corruption-layer)).
+Authentication is in [authorization.md](./authorization.md); the output side is in
+[capsule.md](./capsule.md).
+
+## Required overrides: `method` / `pathname` (plus `contentType` when there is a body)
+
+- `static get method ()`: the HTTP method. Return **a value of `REST_METHOD`** such as
+  `REST_METHOD.GET` — never a hard-coded string.
+- `static get pathname ()`: the endpoint path. Write **the variable parts as `[placeholder]`**
+  (e.g. `/v1/projects/[projectId]/documents`). The name inside `[]` corresponds to a key of the
+  `pathParameterHash` passed to `create()`.
+- `static get contentType ()`: needed only for methods that carry a body (`POST` / `PUT` / `PATCH`),
+  e.g. `'application/json'`. It is not called for methods without a body, so it can stay undefined.
+- **Why `[placeholder]`**: declaring the variable parts lets `RequestPathParameterHash` interpolate
+  the values, and a missing key makes `hasInvalidParameterHash()` return `true` so the request becomes
+  **an error `Capsule` before it is sent**. Assembling the path by string concatenation defeats that
+  validation and an invalid URL goes out as-is.
+
+```js
+// Good: variable parts as [placeholder], method from REST_METHOD
+/** @override */
+static get method () {
+  return REST_METHOD.GET
+}
+
+/** @override */
+static get pathname () {
+  return '/v1/projects/[projectId]/documents'
+}
+```
+
+```js
+// Bad: assembling the path by string concatenation (no missing-key validation, differences not confined)
+static get pathname () {
+  return `/v1/projects/${this.projectId}/documents` // NG
+}
+```
+
+## Declare in `querySchema` / `bodySchema` only the keys that need conversion or validation
+
+Declare the query and body schemas with the scalars from `@openreachtech/mentsu-schema` (`TextScalar` /
+`KeywordScalar` / `IntegerScalar` / `DatetimeScalar`, …).
+
+- A declared key becomes subject to **value normalization and validation** — `DatetimeScalar`, for
+  instance, converts to an ISO string on the way out.
+- The default is `{}`. **Keys absent from the schema are still sent**, so declare only the keys that
+  need conversion or validation; the minimum is a fine place to start.
+- **Why the minimum is enough**: the point of the schema is to shape values to the external API's spec
+  before sending. Declaring keys that need no conversion (a plain string, say) achieves nothing, and a
+  declaration that drifts from the actual spec is easy to misread. Declare what needs converting.
+
+```js
+import {
+  KeywordScalar,
+  IntegerScalar,
+} from '@openreachtech/mentsu-schema'
+
+export default class FindDocumentsPayload extends BasePayload {
+  /** @type {Record<string, *>} */
+  static querySchema = {
+    keyword: KeywordScalar,
+    limit: IntegerScalar,
+  }
+
+  // method / pathname / authentication ...
+}
+```
+
+## When the outgoing keys are snake_case, swap in the Snake conversion classes
+
+Write camelCase internally, and when the external API demands snake_case, absorb the difference by
+returning a key-conversion class.
+
+- `static get RequestQueryCtor ()`: returning `SnakeCasedKeyRequestQuery` makes the query keys
+  snake_case.
+- `static get RequestBodyCtor ()`: returning `SnakeCasedKeyRequestBody` makes the body keys snake_case.
+- **Why convert here**: confining the difference between our naming convention (camelCase) and the
+  external API's (snake_case) to the payload is the whole point of this module. The caller always
+  writes camelCase (`bodyText`) and it becomes `body_text` on the way out. If the caller has to think
+  about snake_case, the difference has leaked.
+
+```js
+import {
+  TextScalar,
+} from '@openreachtech/mentsu-schema'
+
+import {
+  BasePayload,
+  SnakeCasedKeyRequestBody,
+  REST_METHOD,
+} from '@openreachtech/mentsu-rocket-client'
+
+export default class CreateDocumentPayload extends BasePayload {
+  /** @type {Record<string, *>} */
+  static bodySchema = {
+    title: TextScalar,
+    bodyText: TextScalar, // SnakeCasedKeyRequestBody converts this to body_text on the way out
+  }
+
+  /** @override */
+  static get method () {
+    return REST_METHOD.POST
+  }
+
+  /** @override */
+  static get contentType () {
+    return 'application/json'
+  }
+
+  /** @override */
+  static get pathname () {
+    return '/v1/projects/[projectId]/documents'
+  }
+
+  /**
+   * get: RequestBody constructor (camelCase -> snake_case).
+   *
+   * @override
+   * @returns {typeof SnakeCasedKeyRequestBody}
+   */
+  static get RequestBodyCtor () {
+    return SnakeCasedKeyRequestBody
+  }
+
+  // For authentication (AuthorizationBuilderCtor / authorizationApiKey) see authorization.md
+}
+```
+
+## Inject fixed and default values with the `enrichXxx()` hooks
+
+An API version that is always attached, a default `limit` and the like are injected with
+`static enrichPathParameterHash ()` / `static enrichBody ()` / `static enrichQuery ()`.
+
+- **Why**: so the caller is not forced to pass the same value every time. Injecting a fixed value is
+  the payload's responsibility too, and stays confined there.
+
+## Define the input types with `@typedef`
+
+Declare the shape of `pathParameterHash` / `query` / `body` with `@typedef`, so the caller can assemble
+them with the right keys.
+
+```js
+/**
+ * @typedef {{
+ *   projectId: string
+ * }} FindDocumentsPathParameterHash
+ */
+
+/**
+ * @typedef {{
+ *   keyword?: string
+ *   limit?: number
+ * }} FindDocumentsQuery
+ */
+```
+
+## Build one with `Payload.create()`, or with `createPayload()` through the launcher
+
+```js
+const payload = CreateDocumentPayload.create({
+  pathParameterHash: {
+    projectId: 'fake-project-id-001',
+  },
+  body: {
+    title: 'fake-title-001',
+    bodyText: 'fake-body-001',
+  },
+})
+```
+
+- When you already hold the launcher, use `Launcher.createPayload({ ... })` — the shortcut for
+  `this.Payload.create(...)` ([usage.md](./usage.md)).

--- a/kit/skills/backend/hb-external-api-client/references/sdk-wrapper.md
+++ b/kit/skills/backend/hb-external-api-client/references/sdk-wrapper.md
@@ -1,0 +1,291 @@
+# The SDK-wrapping pattern (an interim implementation)
+
+What to do when the vendor publishes an official SDK (`@google/genai`, the AWS SDK, …). Rather than
+hitting HTTP directly, **the launcher holds the SDK** and calls it. The way differences are absorbed
+(input in the `Payload`, output in the `Capsule`) is the same as in the direct-HTTP pattern; **only the
+transport step changes, from `fetch` to an SDK call**. Referenced from [SKILL.md](../SKILL.md). Direct
+HTTP is in [launcher.md](./launcher.md).
+
+## ⚠️ This is interim. Migrate once it is supported properly
+
+rocket-client does **not support** the SDK-wrapping shape at present. This section is a **temporary
+workaround that overrides `BaseLauncher.launchRequest()`** — the `fetch` flow — and substitutes an SDK
+call.
+
+- Migrate as soon as an update supports it properly.
+- **Keep it minimal, because it is interim** — add extensions such as holding the error only when you
+  actually need them.
+- **Limit where it is used**: only where an official SDK is provided. If REST can be hit directly, use
+  the direct-HTTP pattern and do not override `launchRequest()`.
+- The existing `app/geminiClient/` is an SDK wrapper of the same kind.
+
+## Launcher: hold the SDK and override `launchRequest()`
+
+- Extend `constructor` / `create()` to hold the SDK instance. Produce the default from a factory
+  (`createSdkClient()`) so that **a test can swap it with `create({ sdkClient })`**.
+- Override `launchRequest()` so that instead of the `fetch` flow (`createFetchRequest` → `fetch` → JSON
+  parsing), it **calls the SDK method and builds the `Capsule` straight from the result**.
+- The raw object the SDK returns (the one with getters like `.text`) is **stored in `rawResponse` without
+  going through schema normalization**. The `Capsule` reads it from `this.rawResponse` directly.
+- Keep calling the input validation (`hasInvalidParameterHash()`) after the override, and on invalid
+  input return an error `Capsule` without calling the SDK. When the SDK call throws, return a `Capsule`
+  with `rawResponse: null` so that `hasError()` is `true`.
+- **Why make it injectable**: the SDK really does perform the external communication, so a test cannot
+  call the real one. Only with `create({ sdkClient })` can the launcher's behaviour be verified against a
+  stub SDK ([testing.md](./testing.md)).
+
+```js
+import {
+  GoogleGenAI,
+} from '@google/genai'
+
+import {
+  env,
+} from '../globals/_.js'
+
+import {
+  BaseLauncher,
+} from '@openreachtech/mentsu-rocket-client'
+
+import SendMessageToGeminiPayload from './SendMessageToGeminiPayload.js'
+import SendMessageToGeminiCapsule from './SendMessageToGeminiCapsule.js'
+
+export default class SendMessageToGeminiLauncher extends BaseLauncher {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   config: Record<string, *>
+   *   sdkClient: import('@google/genai').GoogleGenAI
+   * }} params
+   */
+  constructor ({
+    config,
+    sdkClient,
+  }) {
+    super({
+      config,
+    })
+
+    this.sdkClient = sdkClient
+  }
+
+  /**
+   * Factory method.
+   *
+   * @override
+   * @param {{
+   *   config?: Record<string, *>
+   *   sdkClient?: import('@google/genai').GoogleGenAI
+   * }} [params]
+   * @returns {SendMessageToGeminiLauncher}
+   */
+  static create ({
+    config = this.clientConfig,
+    sdkClient = this.createSdkClient({
+      config,
+    }),
+  } = {}) {
+    return new this({
+      config,
+      sdkClient,
+    })
+  }
+
+  /**
+   * get: client configuration.
+   *
+   * @override
+   * @returns {{
+   *   LLM_API_KEY: string
+   * }}
+   */
+  static get clientConfig () {
+    return {
+      LLM_API_KEY: env.LLM_API_KEY,
+    }
+  }
+
+  /** @override */
+  static get Payload () {
+    return SendMessageToGeminiPayload
+  }
+
+  /** @override */
+  static get Capsule () {
+    return SendMessageToGeminiCapsule
+  }
+
+  /**
+   * Create the vendor SDK client (transport).
+   *
+   * @param {{
+   *   config: {
+   *     LLM_API_KEY: string
+   *   }
+   * }} params
+   * @returns {import('@google/genai').GoogleGenAI}
+   */
+  static createSdkClient ({
+    config,
+  }) {
+    return new GoogleGenAI({
+      apiKey: config.LLM_API_KEY,
+    })
+  }
+
+  /**
+   * Launch request via the SDK (provisional override of the fetch flow).
+   *
+   * @override
+   * @param {{
+   *   payload: SendMessageToGeminiPayload
+   * }} params
+   * @returns {Promise<SendMessageToGeminiCapsule>}
+   */
+  async launchRequest ({
+    payload,
+  }) {
+    if (payload.hasInvalidParameterHash()) {
+      return this.Ctor.createCapsuleAsInvalidInputError({
+        payload,
+      })
+    }
+
+    try {
+      const result = await this.sdkClient
+        .models
+        .generateContent(
+          payload.toSdkParams()
+        )
+
+      return this.Ctor.createCapsule({
+        payload,
+        rawResponse: result,
+        rawBody: null,
+      })
+    } catch (error) {
+      return this.Ctor.createCapsule({
+        payload,
+        rawResponse: null,
+        rawBody: null,
+      })
+    }
+  }
+}
+```
+
+## Payload: still extends `BasePayload`, as a container with `toSdkParams()`
+
+Even for an SDK call the `Payload` extends `BasePayload`, because `Capsule`'s `hasError()` and friends
+consult the payload's `hasAuthorization()` / `hasInvalidParameterHash()`. The parameters for the SDK call
+are returned from `toSdkParams()`.
+
+- `method` / `pathname` / `contentType` are unused by an SDK call, but `BasePayload.create()` consults
+  them, so they are still declared (interim).
+- **Why extend `BasePayload`**: to keep the same split of responsibilities in an SDK wrapper — input
+  validation in the payload, extraction in the capsule. Drop the inheritance for a plain object and the
+  payload interface that `Capsule.hasError()` assumes is missing, and it breaks.
+
+```js
+import {
+  KeywordScalar,
+} from '@openreachtech/mentsu-schema'
+
+import {
+  BasePayload,
+  REST_METHOD,
+} from '@openreachtech/mentsu-rocket-client'
+
+export default class SendMessageToGeminiPayload extends BasePayload {
+  /** @type {Record<string, *>} */
+  static bodySchema = {
+    model: KeywordScalar,
+  }
+
+  // Interim: unused by the SDK call, but declared because BasePayload.create() consults it.
+  /** @override */
+  static get method () {
+    return REST_METHOD.POST
+  }
+
+  /** @override */
+  static get pathname () {
+    return '/'
+  }
+
+  /** @override */
+  static get contentType () {
+    return 'application/json'
+  }
+
+  /**
+   * SDK params.
+   *
+   * @returns {Record<string, *>}
+   */
+  toSdkParams () {
+    return this.requestBody.body
+  }
+}
+```
+
+The caller passes the SDK parameters as `body`:
+
+```js
+const payload = SendMessageToGeminiPayload.create({
+  body: {
+    model: 'gemini-2.5-flash',
+    contents: 'fake-contents-001',
+  },
+})
+```
+
+## Capsule: extract from `this.rawResponse` (the SDK object)
+
+In an SDK wrapper, `extractXxx()` reads not the JSON-normalized `this.body` but `this.rawResponse` — the
+raw object the SDK returns, with getters like `.text`. The conventions for null guards and defaults are
+the same as for direct HTTP ([capsule.md](./capsule.md)).
+
+```js
+import {
+  BaseCapsule,
+} from '@openreachtech/mentsu-rocket-client'
+
+/**
+ * @extends {BaseCapsule<*, *>}
+ */
+export default class SendMessageToGeminiCapsule extends BaseCapsule {
+  /**
+   * Extract content text from the SDK response.
+   *
+   * @returns {string}
+   */
+  extractContentText () {
+    return this.rawResponse?.text
+      ?? ''
+  }
+
+  /**
+   * Extract function calls from the SDK response.
+   *
+   * @returns {Array<{
+   *   name: string
+   *   arguments: object
+   * }>}
+   */
+  extractFunctionCalls () {
+    return this.rawResponse?.functionCalls
+      ?.map(functionCall => ({
+        name: functionCall.name,
+        arguments: functionCall.args,
+      }))
+      ?? []
+  }
+}
+```
+
+- When the SDK call throws, `launchRequest()` returns a `Capsule` with `rawResponse: null` — the
+  equivalent of a network error — so `capsule.hasError()` is `true`. Pulling out the SDK's error message
+  and the like needs an extension, such as adding a factory to the `Capsule` that holds the error; keep
+  it minimal while this is interim.

--- a/kit/skills/backend/hb-external-api-client/references/testing.md
+++ b/kit/skills/backend/hb-external-api-client/references/testing.md
@@ -1,0 +1,130 @@
+# Testing (tests for Payload / Capsule / Launcher)
+
+The unit-test conventions for an external API client. The files live under
+`tests/__tests__/app/<serviceName>Client/`, one per class. The general Jest conventions come from the
+`hc-jest` skill; this file states only what is specific to this module. Referenced from
+[SKILL.md](../SKILL.md).
+
+- Use `test.each()`, and make the test data unique with explicit fake values (`fake-...`).
+- **Always stub the external communication**: replace `fetch` for direct HTTP, or `sdkClient` for an
+  SDK wrapper. Never write a test that hits the real thing (the mocking conventions of the `hc-jest`
+  skill).
+
+## What to test on a payload
+
+- That it extends `BasePayload` (inheritance).
+- That `method` / `pathname` / `contentType` are correct.
+- That `querySchema` / `bodySchema` hold the expected keys.
+- That the authentication members (`AuthorizationBuilderCtor` / `authorizationApiKey`) are correct.
+- That after `create(...)`, `hasInvalidParameterHash()` is what it should be (`true` when a path
+  parameter is missing).
+- **Why test the validation too**: the payload's responsibility is to absorb the input differences and
+  reject invalid input before sending. Without asserting the schema keys and
+  `hasInvalidParameterHash()`, there is no signal when that absorption breaks.
+
+## What to test on a capsule
+
+- That it extends `BaseCapsule`.
+- For each `extractXxx()`, split "the value is present" and "the value is absent (returns the default /
+  `null`)" into separate `describe` blocks. Build one with
+  `Capsule.create({ rawResponse, payload, rawBody })`.
+- That `hasError()` is `true` for a status code (>= 400), a network error and an input error.
+- **Why the absent case is mandatory**: the null guard and the default in `extractXxx()`
+  ([capsule.md](./capsule.md#extractxxx-always-guards-against-null-and-returns-null--an-empty-array-when-the-value-is-missing))
+  only matter when the response is missing something. Asserting only the present case lets a missing guard through —
+  `body` is `null` and it throws a `TypeError`.
+
+## What to test on a launcher
+
+- That the base launcher extends `BaseLauncher`, and that `clientConfig` returns the expected
+  connection settings.
+- That the derived launcher's `Payload` / `Capsule` return the right classes.
+- That `launchRequest()`, with **`fetch` stubbed** (by replacing `static get fetch ()`), is called with
+  the correct `Request` (URL, method, headers, body) and returns a `Capsule`.
+- For an SDK wrapper ([sdk-wrapper.md](./sdk-wrapper.md)), inject a stub SDK through
+  `create({ sdkClient })` and assert that `launchRequest()` calls the SDK method with the right
+  arguments and returns the result carried in a `Capsule`.
+
+## Replace `fetch` by overriding it in a sub-class
+
+Stub `fetch` by creating an anonymous class inside the test that extends `CreateDocumentLauncher` and
+overrides `static get fetch ()`. Have `jest.fn().mockResolvedValue(...)` return a `Response`, then assert
+that it was called and what the `Capsule` extracted.
+
+```js
+import CreateDocumentLauncher from '../../../../app/documentApiClient/CreateDocumentLauncher.js'
+import CreateDocumentPayload from '../../../../app/documentApiClient/CreateDocumentPayload.js'
+import CreateDocumentCapsule from '../../../../app/documentApiClient/CreateDocumentCapsule.js'
+
+describe('CreateDocumentLauncher', () => {
+  describe('.get:Payload', () => {
+    test('to be CreateDocumentPayload', () => {
+      expect(CreateDocumentLauncher.Payload)
+        .toBe(CreateDocumentPayload)
+    })
+  })
+
+  describe('.get:Capsule', () => {
+    test('to be CreateDocumentCapsule', () => {
+      expect(CreateDocumentLauncher.Capsule)
+        .toBe(CreateDocumentCapsule)
+    })
+  })
+
+  describe('#launchRequest()', () => {
+    const cases = [
+      {
+        params: {
+          pathParameterHash: {
+            projectId: 'fake-project-id-001',
+          },
+          body: {
+            title: 'fake-title-001',
+            bodyText: 'fake-body-001',
+          },
+        },
+      },
+    ]
+
+    test.each(cases)('projectId: $params.pathParameterHash.projectId', async ({
+      params,
+    }) => {
+      const responseTally = new Response(
+        JSON.stringify({
+          document_id: 'fake-document-id-001',
+        }),
+        {
+          status: 200,
+        }
+      )
+      const fetchSpy = jest.fn()
+        .mockResolvedValue(responseTally)
+
+      const SpyLauncher = class extends CreateDocumentLauncher {
+        /** @override */
+        static get fetch () {
+          return fetchSpy
+        }
+      }
+
+      const launcher = SpyLauncher.create()
+
+      const payload = SpyLauncher.createPayload(params)
+
+      const capsule = await launcher.launchRequest({
+        payload,
+      })
+
+      expect(fetchSpy)
+        .toHaveBeenCalled()
+      expect(capsule.extractDocumentId())
+        .toBe('fake-document-id-001')
+    })
+  })
+})
+```
+
+- Build the stub `Response` in **the external API's raw shape** (snake_case `document_id`) and assert all
+  the way through that `extractDocumentId()` returns the value in our own terms
+  (`fake-document-id-001`). That is how you confirm the whole chain of difference absorption —
+  incoming key conversion, then extraction — is working.

--- a/kit/skills/backend/hb-external-api-client/references/usage.md
+++ b/kit/skills/backend/hb-external-api-client/references/usage.md
@@ -1,0 +1,152 @@
+# Usage (the implementation steps, and use from the caller)
+
+The steps for adding a new API operation, and how a caller such as a resolver or a job (an
+ActionExecuter) uses it. Referenced from [SKILL.md](../SKILL.md). Each layer is detailed in
+[launcher.md](./launcher.md) / [payload.md](./payload.md) / [capsule.md](./capsule.md) /
+[authorization.md](./authorization.md).
+
+## Implementation steps
+
+Start from **step 0** when the external service itself does not exist yet, or from **step 1** when
+adding an operation to a service that does.
+
+### Step 0: lay the groundwork for the service (once per service)
+
+1. Create the `app/<serviceName>Client/` directory.
+2. Create the **base launcher** (`Base<Service>Launcher.js`): extend `BaseLauncher` and implement
+   `clientConfig`, taking the base URL from an environment variable
+   ([launcher.md](./launcher.md#base-launcher-one-per-service-holding-clientconfig)).
+3. Add the environment variables for the base URL, credentials and so on to `.env.*`
+   (e.g. `DOCUMENT_API_BASE_URL`, `DOCUMENT_API_TOKEN`).
+
+### Step 1: read the API spec
+
+Establish the endpoint (method and path), the required and optional parameters (path / query / body),
+the response shape, the authentication scheme and the content type. **The differences you find here are
+exactly what gets confined to `Payload` / `Capsule`.**
+
+### Step 2: write the payload ([payload.md](./payload.md))
+
+1. Implement `method` and `pathname` (variable parts as `[placeholder]`), plus `contentType` for a
+   method with a body.
+2. Declare in `querySchema` / `bodySchema` only the keys that need conversion or validation.
+3. When the outgoing keys are snake_case, swap `RequestQueryCtor` / `RequestBodyCtor` for the Snake
+   ones.
+4. When authentication is required, implement `AuthorizationBuilderCtor` / `authorizationApiKey`
+   ([authorization.md](./authorization.md)).
+5. Define the input types with `@typedef`.
+
+### Step 3: write the capsule ([capsule.md](./capsule.md))
+
+1. When the response is snake_case, swap `ResponseBodyCtor` for `CamelCasedKeyResponseBody`.
+2. Work out which values you need out, and implement `extractXxx()` for each with a null guard
+   (`null` / an empty array when missing).
+
+### Step 4: write the derived launcher ([launcher.md](./launcher.md#derived-launcher-one-per-api-operation-tying-payload--capsule-together))
+
+1. Extend the base launcher.
+2. Return step 2's payload from `static get Payload ()` and step 3's capsule from
+   `static get Capsule ()`.
+
+### Step 5: write the tests
+
+Write unit tests for the `Payload`, the `Capsule` and the `Launcher` ([testing.md](./testing.md)).
+
+## Use from the caller (three steps)
+
+From a resolver or a job, there are three steps.
+
+1. Build the launcher with `Launcher.create()` (the connection settings are assembled from
+   `clientConfig`).
+2. Build the payload with `Launcher.createPayload({ ... })` and call
+   `launcher.launchRequest({ payload })`.
+3. Check `hasError()` on the returned `Capsule`, and pull values out with `extractXxx()`.
+
+```js
+import CreateDocumentLauncher from '../../../../../../app/documentApiClient/CreateDocumentLauncher.js'
+
+export default class SomeResolver {
+  /**
+   * Create document launcher (factory for DI).
+   *
+   * @returns {CreateDocumentLauncher}
+   */
+  static createDocumentLauncher () {
+    return CreateDocumentLauncher.create()
+  }
+
+  /**
+   * Create a document via the external API.
+   *
+   * @param {{
+   *   projectId: string
+   *   title: string
+   *   bodyText: string
+   * }} params
+   * @returns {Promise<{
+   *   hasError: boolean
+   *   documentId: string | null
+   * }>}
+   */
+  async createDocument ({
+    projectId,
+    title,
+    bodyText,
+  }) {
+    const payload = CreateDocumentLauncher.createPayload({
+      pathParameterHash: {
+        projectId,
+      },
+      body: {
+        title,
+        bodyText,
+      },
+    })
+
+    const capsule = await this.documentApiLauncher.launchRequest({
+      payload,
+    })
+
+    return {
+      hasError: Boolean(capsule.hasError()),
+      documentId: capsule.extractDocumentId(),
+    }
+  }
+}
+```
+
+- The caller assembles in camelCase (`bodyText`) and pulls the value out with `extractDocumentId()` —
+  nothing more. **It knows nothing of the external API's snake_case or of the response's nesting.** That
+  is what confinement looks like when it is working
+  ([SKILL.md](../SKILL.md#first-principle-confine-every-difference-from-the-external-api-to-payload--capsule-anti-corruption-layer)).
+
+## The caller writes no `try-catch`
+
+`launchRequest()` catches `fetch` exceptions and parse failures internally and converts them into an
+error `Capsule`, so the caller decides failure with `capsule.hasError()` rather than `try-catch`
+([SKILL.md](../SKILL.md#decide-failure-with-capsulehaserror-not-try-catch)).
+
+```js
+// Bad: handling errors through two channels, try-catch and the Capsule (a case falls through)
+try {
+  const capsule = await launcher.launchRequest({ payload })
+  return capsule.extractDocumentId()
+} catch (error) {
+  // launchRequest never lands here. This catch is dead
+}
+```
+
+## DI: inject a stub launcher
+
+Let the class receive the launcher through its `constructor` / `create()`, and use a factory method such
+as `create<Service>Launcher()` as the default. A test can then inject a stub launcher.
+
+- **Why**: a launcher really does hit the external API, so a test cannot call the real one. With DI
+  through a factory, the test gets the stub and production gets the real thing, without the caller
+  changing.
+
+## Hooks (optional): run something before or after sending
+
+Use `launchRequest({ payload, hooks: { beforeRequest, afterRequest } })`. When
+`beforeRequest(payload)` returns `true`, sending is stopped and the aborted-by-hooks `Capsule` is
+returned.

--- a/kit/skills/backend/hb-graphql-schema/SKILL.md
+++ b/kit/skills/backend/hb-graphql-schema/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: hb-graphql-schema
+description: >
+  Author and edit GraphQL SDL (.graphql) files for a renchan server: per-audience schemas loaded
+  via each engine's schemaPath, numbered per-domain files, custom scalars, and the conventions for
+  type and field naming, nullability, enums and pagination. Use this skill whenever the user asks
+  to add or change a GraphQL schema — a new operation, a new type, a new domain file, a scalar, an
+  enum, pagination or sort types — or asks where an SDL definition belongs or what to name a field.
+---
+
+# GraphQL Schema (SDL conventions)
+
+A skill for writing the `.graphql` SDL files that define each audience's GraphQL contract.
+The SDL declares the shape; the behavior behind each field is implemented by
+`hb-query-resolver` / `hb-mutation-resolver`, and input values are checked by
+`hb-resolver-validator`. This skill covers where an SDL definition goes, how it is named, and
+how its fields are typed.
+
+## Grand principle: the SDL is a derived contract — names, nullability, and placement follow mechanical rules, not taste
+
+Every schema decision in this convention can be derived: the operation name drives the
+type names one-to-one (`<Operation>Input` / `<Operation>Result`), non-null `!` is the
+default unless a value is genuinely optional, each business domain gets its own numbered
+file, and each audience keeps its own schema. **Do not invent ad-hoc names,
+nullable-by-default fields, or a shared "misc" file** — a reader who knows the operation
+name must be able to predict the file, the type names, and the nullability without opening
+anything.
+
+- **Why mechanical naming**: resolvers are matched to operations by name
+  (`static get schema()` in `hb-query-resolver` / `hb-mutation-resolver` returns the SDL field
+  name), and JSDoc types reference `<Operation>Input` / `<Operation>Result` directly. One
+  mismatched name breaks the chain from SDL to resolver to type-check.
+- **Why non-null by default**: a nullable field forces every consumer to write a null
+  branch. Reserving nullability for genuinely optional values makes each remaining `?`
+  meaningful — nullability becomes documentation, not noise.
+- **Why per-audience, per-domain files**: audiences (e.g. customer / admin) have different
+  contracts and lifecycles. Merging them, or piling domains into one file, makes it
+  impossible to see which audience a change affects.
+
+```graphql
+# Good: names derived from the operation, non-null by default, deliberate nullability
+type Query {
+  orders(input: OrdersInput!): OrdersResult!
+}
+
+input OrdersInput {
+  pagination: PaginationInput!
+  filters: OrderFiltersInput   # nullable: filters are genuinely optional
+}
+
+type OrdersResult {
+  orders: [OrderSummary!]!
+  pagination: Pagination!
+}
+```
+
+```graphql
+# Avoid: invented payload name, nullable-by-default fields
+#   → the resolver/type chain can no longer be predicted from the operation name,
+#     and every consumer must null-check fields that are never actually null.
+type Query {
+  orders(input: OrdersArgs): OrdersPayload
+}
+
+type OrdersPayload {
+  orders: [OrderSummary]
+  pagination: Pagination
+}
+```
+
+## 1. Where a schema lives and how it loads (check the engine first)
+
+Each audience is loaded by its own `*GraphqlServerEngine.js`, and **how the schema is
+loaded can differ by audience**. Before adding or editing a file, check that audience's
+engine `schemaPath`:
+
+- **Folder path** (e.g. `server/graphql/schemas/customer/`) → the folder's numbered files
+  are merged into one schema at load time. Follow the numbered-file conventions below.
+- **Single file path** (e.g. `server/graphql/schemas/admin.graphql`) → edit that one file.
+  A sibling folder of the same audience name may exist but be **unwired** — adding files
+  there changes nothing until the engine's `schemaPath` points at it.
+
+```js
+// server/graphql/CustomerGraphqlServerEngine.js — the source of truth for what loads
+static get config () {
+  return {
+    // ...existing config...
+    schemaPath: rootPath.to('server/graphql/schemas/customer/'),
+  }
+}
+```
+
+- **Never put a type for one audience in another audience's folder.** Even identical-looking
+  types (e.g. `Pagination`) are declared per audience, because the audiences' contracts
+  evolve independently.
+
+## 2. File organization — numbered, per-domain
+
+A merged-folder audience is split into numbered per-domain files. The first file
+(`001-common.graphql`) holds shared plumbing (scalars, `Pagination`, `Sort`, shared enums);
+every later file is one business domain.
+
+```
+server/graphql/schemas/customer/
+  001-common.graphql          # scalars, Pagination, Sort, shared enums
+  002-auth.graphql
+  003-order.graphql
+  004-billing.graphql
+```
+
+- Filename is `NNN-<domain>.graphql`. Domain casing (kebab-case vs camelCase) can vary
+  between existing files — **match the casing of the sibling files** in the folder you are
+  editing.
+- **One domain per file.** Add a new numbered file for a new domain rather than growing an
+  existing one.
+- All files in the folder are merged at load time, so `type Query` / `type Mutation` may be
+  declared in several files ([4](#4-query--mutation-blocks--colocated-per-domain-file)).
+
+## 3. Custom scalars — declared once, at the top of the common file
+
+Custom scalars are declared **only** in that audience's `001-common.graphql`, at the very
+top, one per line, no `!`:
+
+```graphql
+scalar BigNumber
+scalar DateTime
+scalar Upload
+```
+
+- Do not re-declare a scalar in any other file. Just reference it (`createdAt: DateTime!`).
+- Scalars can differ across audiences — declare only the scalars the audience uses,
+  matching the sibling audiences' style rather than copying their scalar list.
+
+## 4. Query / Mutation blocks — colocated per domain file
+
+Do **not** keep one giant root `Query` / `Mutation`. Each domain file opens its own
+`type Query` and `type Mutation` block listing only that domain's fields; the loader merges
+them.
+
+```graphql
+# 003-order.graphql
+type Query {
+  orders(input: OrdersInput!): OrdersResult!
+  orderDetail(input: OrderDetailInput!): OrderDetailResult!
+}
+
+type Mutation {
+  cancelOrder(input: CancelOrderInput!): CancelOrderResult!
+  archiveDeliveredOrders: ArchiveDeliveredOrdersResult!
+}
+```
+
+- A field with no input takes no argument (`archiveDeliveredOrders: ArchiveDeliveredOrdersResult!`).
+- Every operation returns a non-null payload type (`...Result!`).
+
+## 5. Type naming — `<Operation>Input` and `<Operation>Result`
+
+The operation name drives the type names, one-to-one:
+
+| Kind | Name | Example |
+| --- | --- | --- |
+| Input | `<Operation>Input` | `cancelOrder` → `CancelOrderInput` |
+| Payload | `<Operation>Result` | `orders` → `OrdersResult` |
+
+- Nested / domain object types are plain nouns (`OrderItem`, `ProductImage`, `Status`).
+- Sub-summary types carry a `Summary` suffix (`OrderSummary`).
+- One operation, one input type, one result type — do not share an input or result type
+  between operations even when the shapes currently coincide; shared types couple
+  operations that will diverge.
+
+## 5.1 Field naming — the SDL borrows the database's vocabulary
+
+The SDL does not invent a second vocabulary. A field carries the same name as the column it
+exposes, so renaming a concept is one change across the migration, the model, and the schema.
+
+- Datetime fields end with `At`; date-only fields end with `On`. A range keeps the suffix and
+  adds `From` / `To` (`modifiedAtFrom` / `modifiedAtTo`).
+- **Never expose `updatedAt` / `createdAt`.** They read as the ORM's audit columns, whose timing
+  is a framework detail the application does not own — a migration backfill moves them without any
+  business event. A business time is its own named field: `modifiedAt`, `generatedAt`,
+  `registeredAt`. This is the SDL side of the business-time-vs-audit-time split the database
+  design convention enforces on the column side.
+- A classification field is `xxxCategory`, not `xxxType` — `type` collides with the JSDoc type
+  annotation, so a reader cannot tell whether it means a JavaScript type or a business
+  classification. The shared naming convention lists the one exception: a word borrowed verbatim
+  from an external standard (`mimeType`).
+- A `sort.targetColumn` allow-list uses these same field names, so renaming a field renames the
+  sort key in the same change.
+- **A single-character key is prohibited** — in a field, an argument, or an input type. `q`, `s`,
+  `n`, `p` state nothing about what the value is; name the key for what it holds (`searchQuery`,
+  `sortKey`, `pageNumber`). The SDL is the contract every client reads *before* it reads any code,
+  so a one-letter key costs every consumer a trip into the resolver to learn what to pass, and the
+  generated TypeScript type inherits the same opaque name. Abbreviations are limited to the shared
+  naming convention's whitelist, and no single letter is on it.
+
+```graphql
+# Good: the key states what the value is
+input SearchArticlesInput {
+  searchQuery: String!
+  sortKey: String!
+}
+
+# Avoid: single-character keys — the contract no longer explains itself
+input SearchArticlesInput {
+  q: String!
+  s: String!
+}
+```
+
+## 6. Non-null `!` — the default
+
+`!` is applied to nearly every field and argument. A field is non-null unless the value is
+**genuinely optional**; nullability is deliberate, not the fallback.
+
+```graphql
+type Order {
+  id: Int!
+  customerId: Int              # nullable: guest orders have no customer
+  items: [OrderItem!]!         # non-null list of non-null elements
+  modifiedAt: DateTime!
+}
+```
+
+- Lists are `[T!]!` when the list is required; use `[T!]` only when the whole list is
+  genuinely optional.
+- Optional inputs drop the `!` and carry a short comment stating why the null is allowed
+  (`avatarUrl: String # allow null`).
+- SDL `!` only guards *presence*. Value-level checks (ranges, formats, enum membership)
+  belong to the `hb-resolver-validator` skill — do not weaken the SDL to "validate later",
+  and do not assume `!` makes a validator unnecessary.
+
+## 7. Money / decimal fields — `String!`, decimal-as-string
+
+Money and decimal amounts are typed **`String!`** — not `Float` (loses precision) and not
+`BigNumber` (reserved for non-money large integers such as byte sizes). Resolvers emit them
+via `BigNumber#toFixed(2)`.
+
+```graphql
+type OrderItem {
+  quantity: Int!
+  unitPrice: String! # Decimal as string for precision
+  totalPrice: String!
+}
+```
+
+```js
+// Resolver side: emit decimals as fixed strings
+return {
+  unitPrice: orderItem.unitPrice.toFixed(2),
+  totalPrice: orderItem.totalPrice.toFixed(2),
+}
+```
+
+```graphql
+# Avoid: Float for money → binary floating point corrupts amounts like 0.1 + 0.2
+type OrderItem {
+  totalPrice: Float!
+}
+```
+
+## 8. Pagination type shape
+
+A list query returns its rows plus a `Pagination` object; the input carries a
+`PaginationInput`. Both live in `001-common.graphql`.
+
+```graphql
+type Pagination {
+  limit: Int!
+  offset: Int!
+  sort: Sort
+  totalRecords: Int!
+}
+
+input PaginationInput {
+  limit: Int!
+  offset: Int!
+  sort: SortInput
+}
+
+type OrdersResult {
+  orders: [OrderSummary!]!
+  pagination: Pagination!
+}
+
+input OrdersInput {
+  pagination: PaginationInput!
+  filters: OrderFiltersInput   # optional filters
+}
+```
+
+- `sort` / `SortInput` are **nullable** on the pagination pair; `limit` / `offset` /
+  `totalRecords` are non-null.
+- The `Sort` shape can differ across audiences — match the pagination/sort types already
+  used in the audience folder you are editing; never copy one audience's shape into
+  another.
+- Enums for filters/sort live in the domain file that uses them, or in `001-common` when
+  shared.
+- Validation of `limit` / `offset` / `sort` values on the resolver side is covered by the
+  shared pagination validator in `hb-resolver-validator`.
+- Enums are written **one member per line**, never inline — an inline enum has nowhere to put
+  the per-member comment that explains what the value means, and every added member re-diffs
+  the whole line.
+
+```graphql
+# Good
+enum SortDirection {
+  ASC
+  DESC
+}
+
+# Avoid
+enum SortDirection { ASC DESC }
+```
+
+## 9. Mirror every SDL type into `types/<Audience>GraphQL.d.ts`
+
+Defining a type in the SDL is **only half the job** — declare the matching TypeScript
+interface in the audience's `types/<Audience>GraphQL.d.ts` in the same change. Resolvers
+reference these via JSDoc
+(`@param {{ input: server.graphql.customer.CancelOrderInput }}`,
+`@returns {Promise<server.graphql.customer.OrdersResult>}`), so a type present in
+the SDL but missing from the `.d.ts` fails type-check.
+
+```typescript
+declare global {
+  namespace server.graphql.customer {
+    interface CancelOrderInput {
+      orderId: number
+    }
+
+    interface CancelOrderResult {
+      canceledOrderId: number
+    }
+  }
+}
+```
+
+- Name the interfaces exactly `<Operation>Input` / `<Operation>Result`.
+- Keep fields in sync field-for-field: GraphQL `!` → required property, nullable → `?`.
+
+## 10. Match the surrounding file's style
+
+Section banners and member ordering are per-audience habits, not one global rule — some
+folders use light banners (`# ===== Order Mutation Input Types =====`), others use full
+`#### QUERY` / `#### MUTATION` / `#### TYPE` / `#### INPUT` blocks with dictionary-order
+rules stated in a header comment. **Follow whichever style the surrounding file already
+uses**, including any stated ordering rule.
+
+## Finishing checklist
+
+- [ ] Did you check the audience engine's `schemaPath` before adding a file (merged folder vs single file, and is the folder actually wired)?
+- [ ] Is the definition in the right audience and the right numbered domain file (new domain → new `NNN-<domain>.graphql`, casing matched to siblings)?
+- [ ] Are custom scalars declared only once, at the top of that audience's `001-common.graphql`?
+- [ ] Are the domain's `type Query` / `type Mutation` blocks colocated in the domain file (no giant root block)?
+- [ ] Are the type names exactly `<Operation>Input` / `<Operation>Result`, with plain-noun object types and `Summary` sub-types?
+- [ ] Is `!` the default, with every nullable field genuinely optional (and commented why)? Lists `[T!]!` unless the whole list is optional?
+- [ ] Are money/decimal fields `String!` (emitted via `toFixed(2)`), with `BigNumber` reserved for non-money large integers?
+- [ ] Do list operations use the audience's `Pagination` / `PaginationInput` shape (nullable `sort`, non-null `limit`/`offset`/`totalRecords`)?
+- [ ] Did you mirror every added/changed SDL type into `types/<Audience>GraphQL.d.ts`, field-for-field, in the same change?
+- [ ] Did you match the surrounding file's banner style and any stated ordering rule?

--- a/kit/skills/backend/hb-graphql-server-engine/SKILL.md
+++ b/kit/skills/backend/hb-graphql-server-engine/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: hb-graphql-server-engine
+description: >
+  Implement and wire a GraphQL server engine — a per-endpoint *GraphqlServerEngine class under
+  server/graphql/ that declares one endpoint's URL, schema path, resolver directories, Share and
+  Context DI, auth filter, middleware, scalars and error codes, then is booted in server/index.js.
+  Use whenever the user asks to add a GraphQL endpoint (a new role such as user / admin / portal),
+  pair a stub engine with an actual one, change its auth policy or public-operation allowlist, or
+  enable Redis PubSub.
+---
+
+# GraphQL Server Engine
+
+A skill for the **`*GraphqlServerEngine` classes under `server/graphql/`**. An engine is the one
+object that **wires a single GraphQL endpoint**: its URL and port, which schema and resolver
+directories to load, the Share / Context dependency-injection classes, the authentication filter,
+the Express middleware, the custom scalars, and the error-code hash. `server/index.js` then boots
+**one HTTP server per engine** through `GraphqlServerBuilder`.
+
+The engine sits *above* the pieces other skills build: resolvers (`hb-resolver-validator`
+validates their input), post-workers (`hb-post-worker` run after they resolve),
+and jobs they enqueue (`hb-renchan-job-bullmq`). This skill is about the
+**wiring layer** that mounts all of them onto an endpoint.
+
+> The class names, endpoints, and ports below (`CustomerGraphqlServerEngine`, `/graphql-customer`, …)
+> are **placeholders**; the pattern is the general Renchan convention. Adapt the anchors to whatever
+> roles your project has.
+
+## What an engine configures (the whole surface)
+
+An engine file is the **entry-point configuration** for one API endpoint. Everything it declares is
+one of these settings — nothing more:
+
+| Setting | Member | Section |
+| --- | --- | --- |
+| Endpoint routing (URL, schema / resolver dirs, redis) | `static get config` | [§2](#2-static-get-config--the-endpoints-routing-declaration) |
+| Middleware (cors / json / static / upload / urlencoded) | `collectMiddleware()` | [§6](#6-middleware-scalars-error-codes) |
+| Share / Context DI classes | `static get Share` / `static get Context` | [§3](#3-share-and-context--the-di-the-engine-hands-to-every-resolver) |
+| Custom scalars | `collectScalars()` | [§6](#6-middleware-scalars-error-codes) |
+| Auth policy — the **no-auth (public) operations** + the filter | `schemasToSkipFiltering` + `generateFilterHandler()` | [§4](#4-authentication-schemastoskipfiltering--generatefilterhandler) |
+| Shared error codes | `standardErrorCodeHash` | [§6](#6-middleware-scalars-error-codes) |
+
+**App-common settings are not repeated per engine** — they are lifted into an **app base class**
+(`BaseAppGraphqlServerEngine`) that every engine extends ([§1](#1-two-base-classes-put-app-common-settings-in-an-app-base-and-extend-it)).
+
+## Grand principle: one endpoint = one engine, and the engine only *declares and wires*
+
+Each GraphQL endpoint (a role such as `user` / `admin` / `portal`) gets **exactly one engine class**.
+The engine **holds no business logic** — no DB queries, no response building, no request handling. It
+is a thin **declaration + composition** object: routing config, DI wiring (`Share` / `Context`),
+and cross-cutting policy (auth filter, error mapping, scalars, middleware). All real work lives in
+the resolvers and the context; the engine just points at them.
+
+- **Why a class per endpoint**: each role has its own schema, its own resolver set, its own auth
+  audience, and its own port. Keeping them in separate engine classes means a role's policy changes
+  in one file, and adding a role never edits an existing engine (Open-Closed).
+- **Why no logic in the engine**: the engine is instantiated once at boot and shared across every
+  request. Anything stateful or per-request belongs in `Context` (per request) or `Share` (per
+  process); anything domain-specific belongs in a resolver. An engine that starts doing work becomes
+  a god object that every endpoint's behavior routes through.
+- **Extend the app base, override only what differs.** The shared middleware and error codes live in
+  the app base ([§1](#1-two-base-classes-put-app-common-settings-in-an-app-base-and-extend-it)); a concrete engine should be
+  mostly `config` + `Share` + `Context` + auth policy.
+
+**Comment language**: the `js` examples in this SKILL.md use English comments (matching the framework
+files). In the **engine files you generate** (`*GraphqlServerEngine.js`), keep structural comments in
+English and any domain notes in the surrounding language of the repo — same rule the other skills use.
+
+## 1. Two base classes: put app-common settings in an app base and extend it
+
+There are two layers of base class. The pattern is: **the framework base defines the contract; an
+app base holds the settings shared across your endpoints; each concrete engine extends the app base
+and overrides only what is endpoint-specific.**
+
+| Base | Where | Role |
+| --- | --- | --- |
+| `BaseGraphqlServerEngine` | `@openreachtech/renchan` | The **framework contract**: factory (`create` / `createAsync`), `buildErrorHash`, and the abstract members every engine fills in (`config`, `Share`, `Context`, `collectMiddleware`, `generateFilterHandler`, …). |
+| `BaseAppGraphqlServerEngine` | `server/graphql/BaseAppGraphqlServerEngine.js` | **This app's shared settings** — factor here anything common to every endpoint: the shared `collectMiddleware()` (cors / json / static / upload / urlencoded) and `standardErrorCodeHash`. |
+
+- **When a setting is the same for every endpoint, lift it into the app base.** Middleware and the
+  error-code hash are the usual ones. Each concrete engine then extends `BaseAppGraphqlServerEngine`
+  and declares only the parts that differ per endpoint — `config`, `Share`, `Context`, and the auth
+  policy. This keeps one source of truth for the shared config (Open Reach Tech's DRY / "carve once"
+  stance) and makes a new endpoint a short file.
+- **Only override a shared member to change it** for one endpoint — e.g. the user endpoint overrides
+  `collectMiddleware()` just to raise the body limit to `30mb` ([§6](#6-middleware-scalars-error-codes)).
+- Prefer having the app base hold the shared middleware + error codes and every engine — **stub** and
+  **actual** — extend it. If some engines still extend the framework base directly and repeat those
+  members, migrate them to the app base when you next touch an engine so the shared settings live in
+  one place.
+
+```js
+// Good: a new engine extends the app base and declares only the endpoint-specific parts
+import BaseAppGraphqlServerEngine from './BaseAppGraphqlServerEngine.js'
+import PartnerGraphqlShare from './contexts/PartnerGraphqlShare.js'
+import PartnerGraphqlContext from './contexts/PartnerGraphqlContext.js'
+
+export default class PartnerGraphqlServerEngine extends BaseAppGraphqlServerEngine {
+  /** @override */ static get config () { /* ... §2 ... */ }
+  /** @override */ get schemasToSkipFiltering () { /* ... §4 ... */ }
+  /** @override */ generateFilterHandler () { /* ... §4 ... */ }
+  /** @override */ static get Share () { return PartnerGraphqlShare }
+  /** @override */ static get Context () { return PartnerGraphqlContext }
+  /** @override */ async collectScalars () { /* ... §6 ... */ }
+  // collectMiddleware() / standardErrorCodeHash inherited from the app base
+}
+```
+
+## 2. `static get config` — the endpoint's routing declaration
+
+`config` is the one place the endpoint's URL and file locations are declared. The shape is fixed
+(`GraphqlType.Config`):
+
+| Key | Meaning |
+| --- | --- |
+| `graphqlEndpoint` | The URL path this engine serves (`'/graphql-admin'`). Unique per engine. |
+| `staticPath` | Directory served as static files (`rootPath.to('public/')`). |
+| `schemaPath` | The `.graphql` schema file **or** a directory of them (`server/graphql/schemas/user`). |
+| `actualResolversPath` | Directory of the real resolvers (`.../resolvers/<role>/actual/`), or `null`. |
+| `stubResolversPath` | Directory of stub resolvers (`.../resolvers/<role>/stub/`), or `null`. |
+| `postWorkersPath` | Directory of post-workers, or `null` when unused ([§7](#7-post-resolve-hooks-defineonresolved--postworkerspath)). |
+| `redisOptions?` | Redis connection for subscription PubSub; omit / `null` → in-process `LocalPubSub` ([§5](#5-stub-vs-actual-engines-and-subscriptions-redis-vs-local)). |
+
+```js
+// Good: config is a pure routing declaration; paths via rootPath.to(), redis resolved in env
+import { rootPath, env } from '../../app/globals/_.js'
+
+/** @override */
+static get config () {
+  return {
+    graphqlEndpoint: '/graphql-customer',
+    staticPath: rootPath.to('public/'),
+    schemaPath: rootPath.to('server/graphql/schemas/customer'),
+    actualResolversPath: rootPath.to('server/graphql/resolvers/customer/actual/'),
+    stubResolversPath: rootPath.to('server/graphql/resolvers/customer/stub/'),
+    postWorkersPath: rootPath.to('server/graphql/post-workers/customer/'),
+    redisOptions: {
+      host: env.REDIS_HOST,
+      port: env.REDIS_PORT,
+    },
+  }
+}
+```
+
+- **Always resolve paths with `rootPath.to(...)`** (`app/globals/root-path.js`),
+  never hand-built relative strings.
+- **`graphqlEndpoint` must be unique** across all engines (each maps to its own path + port in
+  `server/index.js`, [§8](#8-wiring-into-serverindexjs)).
+- **Keep `config` a pure declaration — never put logic in the getter.** Resolve the redis connection
+  in the **`env` layer**: `env.redisOptions` returns `{ host, port }` on staging / live and `null` in
+  dev (no Redis), so the getter just references it. Dev then falls back to `LocalPubSub`; staging /
+  live opt in via environment. Do **not** branch inside `config` (`env.REDIS_HOST ? { … } : null`) —
+  a getter must return a value, not compute one.
+
+## 3. `Share` and `Context` — the DI the engine hands to every resolver
+
+Two static getters name the DI classes this endpoint uses. The framework instantiates them and
+threads them into every resolver call.
+
+- **`static get Share`** → the per-**process** shared object (`Base…GraphqlShare`). Built once at boot
+  (`createAsync`), it holds process-wide clients (`env`, the subscription `broker`, external clients,
+  a `jobDispatcherProvider`, …). This is what `hb-post-worker` reaches through
+  `context.share` to dispatch jobs.
+- **`static get Context`** → the per-**request** object (`Base…GraphqlContext`). Built for each request
+  from the access token; it exposes the authenticated principal (`context.admin` / `context.userId`)
+  and the **visa** the auth filter reads ([§4](#4-authentication-schemastoskipfiltering--generatefilterhandler)).
+
+```js
+// Good: the engine only names the classes; the classes hold the DI
+/** @override */ static get Share () { return AdminGraphqlShare }
+/** @override */ static get Context () { return AdminGraphqlContext }
+```
+
+- **Each endpoint pairs its own Share + Context** (`Admin*` with `Admin*`); do not share one role's
+  Context with another endpoint — the principal and permissions differ.
+- The Share / Context implementations themselves (findUser, visa issuing, extra clients) are their own
+  concern; this skill only wires them onto the engine. (See the `contexts/` classes such as
+  `AdminGraphqlContext.js` /
+  `AdminGraphqlShare.js`.)
+
+## 4. Authentication: `schemasToSkipFiltering` + `generateFilterHandler`
+
+Every operation on the endpoint runs through the engine's **filter handler** before its resolver —
+**except** operations named in `schemasToSkipFiltering`. This pair *is* the endpoint's auth policy.
+
+- **`get schemasToSkipFiltering`** → an **allowlist of public operation names** (GraphQL field names)
+  that skip the filter entirely: `signIn`, `resetPassword`, sign-up, unauthenticated public reads.
+  Default is `[]` (everything is filtered).
+- **`generateFilterHandler()`** → returns `async ({ variables, context, information, parent }) => {}`.
+  It reads the operation name from `information.fieldName` and gates it through the request
+  `context`'s **visa**, throwing the matching error from `this.errorHash` on failure.
+
+```js
+// Good: the standard four-step gate (per-operation allow → authn → authz → per-schema permission)
+/** @override */
+get schemasToSkipFiltering () {
+  return [
+    'signIn',
+    'resetPassword',
+    'generatePasswordResetUrl',
+    'generateAccessTokenByOAuthCode',
+  ]
+}
+
+/** @override */
+generateFilterHandler () {
+  return async ({ variables, context, information, parent }) => {
+    const schema = information.fieldName
+
+    // A per-operation visa grant (e.g. owner of the record) short-circuits the rest.
+    if (context.canResolve({ schema })) {
+      return
+    }
+
+    if (!context.hasAuthenticated()) {
+      throw this.errorHash.Unauthenticated.create()
+    }
+
+    if (!context.hasAuthorized()) {
+      throw this.errorHash.Unauthorized.create()
+    }
+
+    if (!context.hasSchemaPermission({ schema })) {
+      throw this.errorHash.DeniedSchemaPermission.create({ value: { schema } })
+    }
+  }
+}
+```
+
+- **The four checks are a fixed ladder**: `canResolve` (a visa grant issued for this operation) →
+  `hasAuthenticated` (a valid principal) → `hasAuthorized` (the principal is active/allowed) →
+  `hasSchemaPermission` (this principal may call this specific operation). Each reads `context.visa`;
+  keep the order and the early returns.
+- **`schemasToSkipFiltering` is security-critical.** An entry here is **fully public**. Only put
+  genuinely unauthenticated operations in it; never place a sensitive mutation there to "make it
+  work". Conversely, a public operation missing from the list will 401. This is exactly check #3 of
+  `hb-security-audit` — every operation authenticated unless intentionally public.
+- **Do not do real work in the filter.** It decides allow/deny from the visa only; it must not run
+  business queries or mutate state.
+
+```js
+// Avoid: an empty filter on a NON-stub engine — disables auth for the whole endpoint
+/** @override */
+generateFilterHandler () {
+  return async () => {} // every operation now unauthenticated. Only stub engines may do this (§5).
+}
+```
+
+## 5. Stub vs actual engines (and subscriptions: Redis vs Local)
+
+Each role is served by **two** engines on **two ports**:
+
+| Kind | Extends | Resolvers | Auth filter | Purpose |
+| --- | --- | --- | --- | --- |
+| **actual** | (app base) | `actualResolversPath` → real resolvers | the real four-step gate | production behavior |
+| **stub** | app base | `actualResolversPath` **points at the stub dir** | `generateFilterHandler` returns a **noop** | frontend/dev fixtures without auth |
+
+- A stub engine is a thin copy with a different `graphqlEndpoint` (`…-stub`), its
+  `actualResolversPath` set to the **stub** resolver directory, and an **auth-disabled** filter
+  (`return async () => {}`, `schemasToSkipFiltering: []`). It exists so the frontend can develop
+  against canned data. **Auth-off is acceptable only because a stub serves fake data on a separate
+  port** — never ship a stub engine's config on a real endpoint.
+- **Subscriptions PubSub**: when `config.redisOptions` is set, progress/subscription events go through
+  **Redis PubSub** (required when a separate process — e.g. the job daemon — publishes to
+  subscribers, see `hb-renchan-job-bullmq` §4). When it is `null`, the
+  engine uses an in-process `LocalPubSub` — fine for dev and single-process endpoints. Enable Redis on
+  the endpoints whose subscriptions are fed by another process.
+
+## 6. Middleware, scalars, error codes
+
+The remaining overrides are cross-cutting endpoint policy:
+
+- **`collectMiddleware()`** → the Express middleware array (cors, `express.json({ limit })`,
+  `express.static`, the upload middleware, `express.urlencoded` capturing `rawBody`). Inherit it from
+  the app base; only override to change a limit (e.g. the user endpoint raises the body limit to
+  `30mb` for uploads).
+- **`async collectScalars()`** → the custom GraphQL scalars this endpoint exposes
+  (`DateTimeScalar`, `BigNumberScalar`). Return only what the schema uses.
+- **`static get standardErrorCodeHash`** → maps the framework error names (`Unauthenticated`,
+  `Unauthorized`, `DeniedSchemaPermission`, `Database`, `Unknown`, `ConcreteMemberNotFound`) to this
+  app's numeric codes. Inherit from the app base; the engine's `this.errorHash` (used in §4) is built
+  from it.
+- **`passesThoughError()`** (default: true in pre-production) lets raw errors through outside
+  production and maps them to `errorHash` codes in production — do not disable error mapping in prod.
+
+```js
+// Good: only override middleware to change a limit; otherwise inherit from the app base
+/** @override */
+collectMiddleware () {
+  return [
+    cors({ origin: '*' }),
+    express.json({ limit: '30mb' }), // this endpoint accepts large uploads
+    express.static(this.config.staticPath),
+    graphqlUploadExpressWithResolvingContentType({ maxFileSize: 10000000, maxFiles: 10 }),
+    express.urlencoded({ extended: true, verify: (req, res, body) => { req['rawBody'] = body.toString() } }),
+  ]
+}
+```
+
+## 7. Post-resolve hooks: `defineOnResolved` + `postWorkersPath`
+
+Two ways to run something *after* a resolver returns, both wired on the engine:
+
+- **`config.postWorkersPath`** → a directory of per-operation post-workers, auto-loaded and matched by
+  operation name. This is how `hb-post-worker` fires. `null` → post-workers never
+  run. Set it to `server/graphql/post-workers/<role>/` to enable them for the endpoint.
+- **`defineOnResolved()`** → an **engine-wide** (all operations) after-resolve hook; default noop. Use
+  it for a cross-cutting after-hook; use a `postWorkersPath` post-worker for a **specific** operation.
+  The same "dispatch only, no heavy logic" rule as post-worker applies.
+
+## 8. Wiring into `server/index.js`
+
+An engine does nothing until it is booted. `server/index.js` starts **one
+HTTP server per engine** with `GraphqlServerBuilder`, each on its own port:
+
+```js
+// Good: register the new engine — import it, build, and listen on a free port
+import PartnerGraphqlServerEngine from './graphql/PartnerGraphqlServerEngine.js'
+
+GraphqlServerBuilder.createAsync({
+  Engine: PartnerGraphqlServerEngine,
+})
+  .then(builder =>
+    builder.buildHttpServer()
+      .listen(6000)
+  )
+```
+
+An endpoint → port layout looks like this (roles, paths, and ports are illustrative — use your own):
+
+| Engine | `graphqlEndpoint` | Port (example) |
+| --- | --- | --- |
+| `CustomerGraphqlServerEngine` | `/graphql-customer` | 4000 |
+| `StubCustomerGraphqlServerEngine` | `/graphql-customer-stub` | 4001 |
+| `AdminGraphqlServerEngine` | `/graphql-admin` | 4100 |
+| `StubAdminGraphqlServerEngine` | `/graphql-admin-stub` | 4101 |
+
+- `createAsync({ Engine })` calls the engine's `createAsync`, which builds the `Share`
+  (`Share.createAsync({ config })`) and constructs the engine; `buildHttpServer().listen(port)` mounts
+  it. **Adding an endpoint = new engine file + these ~6 lines**; forgetting the second step means the
+  engine is dead code.
+- **Pick a unique port** not already used by another engine (including any non-GraphQL engine, such
+  as a REST server).
+- Pair the actual engine with its stub engine here too (both get their own `createAsync` + `listen`).
+
+## Finishing checklist
+
+- [ ] One engine per endpoint, extending the **app base** ([§1](#1-two-base-classes-put-app-common-settings-in-an-app-base-and-extend-it)); no duplicated middleware / error hash unless the endpoint truly differs.
+- [ ] The engine is **declaration + wiring only** — no DB queries, no response building, no per-request state in the engine.
+- [ ] `config` has a **unique `graphqlEndpoint`**, `rootPath.to(...)` paths for schema / resolvers, and `redisOptions` from `env` (or `null`) ([§2](#2-static-get-config--the-endpoints-routing-declaration)).
+- [ ] `static get Share` / `static get Context` name **this role's own** Share + Context ([§3](#3-share-and-context--the-di-the-engine-hands-to-every-resolver)).
+- [ ] `schemasToSkipFiltering` lists **only genuinely public** operations; the filter runs the four-step visa gate; **no real work** in the filter ([§4](#4-authentication-schemastoskipfiltering--generatefilterhandler)).
+- [ ] A **stub** engine (if added) points `actualResolversPath` at the stub dir and uses a **noop** filter — and never leaks that config onto a real endpoint ([§5](#5-stub-vs-actual-engines-and-subscriptions-redis-vs-local)).
+- [ ] Redis PubSub enabled on endpoints whose subscriptions are published by **another process** ([§5](#5-stub-vs-actual-engines-and-subscriptions-redis-vs-local)).
+- [ ] `postWorkersPath` set when the endpoint needs post-workers (`null` disables them) ([§7](#7-post-resolve-hooks-defineonresolved--postworkerspath)).
+- [ ] Engine **registered in `server/index.js`** with a unique port ([§8](#8-wiring-into-serverindexjs)).

--- a/kit/skills/backend/hb-light-rag/SKILL.md
+++ b/kit/skills/backend/hb-light-rag/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: hb-light-rag
+description: >
+  Add lightweight retrieval-augmented generation (RAG) for AI-agent documents in a renchan backend
+  without a vector database — a vector-first / LLM-fallback pipeline that ranks stored Document
+  rows with an offline local embedder, plus a MySQL/MariaDB BOOLEAN-mode n-gram fulltext builder
+  for keyword search. Use whenever the user asks to add or tune document retrieval for an agent,
+  generate or store embeddings, or change how background knowledge is assembled into the prompt.
+---
+
+# Light RAG (vector-first / LLM-fallback document retrieval, no vector DB)
+
+This backend does RAG "lightly" — no external vector database, no heavy embedding service. Documents live as
+`Document` rows; a **local, offline embedder** produces small vectors stored in `DocumentEmbedding`;
+retrieval ranks them with **in-app cosine** and falls back to an **LLM-driven id selection** when vectors
+find nothing. A separate n-gram fulltext builder exists for generic MySQL/MariaDB keyword search.
+
+## Grand principle: size the retrieval to the corpus — local vectors first, LLM fallback, no vector DB
+
+For an agent's own document set (tens–hundreds of docs), a vector database is overkill. Rank a small set of
+**offline-precomputed local vectors** with cosine in the app; only when that yields nothing, ask the model
+to pick document ids from a metadata catalog.
+
+- **Why a local, dependency-free embedder**: `LocalTextEmbedder` hashes word tokens + CJK n-grams into a
+  fixed 256-dim L2-normalized vector — no network, no API cost, works offline, and (being normalized)
+  cosine is just a dot product. It matches surface forms well; true semantic paraphrase is its weakness, so
+  the interface can be swapped for a real embedding provider later without changing callers.
+- **Why vector-first, LLM-fallback**: the vector path is cheap and deterministic; it wins whenever it
+  returns a non-empty selection. Any empty result (feature disabled, no embeddings yet, all below the score
+  floor, empty token budget) falls through to the LLM fetcher, which reads a metadata-only catalog and calls
+  one constrained tool to choose ids. You get cheap-and-fast normally, model-smart when needed.
+- **Why BASE vs DYNAMIC documents**: a `DocumentAttachmentCategory` of `BASE_KNOWLEDGE` inlines the full
+  body into every prompt (small, always-relevant docs); `DYNAMIC_DOCUMENT` puts only catalog/skill metadata
+  in the prompt and fetches the body **on demand** when selected. This keeps the prompt small while still
+  covering a large dynamic corpus.
+- **Why embeddings are offline**: generating a vector is a background job (`DocumentEmbeddingJob`), so the
+  online request only *reads* precomputed vectors — retrieval stays fast and never blocks on embedding.
+
+## Two retrieval families (mostly independent)
+
+| Family | What it retrieves | Where |
+| --- | --- | --- |
+| **Document RAG** (this skill's core) | agent documents (`Document` bodies) for background knowledge | `DynamicDocumentVectorSelector` + `DynamicDocumentsBackgroundKnowledgeFetcher`, meeting at `AiAgentBaseKnowledgeAssembler` |
+| **N-gram fulltext** | generic keyword rows via `MATCH ... AGAINST` | `NgramSearchWordGenerator` + `FullTextSearchConditionGenerator` |
+
+> Record search over CRM data (not documents) goes through Elasticsearch
+> (`app/ReplicaFragments/OriginObjectReplicaFragmentClient.js`) and is a **separate subsystem** — see the
+> `hb-ai-agent-structure` skill's execute step. Because *document* search is not on Elasticsearch and there is no
+> tokenized-document table, the document-RAG path deliberately uses pure local cosine (no lexical/RRF
+> channel).
+
+## 1. Offline embedding — `LocalTextEmbedder` + `DocumentEmbeddingJob`
+
+`LocalTextEmbedder` (in `app/tools/embedding/`) is self-contained (no imports):
+
+- `DIMENSION = 256`, `MODEL_VERSION = 'local-hash-ngram-v1'` (persisted with each vector to guard drift).
+- `#generateTokens(text)` — NFKC-lowercase, then three token sets: word tokens (`w:`), CJK ideograph
+  unigrams (`u:`), and 2/3-gram character grams (`g:`).
+- `#generateEmbedding(text)` — bucket tokens by `FNV-1a hash % 256`, count collisions, L2-normalize →
+  `Float32Array`.
+- `#calculateCosineSimilarity(a, b)` — dot product (vectors are pre-normalized).
+- `.serializeVector()` / `.deserializeVector()` — JSON ↔ `Float32Array`.
+
+`DocumentEmbeddingJob` (a renchan-job-bullmq job; see that skill) generates vectors ahead of time:
+
+```js
+async execute (payload) {
+  const document = await this.findDocument(payload)
+  const sourceText = this.generateEmbeddingSourceText({ document })  // name + description + content
+  const vector = this.embedder.generateEmbedding(sourceText)
+
+  return DocumentEmbedding.upsert(
+    {
+      DocumentId: document.id,
+      embedding: LocalTextEmbedder.serializeVector(vector),
+      embeddingModelVersion: LocalTextEmbedder.MODEL_VERSION,
+      embeddingDimension: LocalTextEmbedder.DIMENSION,
+      savedAt: this.generateCurrentDatetime(),
+    },
+    {
+      conflictFields: ['document_id'],
+    }
+  )
+}
+```
+
+The online selector only *reads* `DocumentEmbedding`; it never embeds documents.
+
+## 2. Vector path — `DynamicDocumentVectorSelector`
+
+The primary retrieval. Constants: `TOP_K = 8`, `MINIMUM_VECTOR_SCORE = 0.01`,
+`DEFAULT_MAX_TOTAL_TOKEN_COUNT = 50000` (overridable by env). The pass returns `''` at any empty step so the
+assembler can fall back:
+
+1. `#extractEligibleDocumentPrimaryKeys(...)` — the agent's DYNAMIC assignments whose document has a
+   COMPLETE skill-generation outcome; `''` if none.
+2. `#loadDocumentEmbeddings(...)` — `DocumentEmbedding` rows for those ids; `''` if none.
+3. `queryVector = this.embedder.generateEmbedding(taskInstructionText)`.
+4. `#generateVectorScores(...)` — cosine of the query vs each stored vector.
+5. rank desc → `.filter(score >= MINIMUM_VECTOR_SCORE)` → `.slice(0, TOP_K)`; `''` if empty.
+6. `#loadDocumentTokenCounts(...)` — estimate tokens per doc (whitespace split of name+description+content).
+7. `#limitDocumentPrimaryKeysToTokenBudget(...)` — greedy accumulate within the budget (always keep the
+   single top-ranked doc even if it alone exceeds it); `''` if empty.
+8. `#fetchPrefetchedDynamicDocumentsPayload(...)` — `RetrieveDynamicDocumentsProcessor.process(...)` → the
+   documents-by-id XML.
+
+The token-budget reduce:
+
+```js
+const selection = rankedScores.reduce(
+  (accumulated, score) => {
+    const documentTokenCount = tokenCountByDocumentId.get(score.documentId)
+      ?? 0
+    const projectedTotalTokenCount = accumulated.totalTokenCount + documentTokenCount
+    const isFirstDocument = accumulated.documentIds.length === 0
+    const shouldKeepDocument = isFirstDocument
+      || projectedTotalTokenCount <= maxTotalTokenCount
+
+    const accumulatedWithDocument = {
+      documentIds: [
+        ...accumulated.documentIds,
+        score.documentId,
+      ],
+      totalTokenCount: projectedTotalTokenCount,
+    }
+
+    return shouldKeepDocument
+      ? accumulatedWithDocument
+      : accumulated
+  },
+  {
+    documentIds: [],
+    totalTokenCount: 0,
+  }
+)
+```
+
+## 3. LLM fallback — `DynamicDocumentsBackgroundKnowledgeFetcher`
+
+When the vector path returns `''`, the assembler calls the LLM fetcher: it builds a **metadata-only
+catalog** (`DynamicDocumentCatalogSectionBuilder`), sends **one constrained AI turn** forcing the
+`retrieve_dynamic_documents` tool (`isAutoHandleFunctionCall: false`,
+`shouldPrefetchDynamicDocumentsForBackground: false` to prevent recursion), extracts and normalizes the
+returned `documentIds`, intersects them with the eligible set (order preserved), and fetches bodies through
+the same `RetrieveDynamicDocumentsProcessor`. The processor loads `Document` rows by id and emits
+`<retrieve_dynamic_documents_result>` XML (id list + `{ document_id, document_title, document_body }` per
+doc, missing ids omitted). Both paths therefore produce the **same XML shape**.
+
+## 4. The combination seam — `AiAgentBaseKnowledgeAssembler`
+
+`.createAsync(...)` coordinates it. It **short-circuits with an empty dynamic section unless the caller
+sets `shouldPrefetchDynamicDocumentsForBackground: true`** (set by the AI-generation jobs / the document
+mutation). When prefetch is on, `#resolvePrefetchedDynamicDocumentsBackgroundSectionAsync(...)` is the
+vector-first / LLM-fallback core:
+
+```js
+const vectorSection = this.isDynamicDocumentVectorSelectionEnabled()
+  ? await dynamicDocumentVectorSelector.fetchPrefetchedDynamicDocumentsBackgroundSectionAsync({
+      aiAgentDocumentAssignments,
+      employeeId,
+      employeeRoleIds,
+      taskInstructionText,
+    })
+  : ''
+
+if (vectorSection.trim().length > 0) {
+  return vectorSection
+}
+
+return this.fetchPrefetchedDynamicDocumentsBackgroundSectionViaLlmAsync({
+  aiAgentDocumentAssignments,
+  employeeId,
+  employeeRoleIds,
+  taskInstructionText,
+  dynamicDocumentsBackgroundKnowledgeFetcher,
+})
+```
+
+The assembler then builds the final background block: runtime datetime + **BASE-knowledge docs (full bodies
+inlined)** + the **dynamic-documents section** (only when the prefetched section is non-empty, CDATA-wrapped;
+the catalog is never duplicated into the final prompt). BASE vs DYNAMIC is decided by
+`DocumentAttachmentCategoryId === DOCUMENT_ATTACHMENT_CATEGORY.BASE_KNOWLEDGE.ID`. This background block is
+part 1 of the composed instruction — see the **`hb-ai-prompt-document-store` skill**.
+
+## 5. N-gram fulltext (generic keyword search)
+
+Independent of document RAG. `NgramTextTokenizer` (uses the `ngram` package) makes 2/3-gram tokens for
+Japanese text (detected via a CJK regex) and passes non-Japanese text through unchanged.
+`NgramSearchWordGenerator` builds a MySQL/MariaDB BOOLEAN-mode `AGAINST` string, and
+`FullTextSearchConditionGenerator` wraps it into a clause:
+
+```js
+// NgramSearchWordGenerator#formatTokenGroups: AND requires each group, OR space-joins them
+const formattedGroups = tokenGroups.map(tokens =>
+  `(${tokens.map(token => `+${token}`).join(' ')})`
+)
+
+return this.logicalOperator === 'or'
+  ? formattedGroups.join(' ')
+  : formattedGroups.map(group => `+${group}`).join(' ')
+
+// FullTextSearchConditionGenerator#generateCondition (null when the against text is empty):
+`MATCH (${matchColumnNames}) AGAINST ('${againstText}' IN BOOLEAN MODE)`
+```
+
+AND → `+apple +banana`; OR → `apple banana`. Use this for generic fulltext filtering, not for agent
+document RAG.
+
+## Models
+
+| Model (table) | Key columns | Role |
+| --- | --- | --- |
+| `Document` (`documents`) | `name`, `description`, `content` (the RAG body) | the document; `BackupMixinModel` → `DocumentBk` |
+| `DocumentEmbedding` (`document_embeddings`) | `DocumentId`, `embedding` (JSON vector), `embeddingModelVersion`, `embeddingDimension`, `savedAt` | one vector per document (upsert on `document_id`) |
+| `DocumentAttachmentCategory` | `name`, `displayName`, `displayOrder` | `BASE_KNOWLEDGE {ID:1}` (inline body) vs `DYNAMIC_DOCUMENT {ID:2}` (catalog + on-demand body) |
+| `AiAgentDocumentAssignment` | `AiAgentId`, `DocumentId`, `DocumentAttachmentCategoryId` (default 1), `order` | binds a document to an agent; `order` drives assembly sort |
+
+Eligibility for the DYNAMIC path also requires a COMPLETE `DocumentSkillGenerationOutcome`. See the
+**`hb-ai-prompt-document-store` skill** for the full model set, migrations, and seeders, and the
+**sequelize-model / sequelize-migration skills** for how to declare them.
+
+## Env flags
+
+| Env var | Read at | Default | Effect |
+| --- | --- | --- | --- |
+| `IS_DYNAMIC_DOCUMENT_VECTOR_SELECTION_ENABLED` | `AiAgentBaseKnowledgeAssembler` | enabled (only the literal `'false'` disables) | gate the vector-first path; disabled → straight to LLM fetcher |
+| `DYNAMIC_DOCUMENT_VECTOR_SELECTION_MAX_TOKEN_COUNT` | `DynamicDocumentVectorSelector` | `50000` (used if unset / non-finite / ≤ 0) | cap total estimated tokens of selected dynamic bodies |
+
+## Cross-cutting rules
+
+- **Embed offline, retrieve online** — never embed a document in the request path.
+- **Every empty step returns `''`** so the vector→LLM fallback composes cleanly; never throw to signal
+  "nothing found".
+- **Keep the embedder interface swappable** — callers depend on `#generateEmbedding` /
+  `#calculateCosineSimilarity`, not on the hashing internals.
+- Return `null` / `''` for missing values, not `undefined`; one class per file, `static create()` factory.
+
+## Detail files
+
+- [retrieval-internals.md](./references/retrieval-internals.md) — `LocalTextEmbedder` tokenization and
+  hashing in full, the vector selector step methods, the LLM fetcher's catalog + constrained tool turn, the
+  `RetrieveDynamicDocumentsProcessor` XML, and the n-gram tokenizer / fulltext builder details.

--- a/kit/skills/backend/hb-light-rag/references/retrieval-internals.md
+++ b/kit/skills/backend/hb-light-rag/references/retrieval-internals.md
@@ -1,0 +1,143 @@
+# Retrieval internals (embedder, selectors, processor, n-gram)
+
+Referenced from `SKILL.md`. The exact internals behind the vector-first / LLM-fallback document RAG and the
+n-gram fulltext builder.
+
+## `LocalTextEmbedder` (`app/tools/embedding/LocalTextEmbedder.js`)
+
+Self-contained, no imports. Turns text into a fixed-dim L2-normalized vector so cosine == dot product.
+
+- `DIMENSION = 256`, `MODEL_VERSION = 'local-hash-ngram-v1'`.
+- `.generateHash(token)` — FNV-1a 32-bit: seed `0x811c9dc5`, per char `Math.imul(hash ^ charCode,
+  0x01000193)`, returned `>>> 0`.
+- `#generateTokens(text)` — NFKC + lowercase, then:
+  - **word tokens**: `text.split(/[^0-9a-zÀ-ɏ]+/u)`, keep length ≥ 2, prefix `w:`.
+  - **ideograph unigrams**: from whitespace-stripped `compactText`, chars with codepoint ≥ `0x3400`, prefix
+    `u:`.
+  - **character grams**: sliding windows of size `[2, 3]` over `compactText`, prefix `g:`.
+- `#generateEmbedding(text)`:
+
+```js
+const bucketCounts = this.generateTokens(text).reduce(
+  (counts, token) => {
+    const bucketIndex = Ctor.generateHash(token) % dimension
+
+    counts.set(bucketIndex, (counts.get(bucketIndex) ?? 0) + 1)
+
+    return counts
+  },
+  new Map()
+)
+
+const rawVector = Array.from({ length: dimension }, (each, index) => bucketCounts.get(index) ?? 0)
+const sumOfSquares = rawVector.reduce((sum, value) => sum + value * value, 0)
+const norm = Math.sqrt(sumOfSquares) || 1
+
+return Float32Array.from(rawVector, value => value / norm)
+```
+
+- `#calculateCosineSimilarity(vectorA, vectorB)` — `vectorA.reduce((sum, value, index) => sum + value *
+  vectorB[index], 0)` (dot product; both are pre-normalized).
+
+The `Map` here is a local accumulator inside one method (a legitimate collection use), not per-instance
+mutable state.
+
+## `DynamicDocumentVectorSelector` step methods
+
+`#fetchPrefetchedDynamicDocumentsBackgroundSectionAsync(...)` runs the 8 steps in `SKILL.md`; the helpers:
+
+- `#extractEligibleDocumentPrimaryKeys(...)` → delegates to
+  `DynamicDocumentCatalogSectionBuilder#extractEligibleDynamicDocumentPrimaryKeys` (DYNAMIC assignments with
+  a `Document` whose `DocumentSkillGenerationOutcome` is COMPLETE).
+- `#loadDocumentEmbeddings(...)` → `DocumentEmbedding.findAll({ where: { DocumentId: { [Op.in]: ids } } })`.
+- `#generateVectorScores(...)` → per row `{ documentId, score: embedder.calculateCosineSimilarity(query,
+  LocalTextEmbedder.deserializeVector(row.embedding)) }`.
+- `#rankVectorScores(...)` → sort by descending `score`.
+- `#loadDocumentTokenCounts(...)` → load `id, name, description, content`, return `Map<id,
+  estimatedTokenCount>`.
+- `#estimateDocumentTokenCount(...)` → join name+description+content with `\n`, split on `/\s+/u`, count
+  non-empty (a dependency-free proxy — do not confuse with `tiktoken`).
+- `#limitDocumentPrimaryKeysToTokenBudget(...)` → the greedy reduce in `SKILL.md` (always keep the top-ranked
+  doc).
+- `#fetchPrefetchedDynamicDocumentsPayload(...)` → `RetrieveDynamicDocumentsProcessor.process({ contextHint:
+  null, documentIds, extraToolOptions: { employeeId, employeeRoleIds } })`.
+
+`.MAX_TOTAL_TOKEN_COUNT` reads `process.env.DYNAMIC_DOCUMENT_VECTOR_SELECTION_MAX_TOKEN_COUNT`, falling back
+to `DEFAULT_MAX_TOTAL_TOKEN_COUNT = 50000` when not finite or ≤ 0.
+
+## `DynamicDocumentsBackgroundKnowledgeFetcher` (LLM fallback)
+
+- Provider→tool-id map: `.retrieveDynamicDocumentsAiToolIdsByProvider` → `{ claude, gemini, openai }` from
+  `CONTEXT_ASSEMBLER_DYNAMIC_DOCUMENT.AI_TOOL.RETRIEVE_DYNAMIC_DOCUMENTS_*.ID`; tool name
+  `'retrieve_dynamic_documents'`.
+- `#buildDynamicDocumentSelectionArguments(...)` — resolve eligible keys, load the prefetch worker agent
+  (`AiAgent.findByPk(DEFAULT_AI_AGENT.AI_AGENT_FOR_DYNAMIC_DOCUMENT_BODY_PREFETCH.ID, { include: [...] })`),
+  pick the processor by its default model (see the `hb-multi-llm-provider` skill), resolve the provider-specific
+  `AiTool` id, `JSON.parse` its `payload`, build the metadata catalog + instruction.
+- `#sendDynamicDocumentSelectionRequestAsync(...)` — one `processor.sendRequestToAi(...)` with
+  `toolChoices: [{ name: 'retrieve_dynamic_documents' }]`, `isAutoHandleFunctionCall: false`,
+  `shouldPrefetchDynamicDocumentsForBackground: false` (recursion guard).
+- `#extractRetrieveDynamicDocumentsFunctionCall(...)` → `#normalizeRetrieveToolInvocationDocumentIds(...)`
+  (`arguments.documentIds` → `Number`s) → `#filterDocumentPrimaryKeysToCatalogSubset(...)` (intersect with
+  the eligible set, order preserved) → `''` if empty, else fetch the payload.
+- The instruction (`#buildDynamicDocumentBodyPrefetchInstruction`) lists the allowed `document_id` values
+  and requires exactly one tool call returning a non-empty integer array.
+
+## `DynamicDocumentCatalogSectionBuilder`
+
+Builds the `<dynamic_document_catalog>` metadata block (no bodies) and the shared eligibility rule
+(`#extractEligibleDynamicDocumentPrimaryKeys`, used by **both** selectors): an assignment must be DYNAMIC
+category, have a `Document`, and that document's skill-generation outcome must be COMPLETE
+(`DocumentSkillGenerationStatusId === DOCUMENT_SKILL_GENERATION_STATUS.COMPLETE.ID`).
+
+## `RetrieveDynamicDocumentsProcessor` (retrieval leaf)
+
+`#get:aiToolName` = `'retrieve_dynamic_documents'`. `#process(...)` validates → normalizes ids →
+`Document.findAll({ where: { id: { [Op.in]: ids } } })` → maps by PK → emits, in request order (missing ids
+omitted):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<retrieve_dynamic_documents_result>
+  <document_ids>
+    <document_id>{id}</document_id>
+  </document_ids>
+  <documents>
+    <document>
+      <document_id>{id}</document_id>
+      <document_title>{escaped name}</document_title>
+      <document_body>{escaped content}</document_body>
+    </document>
+  </documents>
+</retrieve_dynamic_documents_result>
+```
+
+(Phase-1 note in the code: per-document ACL is intentionally omitted here and restored later; documents are
+returned by id in request order.) The assembler CDATA-wraps this XML into the background block.
+
+## N-gram tokenizer and fulltext builder
+
+`NgramTextTokenizer` (`app/tools/TextTokenizer/`) — uses the `ngram` package.
+
+- `.create()` defaults `minNgram = 2, maxNgram = 3`; `.createAsync()` defaults `minNgram = 2, maxNgram = 2`.
+- `#isJapaneseText({ text })` — resets `REGEX.JAPANESE.lastIndex` then `.test(text)`; the regex covers
+  hiragana/katakana/kanji/fullwidth forms and select symbols.
+- `#tokenizeSentence(sentence)` — `''` for empty; **returns non-Japanese text unchanged**; else
+  `[...new Set(this.tokenizer.ngram(sentence, minNgram, maxNgram))].join(' ')`.
+
+`NgramSearchWordGenerator` (`app/tools/FullTextSearch/NgramSearchKeywordGenerator.js` — class name differs
+from the filename):
+
+- `.create()` defaults `nGramLength = 2, logicalOperator = 'and'`.
+- `#splitToWords()` — replace BOOLEAN-mode operator chars `/[+\-*()<>~'"@[\]{}]/ug` with spaces, split on
+  `/\s+/u`.
+- `#generateTokenGroups({ words })` — short words (`length < nGramLength`) become single-token groups; long
+  words are n-grammed, filtered to grams the word actually `includes` (drops padding), deduped per word.
+- `#formatTokenGroups(...)` — the AND/OR formatting in `SKILL.md`.
+
+`FullTextSearchConditionGenerator` — `#generateCondition()` returns
+`MATCH (${matchColumnNames}) AGAINST ('${againstText}' IN BOOLEAN MODE)`, or `null` when the against text is
+empty; `#formatAgainstText()` delegates to `NgramSearchWordGenerator`.
+
+This n-gram/fulltext infra is generic MySQL/MariaDB fulltext and is **not** wired into the document-RAG
+selectors.

--- a/kit/skills/backend/hb-multi-llm-provider/SKILL.md
+++ b/kit/skills/backend/hb-multi-llm-provider/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: hb-multi-llm-provider
+description: >
+  Support multiple LLM providers (Anthropic Claude / OpenAI / Google Gemini) behind one
+  abstraction in a renchan backend: an abstract model processor, one provider base per vendor, one
+  concrete processor per model, and a loader that picks one by model name at runtime, with model
+  and provider metadata in the DB and env, not in code. Use whenever the user asks to add an LLM
+  model or provider, change how a model is selected, normalize provider responses, or wire
+  function calls and file upload.
+---
+
+# Multi-LLM Provider (Claude / OpenAI / Gemini behind one abstraction)
+
+This backend talks to three LLM vendors through **one processor abstraction** so callers (agents,
+resolvers, jobs) never branch on the provider. A caller resolves a **model name** to a processor and calls
+`processor.sendRequestToAi(...)`; everything provider-specific (SDK calls, function-call shape, file
+upload, response parsing) is hidden behind the processor and its capsule.
+
+## Grand principle: one base + one subclass per model; provider differences live in a provider base, the model is chosen from the DB
+
+The abstraction is a three-level strategy: `BaseAiModelProcessor` (the contract) → one **provider base**
+per vendor (Claude/OpenAI/Gemini plumbing) → one **concrete processor per model** whose only distinct
+member is `#get:aiModel`. A loader auto-discovers the concrete processors and picks one by model-name
+string at runtime.
+
+- **Why a per-model class whose only identity is `#get:aiModel`**: adding a model must be additive
+  (Open–Closed) — drop one file whose `#get:aiModel` returns the new name, and the loader finds it. The
+  concrete class holds *no* target model id or token limit; those come from the DB `AiModel` /
+  `AiModelCapability` rows, so a model's real endpoint and limits are data, not code.
+- **Why a provider base between them**: the three vendors differ only in a few mechanics —
+  function-call event shape (`tool_use` vs `function_call` vs `functionCall`), how tool results are fed
+  back (`messages` vs `input` vs `contents`), and file upload (Claude file id / OpenAI file id / Gemini
+  file uri). Concentrating those in one provider base per vendor keeps every concrete model processor
+  identical except for its name.
+- **Why normalize responses through `AiModelResponse`**: callers must read `#hasError()`,
+  `#extractFunctionCalls()`, `#extractContentText()` the same way regardless of vendor. Each provider's
+  capsule exposes the same method surface; `AiModelResponse` is the thin uniform wrapper over it.
+- **Why choose the model from the DB**: which model an agent uses is per-agent config
+  (`AiAgentDefaultModel → AiModel.name`), overridable per call — never hard-coded. Swapping a model is a
+  data change.
+
+## Layers and files
+
+```
+app/tools/
+  BaseAiModelProcessor.js                     abstract contract (get aiModel, sendRequestToAi, ...)
+  BaseAiModelProviderProcessor/
+    BaseClaudeAIProcessor.js                  Claude function-call loop + Files API upload
+    BaseOpenAIProcessor.js                    OpenAI function_call + file upload (with expiry)
+    BaseGeminiAIProcessor.js                  Gemini functionCall + file uri upload
+  AiModelProcessor/
+    ClaudeSonnet4_5AiModelProcessor.js        concrete: get aiModel + sendRequestToAi
+    OpenAiGPT_5_AiModelProcessor.js           (~21 concrete model files, one per model)
+    Gemini2_5FlashAiModelProcessor.js
+    ...
+  BulkAiModelProcessorsLoader.js              auto-discovery + getProcessor(aiModel)
+  AiPayloadGenerator/
+    BaseAiMessagePayloadGenerator.js          shared history trimming / token budget
+    ClaudeMessagePayloadGenerator.js          provider payload shaping (tools, toolChoice, files)
+    OpenAiMessagePayloadGenerator.js
+    GeminiMessagePayloadGenerator.js
+  AiModelResponse.js                          normalized response wrapper
+app/claudeClient/ | app/geminiClient/ | app/openAiClient/   low-level Launcher/Payload/Capsule/Client
+```
+
+## 1. The contract — `BaseAiModelProcessor`
+
+Abstract members a concrete processor must satisfy:
+
+- `#get:aiModel` (abstract) — the model-name string the loader matches on (e.g. `'sonnet-4-5'`).
+- `#sendRequestToAi({ ... })` (abstract) — non-streaming request; returns an `AiModelResponse`.
+- `#sendStreamRequestToAi({ ..., onText, onComplete })` (abstract) — streaming variant.
+- `#prepareAttachedFiles({ fileUrls })` (concrete default: returns `fileUrls` unchanged) — overridden per
+  provider to upload files and attach provider file ids/uris.
+- `#findAiModelByName({ aiModelName })` (concrete) —
+  `AiModel.findOne({ where: { name }, include: [AiModelCapability] })`; this is how a processor gets its
+  DB-backed `targetModelName` and `maxOutputToken`.
+
+The request param bag is uniform across providers:
+
+```js
+async sendRequestToAi ({
+  aiAgent,
+  instruction,
+  documents,
+  fileUrls,
+  historyMessages = [],
+  tools = [],
+  toolChoices = [],
+  isAutoHandleFunctionCall = true,
+  extraToolOptions = {},
+  shouldPrefetchDynamicDocumentsForBackground = false,
+}) {
+  // ...
+}
+```
+
+## 2. A concrete model processor — only `#get:aiModel` is unique
+
+Everything else (build the instruction, prepare files, build the payload, send, handle one round of
+function calls, wrap the response) is the same standard flow inherited/composed from the provider base.
+
+```js
+import BaseClaudeAIProcessor from '../BaseAiModelProviderProcessor/BaseClaudeAIProcessor.js'
+import AiModelResponse from '../AiModelResponse.js'
+
+import CONSTANT_HASH from '../../../constants/aiConstants.cjs'
+
+const {
+  AI_MODEL,
+} = CONSTANT_HASH
+
+export default class ClaudeSonnet4_5AiModelProcessor extends BaseClaudeAIProcessor {
+  static create () {
+    return new this()
+  }
+
+  get aiModel () {
+    return AI_MODEL.CLAUDE_SONNET_4_5.NAME
+  }
+
+  async sendRequestToAi ({
+    aiAgent,
+    instruction,
+    documents,
+    fileUrls,
+    historyMessages = [],
+    tools = [],
+    toolChoices = [],
+    isAutoHandleFunctionCall = true,
+    extraToolOptions = {},
+    shouldPrefetchDynamicDocumentsForBackground = false,
+  }) {
+    const aiModel = await this.findAiModelByName({
+      aiModelName: this.aiModel,
+    })
+
+    const documentInstructionComposer = await this.createDocumentInstructionComposer({
+      // ...splits documents, wires the agent's default instruction (see `hb-ai-prompt-document-store` skill)
+    })
+
+    const preparedFileUrls = await this.prepareAttachedFiles({
+      fileUrls,
+    })
+
+    const payloadGenerator = this.createClaudeMessagePayloadGenerator({
+      aiAgent,
+      aiModel,
+      message: documentInstructionComposer.generateComposedInstruction(),
+      fileUrls: preparedFileUrls,
+      historyMessages,
+      tools,
+      toolChoices,
+    })
+
+    const payload = payloadGenerator.generateClaudeMessagePayload()
+    const fetcher = this.createSendMessageToClaudeFetcher()
+    const capsule = await fetcher.launchRequest(payload)
+
+    if (capsule.hasError()) {
+      return AiModelResponse.create({
+        aiResponseCapsule: capsule,
+      })
+    }
+
+    if (!capsule.hasFunctionCallEvent()) {
+      return AiModelResponse.create({
+        aiResponseCapsule: capsule,
+      })
+    }
+
+    if (!isAutoHandleFunctionCall) {
+      return AiModelResponse.create({
+        aiResponseCapsule: capsule,
+      })
+    }
+
+    const followUpPayload = await this.handleFunctionCalls({
+      payloadParams: payload.params,
+      aiResponses: capsule.extractContent(),
+      extraToolOptions,
+    })
+
+    const followUpCapsule = await fetcher.launchRequest(followUpPayload)
+
+    return AiModelResponse.create({
+      aiResponseCapsule: followUpCapsule,
+    })
+  }
+}
+```
+
+- **`targetModelName` and `maxOutputToken` come from the DB row**, not the class. `#get:aiModel` returns
+  the app-facing name (`AI_MODEL.*.NAME`); the DB row's `targetModelName` is the vendor API model id
+  (e.g. `'claude-sonnet-4-5-20250929'`).
+- **`isAutoHandleFunctionCall: false`** short-circuits after the first response and returns the raw
+  function call — this is exactly what the forced-single-tool actions in the **`hb-ai-agent-structure` skill**
+  rely on.
+- The flow handles **one** round of function calls (one follow-up request), not an open-ended tool loop.
+
+## 3. Runtime selection — `BulkAiModelProcessorsLoader`
+
+The loader auto-discovers every class under `app/tools/AiModelProcessor/` with renchan's
+`DeepBulkClassLoader`, instantiates each via `.create()`, and picks one by matching `#get:aiModel`:
+
+```js
+import {
+  DeepBulkClassLoader,
+} from '@openreachtech/renchan'
+
+// ...
+static async loadProcessorClasses (path) {
+  return DeepBulkClassLoader.create({
+    poolPath: path,
+  })
+    .loadClasses()
+}
+
+getProcessor (aiModel) {
+  return this.processors.find(processor => processor.aiModel === aiModel)
+}
+```
+
+The model **name** passed to `#getProcessor()` comes from the DB — the agent's default model, overridable
+per call:
+
+```js
+// explicit id wins, else the agent's default model
+const targetAiModelId = aiModelId
+  ?? aiAgentDefaultModel?.AiModelId
+  ?? null
+
+const aiModel = await AiModel.findByPk(targetAiModelId)
+const processor = this.bulkAiModelProcessorsLoader.getProcessor(aiModel.name)
+```
+
+or directly via the agent's default-model chain
+`aiAgent.AiAgentDefaultModel.AiModel.name → getProcessor(...)`.
+
+> Do not confuse this with `BulkAiToolProcessorsLoader`: the provider bases use a *tool*-processor loader
+> (`getProcessor(toolName)`) to run function calls — a different loader over `app/aiTools/`.
+
+## 4. Adding a model or a provider
+
+- **New model of an existing provider**: add one file under `app/tools/AiModelProcessor/` extending that
+  provider base, with `#get:aiModel` returning the new `AI_MODEL.*.NAME`; add the `AiModel` +
+  `AiModelCapability` rows (and `AiModelToolAssignment` rows) via a seeder; add the `AI_MODEL` entry in
+  `constants/aiConstants.cjs`. No caller changes — the loader finds it.
+- **New provider**: add a provider base under `app/tools/BaseAiModelProviderProcessor/` implementing the
+  function-call handling + `#prepareAttachedFiles()` for that vendor, a payload generator under
+  `AiPayloadGenerator/`, a capsule that exposes the standard method surface, the low-level
+  Launcher/Payload/Capsule/Client under `app/<provider>Client/`, and an `AI_PROVIDER` entry. Then per-model
+  processors as above.
+
+See [provider-internals.md](./references/provider-internals.md) for the per-vendor function-call and
+file-upload differences, the payload generators, `AiModelResponse`, and the low-level client pattern.
+
+## 5. Config and secrets
+
+- **`AiProvider`** (`ai_providers`): `name`. `AI_PROVIDER = { ANTHROPIC {ID:1}, GOOGLE {ID:2}, OPENAI {ID:3} }`.
+- **`AiModel`** (`ai_models`): `AiProviderId`, `name` (app key), `targetModelName` (vendor id), `isDefault`,
+  `isActive`, `displayOrder`.
+- **`AiModelCapability`** (`ai_model_capabilities`): `contextWindowToken`, `maxOutputToken` (→ payload
+  `maxTokens`).
+- **`AiModelToolAssignment`** (`ai_model_tool_assignments`): which tools a model may use (see the
+  `hb-ai-prompt-document-store` skill for `AiTool`).
+- **API keys / base URLs** come from `@openreachtech/renchan-env` via `app/globals/env.js` (e.g.
+  `CLAUDE_API_TOKEN`, `CLAUDE_API_BASE_URL`, and the analogous OpenAI/Gemini vars) — never hard-code a key.
+
+Model/provider constants live in `constants/aiConstants.cjs` (see the **`hb-constant-definition` skill** for the
+two-file `.cjs` master + ESM bridge rule).
+
+## Cross-cutting rules
+
+- **Callers never branch on the provider** — resolve a processor by name and use the uniform
+  `#sendRequestToAi()` / `AiModelResponse` surface.
+- **A concrete model processor adds no logic beyond `#get:aiModel`** — put shared behavior on the provider
+  base, per-vendor behavior on the provider base too, and model specifics in the DB.
+- **Return `null` / a normalized error response, not `undefined`**, on failure; check `#hasError()` before
+  reading content.
+- One class per file, one `export default`, `static create()` factory; getters return a constant.
+
+## Detail files
+
+- [provider-internals.md](./references/provider-internals.md) — the three provider bases' function-call
+  feedback shapes and file-upload models (Claude/OpenAI/Gemini), the payload generators
+  (tools/toolChoice/history trimming/file source), the `AiModelResponse` + capsule method surface, and the
+  low-level Launcher/Payload/Capsule/Client pattern with where API keys are read.

--- a/kit/skills/backend/hb-multi-llm-provider/references/provider-internals.md
+++ b/kit/skills/backend/hb-multi-llm-provider/references/provider-internals.md
@@ -1,0 +1,153 @@
+# Provider internals (function calls, file upload, payloads, response, clients)
+
+Referenced from `SKILL.md`. This is the per-vendor detail behind the uniform processor surface. The
+concrete model processors are identical except for `#get:aiModel`; the differences below live in the
+three provider bases under `app/tools/BaseAiModelProviderProcessor/` and the payload generators under
+`app/tools/AiPayloadGenerator/`.
+
+## Function-call feedback — the one real per-vendor difference
+
+Each provider base runs the same shape: filter the AI response for tool calls, run each tool via the
+`BulkAiToolProcessorsLoader` (`getProcessor(toolName).process({ ...input, extraToolOptions })`), then push
+the tool results back into the payload and re-request. Only the **event type**, the **result envelope**,
+and the **payload channel** differ.
+
+| Vendor | Function-call event | Tool result fed back as | Payload channel | Arguments |
+| --- | --- | --- | --- | --- |
+| Claude | `response.type === 'tool_use'` | `{ type: 'tool_result', tool_use_id, content }` (role `user`) | `payloadParams.messages` | `response.input` (object) |
+| OpenAI | `response.type === 'function_call'` | original call + `{ type: 'function_call_output', call_id, output }` | `payloadParams.input` | `JSON.parse(response.arguments)` |
+| Gemini | `functionCall` part | `{ role: 'model', parts: [{ functionCall }] }` + `{ role: 'user', parts: [{ functionResponse: { name, response: { result } } }] }` | `payloadParams.contents` | `response.arguments` (already an object) |
+
+Claude's loop, verbatim (the other two mirror it with the shapes above):
+
+```js
+const functionCalls = aiResponses.filter(response => response.type === 'tool_use')
+
+const toolResults = await functionCalls.reduce(
+  async (resultsPromise, response) => {
+    const collectedResults = await resultsPromise
+
+    const aiToolProcessor = bulkAiToolProcessorsLoader.getProcessor(response.name)
+
+    const toolResult = await aiToolProcessor.process({
+      ...response.input,
+      extraToolOptions: {
+        ...extraToolOptions,
+        toolName: response.name,
+      },
+    })
+
+    collectedResults.push({
+      type: 'tool_result',
+      tool_use_id: response.id,
+      content: toolResult.toString(),
+    })
+
+    return collectedResults
+  },
+  Promise.resolve([])
+)
+
+payloadParams.messages.push({
+  role: 'user',
+  content: toolResults,
+})
+```
+
+`#handleStreamingFunctionCalls()` is the streaming counterpart: it builds the same follow-up payload, then
+calls the streaming fetcher forwarding `{ onText, onComplete }` (Claude/Gemini) or `{ onText, onComplete,
+onError }` (Claude adds `onError`).
+
+## File upload — `#prepareAttachedFiles({ fileUrls })`
+
+Each provider base overrides `#prepareAttachedFiles()` to upload attachments once and reuse them, keyed by
+the uploaded file's `idHash` (extracted from the file URL's last path segment; base URLs come from
+`env.BASE_EMPLOYEE_FILE_URL` / `env.BASE_CLIENT_FILE_URL`). It maps app `UploadedFile` rows to a
+per-provider upload record, reusing an existing one when valid, else uploading and saving.
+
+| Vendor | Upload record model | Reuse rule | File identity attached |
+| --- | --- | --- | --- |
+| Claude | `ClaudeUploadedFile` | always reusable (Claude file ids do not expire) | `claudeFileId` |
+| OpenAI | `OpenAiUploadedFile` | reusable if no `expiresAt`, else `expiresAt > now` (Unix seconds → Date) | `openAiFileId` |
+| Gemini | `GeminiUploadedFile` | reusable if `expiresAt > now` (ordered by `expiresAt` DESC) | `geminiFileUri` |
+
+Only files that end up with a provider id/uri are returned. The `AttachedFile` typedef on
+`BaseAiModelProcessor` carries all three optional identities (`claudeFileId` / `openAiFileId` /
+`geminiFileUri`) plus `fileUrl` / `fileType`.
+
+## Payload generators (`app/tools/AiPayloadGenerator/`)
+
+`BaseAiMessagePayloadGenerator` holds the shared state (`aiAgent`, `aiModel`, `targetAiModel`, `message`,
+`historyMessages`, `maxTokens`, `tools`, `emotionalLevel`, `fileUrls`, `toolChoices`) and the
+history-trimming helpers (`#extractFilteredHistoryMessages(...)`, `#createMessageTokenLimiter(...)` →
+`MessageTokenLimiter` for token-budget trimming). Each provider generator extends it.
+
+`ClaudeMessagePayloadGenerator` (the others mirror it):
+
+- `#generateClaudeMessagePayload()` — system prompt = `aiAgent.AiAgentRoleInstruction.role`; trims history;
+  `messages = [...formattedHistory, { role: 'user', content: generateMessagesContent() }]`; returns
+  `SendMessageToClaudePayload.create({ params })`.
+- `#generatePayloadParams(...)` — omit `tools` / `toolChoice` entirely when there are no tools; else include
+  `tools` + `toolChoice: generateToolChoice()`.
+- `#generateToolChoice()` — `{ type: 'auto' }` (none) / `{ type: 'tool', name }` (exactly one — the forced
+  single tool) / `{ type: 'any' }` (multiple).
+- `#formatSingleMessage()` — role from `MESSAGE_SENDER_CATEGORY.HUMAN.ID` → `'user'` else `'assistant'`;
+  appends document linkages + one-time documents.
+- `#generateMessagesContent()` / `#generateFileSource()` — text block + file blocks; a file block prefers
+  `{ type: 'file', file_id: claudeFileId }` when a Claude file id exists, else `{ type: 'url', url }`;
+  `#extractTypeFromFileType()` → `'document'` (PDF) or `'image'`.
+
+Provider nuances: OpenAI's `#generateOpenAiMessagePayload()` is async (awaited) and passes
+`emotionalLevel: null`; Gemini/OpenAI use their own message channels (`contents` / `input`).
+
+## `AiModelResponse` and the capsule surface
+
+`AiModelResponse.create({ aiResponseCapsule })` is a thin uniform wrapper. Each method guards that the
+capsule implements it, then delegates:
+
+```js
+extractFunctionCalls () {
+  return this.aiResponseCapsule.extractFunctionCalls()
+}
+
+extractContentText () {
+  return this.aiResponseCapsule.extractContentText()
+}
+
+extractErrorMessage () {
+  return this.aiResponseCapsule.extractErrorMessage()
+}
+
+hasError () {
+  return this.aiResponseCapsule.hasError()
+}
+```
+
+The real logic is in the provider capsule (e.g. `SendMessageToClaudeCapsule extends BaseCapsule` from
+`@openreachtech/renchan-tools-external-api`), which every vendor implements with the same surface:
+`#hasError()`, `#extractContent()`, `#hasFunctionCallEvent()`, `#extractFunctionCalls()` (→
+`{ name, arguments }`), `#extractContentText()`, plus model / role / stop-reason / token-usage extractors.
+**This shared surface is what makes the whole abstraction provider-agnostic** — the forced-tool actions in
+the `hb-ai-agent-structure` skill call `response.hasError()` / `response.extractFunctionCalls()` without knowing
+the vendor.
+
+## Low-level clients (`app/claudeClient/`, `app/geminiClient/`, `app/openAiClient/`)
+
+Each provider dir has the same ~11-file layout: for each operation (SendMessage, StreamingMessage,
+UploadFile) a **Payload** (request builder; `#create({ params })`, `#toActualParams()`), a **Fetcher**
+(extends `Base<Provider>ApiRequestLauncher` → `BaseRequestLauncher` from
+`@openreachtech/renchan-tools-external-api`; `#launchRequest()` / `#launchStreamRequest()`, defines
+`#get:CapsuleClass` and `#requestToClient()`), and a **Capsule** (normalizes the response). Plus one shared
+**ApiClient** and one shared **Base...RequestLauncher** that reads the vendor key/base URL from env.
+
+- `SendMessageToClaudeFetcher#get:CapsuleClass` → `SendMessageToClaudeCapsule`;
+  `#requestToClient(p)` → `this.client.sendMessageToClaude({ ...p })`.
+- `ClaudeApiClient` — constructed `{ token, httpRequestClient }`; `#sendMessageToClaude()` POSTs `/messages`
+  with `x-api-key`, `anthropic-version`, `anthropic-beta: files-api-2025-04-14`; `#uploadFileToClaude()`
+  POSTs `/files` as FormData; streaming uses the official SDK
+  (`import Anthropic from '@anthropic-ai/sdk'` → `client.beta.messages.stream(...)`).
+- `Base<Provider>ApiRequestLauncher` reads `environment.CLAUDE_API_TOKEN` / `environment.CLAUDE_API_BASE_URL`
+  (and the OpenAI/Gemini analogues) from the renchan-env facade.
+
+This Launcher/Payload/Capsule/Client shape is the same external-API-client pattern the **external-api-client
+skill** describes; here it is specialized per LLM vendor.

--- a/kit/skills/backend/hb-mutation-resolver/SKILL.md
+++ b/kit/skills/backend/hb-mutation-resolver/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: hb-mutation-resolver
+description: >
+  Implement GraphQL Mutation resolvers under
+  server/graphql/resolvers/<endpoint>/actual/mutations/<Operation>MutationResolver.js, extending
+  BaseMutationResolver (@openreachtech/renchan). Use this skill whenever the user asks to write or
+  edit a mutation resolver — a create / update / delete / sign-in / upload operation that changes
+  state, and the single transaction it runs in. Input validation, heavy background work and read
+  operations each belong to their own convention.
+---
+
+# Mutation Resolver
+
+A skill for writing the **`*MutationResolver` classes** that resolve a GraphQL `Mutation` — the
+synchronous write path of the API. A resolver **extends `BaseMutationResolver`** (from
+`@openreachtech/renchan`), declares which schema it resolves and which error codes it can raise, and
+runs a **fixed four-step flow** in `resolve()`. The value-shape checks live in a separate
+`*InputValidator`; the heavy/slow work lives in a Worker. The resolver
+itself only **orchestrates**.
+
+> Directory layout follows the target convention (same idealized layer as the
+> `*InputValidator`). `BaseMutationResolver` /
+> `BaseResolver` come from the renchan framework; the `*InputValidator` comes from the shared
+> validator layer; the models come from `sequelize/models/`.
+
+## Core principle: a mutation resolver is a filled-in template
+
+Every mutation resolver has the **same skeleton** — the same method set in the same order, and the
+same `resolve()` flow:
+
+```
+resolve() ─┬─▶ validateInput()               → throw the InvalidXxx error, or continue
+           ├─▶ generateTransactionCallback()  → a `async transaction => {...}` closure
+           ├─▶ Model.beginTransaction(callback)→ run every find + save in ONE transaction
+           └─▶ formatResponse()               → shape the result (usually just an id)
+```
+
+Keep the skeleton identical so review attention goes straight to the **operation-specific
+difference (which models, which guards, which columns)**. Do not write it cleverly; lean toward the
+shape of the existing resolvers. Three rules carry most of the weight:
+
+1. **All finds and saves for one request go inside one transaction callback** — never split a
+   `find` and its `save` across the transaction boundary (§4, [transaction.md](./references/transaction.md)).
+2. **The resolver validates then delegates.** Input shape → the `*InputValidator` (§6). Value
+   changes → the transaction callback. Heavy/slow work → a Worker (§8). The resolver holds no
+   business rule that either of those should own.
+3. **Return the save result, not a rendered view** (§5). A mutation returns ids; the frontend
+   re-fetches with a Query. This keeps Mutation and Query responsibilities separate.
+
+> The examples use generic entities (`Article`, `User`) and standard tools; substitute your own
+> domain models. What transfers is the shape — one transaction, validate-then-delegate, return the
+> save result — not the entity names.
+
+- **Comments: English for code, the surrounding language for domain notes.** Comments written into
+  the resolver `.js` are English. Domain/ticket notes may be Japanese where the surrounding files
+  are — match the neighbors.
+
+## 1. Directory, file name, and the `schema` getter
+
+One resolver = one file (one class per file). Place it under the endpoint it belongs to:
+
+- **Path:** `server/graphql/resolvers/<endpoint>/actual/mutations/<Operation>MutationResolver.js`
+  - `<endpoint>` is the GraphQL endpoint (`user`, `customer`, `admin`, `portal`, …).
+  - `actual` = real business logic; the sibling `stub/` holds fixed-data stubs for the same schema.
+  - e.g. `server/graphql/resolvers/user/actual/mutations/CreateArticleMutationResolver.js`.
+- **Class name** = `<Operation>MutationResolver` (PascalCase), where `<Operation>` is the schema in
+  PascalCase (`createArticle` → `CreateArticleMutationResolver`).
+- **`static get schema()`** returns the GraphQL schema name in camelCase and is marked `@override`.
+  The base can derive it from the class name, but **always declare it explicitly** — it is the
+  single, greppable link between the schema and the class.
+
+```js
+import {
+  BaseMutationResolver,
+} from '@openreachtech/renchan'
+
+export default class UpdateArticleMutationResolver extends BaseMutationResolver {
+  /** @override */
+  static get schema () {
+    return 'updateArticle'
+  }
+
+  // ... errorCodeHash, resolve(), helpers ...
+}
+```
+
+## 2. The `resolve()` flow and method order
+
+`resolve()` is the entry point and reads the same everywhere: **validate → build callback → run in
+one transaction → format**. It receives `{ variables: { input }, context }`; `context` supplies
+`now`, `userId` / `user`, and the endpoint identity.
+
+```js
+/**
+ * @param {{
+ *   variables: { input: server.graphql.user.UpdateArticleInput }
+ *   context: UserGraphqlContext
+ * }} params
+ * @returns {Promise<server.graphql.user.UpdateArticleResult>}
+ */
+async resolve ({
+  variables: {
+    input,
+  },
+  context,
+}) {
+  const validationError = this.validateInput({
+    input,
+  })
+
+  if (validationError) {
+    throw validationError
+  }
+
+  const callback = this.generateTransactionCallback({
+    input,
+    context,
+  })
+
+  const article = await Article.beginTransaction(callback)
+
+  return this.formatResponse({
+    article,
+  })
+}
+```
+
+**Method order (matches the framework guideline):**
+
+1. `static get schema ()` — `@override`
+2. `static get errorCodeHash ()` — `@override` (§3)
+3. *(optional)* `constructor` → `static create ()` → `static createXxx ()` factory helpers — only when
+   a dependency must be injected (§7)
+4. `async resolve ()` — the flow above
+5. `createInputValidator ({ input })` (§6)
+6. `validateInput ({ input })` (§6)
+7. `generateTransactionCallback ({ input, context })` (§4)
+8. other instance methods — `findXxx` / `buildXxxAttributes` / `updateXxx`, placed **next to their
+   caller** (call-related methods adjacent; unrelated ones alphabetical)
+9. `formatResponse ({ ... })` (§5)
+10. `@typedef` blocks at the bottom (context type, entity types)
+
+The full template with every helper filled in is in
+[resolve-flow.md](./references/resolve-flow.md).
+
+## 3. `errorCodeHash` and throwing errors
+
+Declare every error the resolver can raise in `static get errorCodeHash ()`, spreading
+`...super.errorCodeHash` first. Each entry maps an `ErrorName` to a **code string** whose leading
+segment encodes the category:
+
+- `203.*` — **invalid input** (`InvalidXxx`). These pair with the validator's predicates (§6).
+- `204.*` — **DB / state** errors (`XxxNotFound`, `NotAllowedToXxx`, `CurrentXxxIsSameAsTheNewOne`).
+- `205.*` — **auth** errors (`InvalidCredentials`).
+
+```js
+/** @override */
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    // Invalid Input Errors
+    InvalidArticleId: '203.M012.001',
+    InvalidTitle: '203.M012.003',
+
+    // Database Errors
+    ArticleNotFound: '204.M012.002',
+    CurrentArticleContentIsSameAsTheNewOne: '204.M012.003',
+  }
+}
+```
+
+The base turns this hash into constructable error classes on `this.errorHash` (via
+`buildErrorHash()` in the factory). **Throw with `this.errorHash.<Name>.create()`** — validator
+errors bubble out of `resolve()`; state errors are thrown from inside the transaction callback so
+the transaction rolls back. Codes, numbering (`M###`), and the wiring are in
+[errors.md](./references/errors.md).
+
+## 4. `generateTransactionCallback()` — one transaction, all writes
+
+`generateTransactionCallback({ input, context })` returns an **`async transaction => { ... }`**
+closure that holds **every find and save for the request**. It is handed to
+`Model.beginTransaction(callback)`, which opens a managed transaction and passes it in. Pass that
+`transaction` to **every** query inside.
+
+```js
+generateTransactionCallback ({
+  input: {
+    title,
+    content,
+    articleId,
+  },
+  context: {
+    now,
+    userId,
+  },
+}) {
+  return async transaction => {
+    const article = await this.findArticle({
+      articleId,
+      transaction,
+    })
+
+    if (!article) {
+      throw this.errorHash.ArticleNotFound.create()
+    }
+
+    article.set({
+      title,
+      content,
+      LastModifiedByUserId: userId,
+      lastModifiedAt: now,
+    })
+
+    return /** @type {*} */ (
+      article.save({
+        transaction,
+      })
+    )
+  }
+}
+```
+
+- **Why one transaction:** a `find` then `save` split across two transactions lets a concurrent
+  request interleave (`find1 → find2 → save1 → save2`) and corrupt state. Keeping them in one
+  callback serializes them.
+- **`.set()` + `.save()`, never `.update()`** — the backup mixin needs the full row; `.update()`
+  can drop fields. Create rows with `Model.create(attributes, { include, transaction })`.
+- **State guards throw inside the callback** (`throw this.errorHash.XxxNotFound.create()`) so the
+  transaction rolls back. Existence / ownership / no-op checks belong here, not in the validator.
+
+Nested-create `include`, existence-count guards, associations, and post-transaction side effects
+(work that must observe the committed result and runs **after** the commit) are in
+[transaction.md](./references/transaction.md).
+
+## 5. `formatResponse()` — return the save result, not a view
+
+`formatResponse()` shapes the transaction's result into the GraphQL result type. **Return the
+minimum that identifies what changed — usually just an id** (plus a timestamp for a delete).
+
+```js
+formatResponse ({
+  article,
+}) {
+  return {
+    articleId: article.id,
+  }
+}
+```
+
+- **Why minimal:** a Mutation's job is to report *that* the write happened. The frontend re-fetches
+  the updated data with a **Query**. Returning a fully rendered object here duplicates the Query and
+  couples the two. Keep Mutation and Query concerns separate. See
+  [resolve-flow.md](./references/resolve-flow.md#formatresponse).
+
+## 6. Input validation → the project's resolver-validator conventions
+
+The resolver never inlines value checks. It builds a `*InputValidator` and runs it; the validator
+returns an `InvalidXxx` error (or `null`).
+
+```js
+createInputValidator ({
+  input,
+}) {
+  return UpdateArticleInputValidator.create({
+    errorHash: this.errorHash,
+    input,
+  })
+}
+
+validateInput ({
+  input,
+}) {
+  return this.createInputValidator({
+    input,
+  })
+    .validateInput()
+}
+```
+
+Write the `*InputValidator` itself following the project's resolver-validator conventions. Split of
+duty: **shape/format → validator; existence/ownership/state → transaction callback (§4).**
+
+## 7. Dependency injection — only when a dependency is needed
+
+Simple resolvers need **no** constructor or factory: the base `create({ errorCodeHash })` builds the
+error hash for you. Add a `constructor` + `static create ()` + `static createXxx ()` factory helpers
+**only** when the resolver depends on a tool (token generator, encipher, random-text generator, …)
+that tests must be able to substitute.
+
+```js
+constructor ({
+  accessTokenGenerator,
+  ...remainingParams
+}) {
+  super(remainingParams)
+
+  this.accessTokenGenerator = accessTokenGenerator
+}
+
+static create ({
+  accessTokenGenerator = this.createAccessTokenGenerator(),
+  errorCodeHash = this.errorCodeHash,
+} = {}) {
+  const errorHash = this.buildErrorHash({
+    errorCodeHash,
+  })
+
+  return new this({
+    accessTokenGenerator,
+    errorHash,
+  })
+}
+```
+
+- **Why inject:** hard-`new`-ing a token/crypto tool inside a method makes the resolver untestable
+  and hides its collaborators. A default-valued factory keeps production calls a plain `.create()`
+  while letting a test pass a fake. Full pattern in
+  [dependency-injection.md](./references/dependency-injection.md).
+
+## 8. Heavy or slow work → a Worker, not the resolver
+
+A resolver responds **synchronously**; it must stay fast. If the operation is slow or uncertain
+(external API, AI call, bulk records, file generation), the resolver should **enqueue a job and
+return immediately** — the real work runs in a Worker. Decide following the project's
+execution-placement-pattern conventions, and implement the Worker following the project's
+renchan-job-bullmq conventions. When in doubt, push to the Worker.
+
+## Testing
+
+Test the resolver following the project's jest rules, split across **two locations by whether
+the test writes to the DB**:
+
+- **No writes → `tests/__tests__/`** (mirror the resolver's source path). Static getters
+  (`schema`, `errorCodeHash`), `createInputValidator` / `validateInput` (validator **mocked** via
+  `jest.spyOn`), `formatResponse` (pure), and the DI factory (§7). Jest auto-discovers every `.js`
+  under `__tests__/`; these run independently, in any order, and hit no DB.
+- **Writes → `tests/_orders/<Category>/mutations/<Resolver>.js`**. `generateTransactionCallback`
+  (run through `Model.beginTransaction`) and `resolve` (full flow) against the seeded DB — assert a
+  valid input persists the row, a missing row throws the `204.*` and rolls back, etc. `<Category>`
+  is the **model the resolver writes to** (`CreateArticle` → `Article`). Ordering within a category
+  is guaranteed by its `_.test.js`, which `import`s each write file in sequence — add an import line
+  there when you add a test, or it never runs.
+
+Everything else (unique fake data, `test.each`, `describe` branches, AAA, mocks) follows the
+project-wide jest rules unchanged. Full placement detail in [testing.md](./references/testing.md).
+
+## Detail files
+
+- [resolve-flow.md](./references/resolve-flow.md) — the full resolver template (every method with
+  JSDoc), method order, `createInputValidator`/`validateInput`, and `formatResponse` shapes (§2,§5,§6)
+- [transaction.md](./references/transaction.md) — `generateTransactionCallback` in depth:
+  one-transaction rule, `beginTransaction`, nested-create `include`, existence guards, `.set()`+
+  `.save()` vs `.update()`, throwing state errors, post-commit side effects (§4)
+- [errors.md](./references/errors.md) — `errorCodeHash` categories (203/204/205), `M###` numbering,
+  `this.errorHash.<Name>.create()`, and how the base builds the error hash (§3)
+- [dependency-injection.md](./references/dependency-injection.md) — `constructor` + `static create()`
+  + `static createXxx()` factory helpers, when to inject, `buildErrorHash` wiring (§7)
+- [testing.md](./references/testing.md) — the `tests/__tests__/` (no-write) vs `tests/_orders/`
+  (write, ordered by `_.test.js`) placement split, what to test in each, and the category rule

--- a/kit/skills/backend/hb-mutation-resolver/references/dependency-injection.md
+++ b/kit/skills/backend/hb-mutation-resolver/references/dependency-injection.md
@@ -1,0 +1,148 @@
+# Dependency injection — constructor + factory helpers
+
+Most mutation resolvers need **no** constructor and no `create()`: the base
+`BaseResolver.create({ errorCodeHash })` builds the error hash and constructs the resolver for you.
+Add the injection triple **only** when the resolver depends on a collaborator that tests must be
+able to replace.
+
+## When to inject
+
+Inject when the resolver uses a **tool with side effects or nondeterminism** that a test cannot let
+run for real:
+
+- a random-text generator (`RandomTextGenerator`) — random ids / tokens,
+- an encipher (`Encipher`) — password hashing / compare,
+- a token generator (`AccessTokenGenerator`) — nondeterministic output,
+- any external client.
+
+Do **not** inject models or the validator — models are imported directly and used statically; the
+validator is built inline in `createInputValidator` (a test stubs that method). If the resolver only
+does validate → transaction → format with plain model calls, skip this file entirely.
+
+## The triple: constructor, factory, per-dependency creators
+
+The example: a `createArticle` resolver that needs a `RandomTextGenerator` to generate a public id.
+
+```js
+import {
+  RandomTextGenerator,
+} from '@openreachtech/renchan-tools'
+
+import {
+  BaseMutationResolver,
+} from '@openreachtech/renchan'
+
+export default class CreateArticleMutationResolver extends BaseMutationResolver {
+  /** @override */
+  static get schema () {
+    return 'createArticle'
+  }
+
+  /**
+   * @param {{
+   *   randomTextGenerator: RandomTextGenerator
+   *   errorHash: object
+   * }} params
+   */
+  constructor ({
+    randomTextGenerator,
+    ...remainingParams
+  }) {
+    super(remainingParams)
+
+    this.randomTextGenerator = randomTextGenerator
+  }
+
+  /**
+   * Factory method.
+   *
+   * @param {{
+   *   randomTextGenerator?: RandomTextGenerator
+   *   errorCodeHash?: object
+   * }} [params]
+   * @returns {CreateArticleMutationResolver}
+   */
+  static create ({
+    randomTextGenerator = this.createRandomTextGenerator(),
+    errorCodeHash = this.errorCodeHash,
+  } = {}) {
+    const errorHash = this.buildErrorHash({
+      errorCodeHash,
+    })
+
+    return new this({
+      randomTextGenerator,
+      errorHash,
+    })
+  }
+
+  /**
+   * @returns {RandomTextGenerator}
+   */
+  static createRandomTextGenerator () {
+    return RandomTextGenerator.create()
+  }
+
+  /** @override */
+  static get errorCodeHash () {
+    return {
+      ...super.errorCodeHash,
+      // ...
+    }
+  }
+
+  // resolve(), generateTransactionCallback(), etc.
+
+  /**
+   * @returns {string}
+   */
+  generateIdHash () {
+    return this.randomTextGenerator.generate()
+  }
+}
+```
+
+The three parts, in order (right after `schema` / before `errorCodeHash` per the method order in the
+[SKILL](../SKILL.md#2-the-resolve-flow-and-method-order)):
+
+1. **`constructor ({ <deps>, ...remainingParams })`** — assign each dependency to `this`, and pass
+   `remainingParams` (which carries `errorHash`) straight to `super()`. Never swallow `errorHash`.
+2. **`static create ({ <dep> = this.create<Dep>(), errorCodeHash = this.errorCodeHash } = {})`** —
+   each dependency **defaults to its creator**, so production calls stay a bare
+   `SomeResolver.create()`. Build the error hash with `this.buildErrorHash({ errorCodeHash })` and
+   pass it as `errorHash` (the base's own `create()` did this for you; once you override `create()`
+   you must do it yourself).
+3. **`static create<Dep> ()`** — one tiny creator per dependency returning the real instance
+   (`return RandomTextGenerator.create()`). This is the single seam a test overrides.
+
+## Why this shape
+
+- **Testability.** A test calls `SomeResolver.create({ randomTextGenerator: fakeGenerator })` (or
+  spies on `createRandomTextGenerator`) and asserts behavior deterministically. Hard-`new`-ing the
+  tool inside a method would make that impossible.
+- **Production stays trivial.** Because every dependency has a default, callers that don't care
+  write `.create()` and get the real wiring — the injection is invisible until a test needs it.
+- **`errorHash` still flows.** Overriding `create()` must not drop the base's error-hash build;
+  `...remainingParams` + `buildErrorHash` keep the error mechanism ([errors.md](./errors.md))
+  intact.
+
+## Use the dependency inside methods via a thin wrapper
+
+Reach the injected tool through a one-line instance method, not by scattering `this.<dep>.foo()`
+across the class — it names the intent and gives tests one more seam:
+
+```js
+generateIdHash () {
+  return this.randomTextGenerator.generate()
+}
+
+async verifyPassword ({
+  originalPassword,
+  passwordHash,
+}) {
+  return this.encipher.compare(
+    originalPassword,
+    passwordHash
+  )
+}
+```

--- a/kit/skills/backend/hb-mutation-resolver/references/errors.md
+++ b/kit/skills/backend/hb-mutation-resolver/references/errors.md
@@ -1,0 +1,120 @@
+# errorCodeHash, error codes, and throwing
+
+Every error a mutation resolver can raise is declared once in `static get errorCodeHash ()`. The
+base turns that hash into constructable error classes on `this.errorHash`, and the resolver throws
+them by name.
+
+## Declaring the hash
+
+Spread `...super.errorCodeHash` first (so framework-level codes stay), then add this resolver's
+errors grouped by category with a blank line and a comment between groups:
+
+```js
+/** @override */
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    // Invalid Input Errors
+    InvalidEmail: '203.M024.001',
+    InvalidPassword: '203.M024.002',
+
+    // Database Errors
+    UserNotFound: '204.M024.001',
+
+    // Authentication Errors
+    InvalidCredentials: '205.M024.001',
+  }
+}
+```
+
+## The code string: `<category>.<M###>.<seq>`
+
+Each value is a dotted string with three parts:
+
+- **`<category>`** — the leading segment classifies the failure:
+  - `203` — **invalid input**. Names are `InvalidXxx` and correspond 1:1 to the validator's
+    predicates (`InvalidTitle` ↔ `isValidTitle`), per the project's resolver-validator conventions.
+  - `204` — **DB / state**. `XxxNotFound`, `NotAllowedToXxx`, `CurrentXxxIsSameAsTheNewOne`. Thrown
+    from inside the transaction callback ([transaction.md](./transaction.md)).
+  - `205` — **auth**. `InvalidCredentials` and the like.
+- **`<M###>`** — the resolver's own identifier (`M024`, `M027`, `M043`, …). All codes in one
+  resolver share the same `M###`; it is unique per resolver so a code pins down which resolver
+  raised it.
+- **`<seq>`** — a zero-padded running number within the resolver (`001`, `002`, …). Numbering is
+  usually contiguous within a category; a gap from a removed code is fine — do not renumber existing
+  codes (they may be referenced by clients).
+
+- **Name = the reason, not the field alone.** `InvalidPublishedAt`, `TagNotFound`,
+  `NotAllowedToEditArticle` — read as a sentence at the throw site. No `info`/`data`/`error`
+  suffixes.
+
+## Throwing
+
+The base's factory runs `buildErrorHash({ errorCodeHash })`, which maps each `{ Name: code }` to a
+`RenchanGraphqlError` subclass and stores them on `this.errorHash` (also reachable as `this.Error`).
+Construct and throw with `.create()`:
+
+```js
+throw this.errorHash.ArticleNotFound.create()
+```
+
+- **Input errors** are returned by the validator and re-thrown at the top of `resolve()`
+  (`if (validationError) throw validationError`).
+- **State/auth errors** are thrown **inside the transaction callback** so the transaction rolls
+  back (`throw this.errorHash.UserNotFound.create()`).
+- Both categories surface to the client as GraphQL errors carrying the declared code.
+
+## How the base wires it (for reference)
+
+You do not write this — it comes from `BaseResolver` — but knowing it explains why the hash is all
+you declare:
+
+```js
+// BaseResolver.create() → buildErrorHash() builds the classes from your codes
+static create ({
+  errorCodeHash = this.errorCodeHash,
+} = {}) {
+  const errorHash = this.buildErrorHash({
+    errorCodeHash,
+  })
+
+  return new this({
+    errorHash,
+  })
+}
+
+// buildErrorHash: { Name: code } → { Name: RenchanGraphqlError subclass }
+static buildErrorHash ({
+  errorCodeHash = this.errorCodeHash,
+} = {}) {
+  return Object.fromEntries(
+    Object.entries(errorCodeHash)
+      .map(([errorName, code]) => [
+        errorName,
+        RenchanGraphqlError.declareGraphqlError({
+          code,
+        }),
+      ])
+  )
+}
+```
+
+So: declare `{ Name: 'code' }` in `errorCodeHash`, and throw `this.errorHash.Name.create()`. When a
+resolver injects dependencies via its own `static create()`, it must still call
+`this.buildErrorHash({ errorCodeHash })` and pass the result as `errorHash` to the constructor —
+see [dependency-injection.md](./dependency-injection.md).
+
+## Optional: a local ErrorHash typedef
+
+For editor help you may add a `@typedef` naming the errors the resolver throws, and annotate the
+throw site. It documents the contract but is optional:
+
+```js
+/**
+ * @typedef {{
+ *   ArticleNotFound: RenchanGraphqlErrorCtor
+ *   NotAllowedToEditArticle: RenchanGraphqlErrorCtor
+ * }} ErrorHash
+ */
+```

--- a/kit/skills/backend/hb-mutation-resolver/references/resolve-flow.md
+++ b/kit/skills/backend/hb-mutation-resolver/references/resolve-flow.md
@@ -1,0 +1,275 @@
+# The resolver template (resolve flow, validator wiring, formatResponse)
+
+The full shape of a mutation resolver, with every standard method filled in. Copy this skeleton and
+replace the operation-specific parts (models, guards, columns). Keep the method **order** and the
+`resolve()` **flow** identical across resolvers — see the [SKILL](../SKILL.md#2-the-resolve-flow-and-method-order).
+
+> Examples use a generic `Article` entity (fields `title` / `content`, audit columns
+> `CreatedByUserId` / `LastModifiedByUserId` / `lastModifiedAt`). Swap in your own model.
+
+## Full template
+
+```js
+import {
+  BaseMutationResolver,
+} from '@openreachtech/renchan'
+
+import UpdateArticleInputValidator from '../../../../../../app/validator/forResolver/user/mutations/UpdateArticleInputValidator.js'
+
+import Article from '../../../../../../sequelize/models/Article.js'
+
+export default class UpdateArticleMutationResolver extends BaseMutationResolver {
+  /** @override */
+  static get schema () {
+    return 'updateArticle'
+  }
+
+  /** @override */
+  static get errorCodeHash () {
+    return {
+      ...super.errorCodeHash,
+
+      // Invalid Input Errors
+      InvalidArticleId: '203.M012.001',
+      InvalidContent: '203.M012.002',
+      InvalidTitle: '203.M012.003',
+
+      // Database Errors
+      ArticleNotFound: '204.M012.002',
+      CurrentArticleContentIsSameAsTheNewOne: '204.M012.003',
+    }
+  }
+
+  /**
+   * Resolve method
+   *
+   * @param {{
+   *   variables: {
+   *     input: server.graphql.user.UpdateArticleInput
+   *   }
+   *   context: UserGraphqlContext
+   * }} params
+   * @returns {Promise<server.graphql.user.UpdateArticleResult>}
+   */
+  async resolve ({
+    variables: {
+      input,
+    },
+    context,
+  }) {
+    const validationError = this.validateInput({
+      input,
+    })
+
+    if (validationError) {
+      throw validationError
+    }
+
+    const callback = this.generateTransactionCallback({
+      input,
+      context,
+    })
+
+    const article = await Article.beginTransaction(callback)
+
+    return this.formatResponse({
+      article,
+    })
+  }
+
+  /**
+   * Create an input validator instance
+   *
+   * @param {{ input: server.graphql.user.UpdateArticleInput }} params
+   * @returns {UpdateArticleInputValidator}
+   */
+  createInputValidator ({
+    input,
+  }) {
+    return UpdateArticleInputValidator.create({
+      errorHash: this.errorHash,
+      input,
+    })
+  }
+
+  /**
+   * Validate the input
+   *
+   * @param {{ input: server.graphql.user.UpdateArticleInput }} params
+   * @returns {import('@openreachtech/renchan').RenchanGraphqlError | null}
+   */
+  validateInput ({
+    input,
+  }) {
+    return this.createInputValidator({
+      input,
+    })
+      .validateInput()
+  }
+
+  /**
+   * Generate the transaction callback
+   *
+   * @param {{
+   *   input: server.graphql.user.UpdateArticleInput
+   *   context: UserGraphqlContext
+   * }} params
+   * @returns {(transaction?: import('sequelize').Transaction) => Promise<model.ArticleEntity>}
+   */
+  generateTransactionCallback ({
+    input: {
+      title,
+      content,
+      articleId,
+    },
+    context: {
+      now,
+      userId,
+    },
+  }) {
+    return async transaction => {
+      const article = await this.findArticle({
+        articleId,
+        transaction,
+      })
+
+      if (!article) {
+        throw this.errorHash.ArticleNotFound.create()
+      }
+
+      if (
+        article.content === content
+        && article.title === title
+      ) {
+        throw this.errorHash.CurrentArticleContentIsSameAsTheNewOne.create()
+      }
+
+      article.set({
+        title,
+        content,
+        LastModifiedByUserId: userId,
+        lastModifiedAt: now,
+      })
+
+      return /** @type {*} */ (
+        article.save({
+          transaction,
+        })
+      )
+    }
+  }
+
+  /**
+   * Find an article by id
+   *
+   * @param {{
+   *   articleId: number
+   *   transaction: import('sequelize').Transaction
+   * }} params
+   * @returns {Promise<model.ArticleEntity>}
+   */
+  async findArticle ({
+    articleId,
+    transaction,
+  }) {
+    return /** @type {*} */ (
+      Article.findOne({
+        where: {
+          id: articleId,
+        },
+        transaction,
+      })
+    )
+  }
+
+  /**
+   * Format the response
+   *
+   * @param {{ article: model.ArticleEntity }} params
+   * @returns {server.graphql.user.UpdateArticleResult}
+   */
+  formatResponse ({
+    article,
+  }) {
+    return {
+      articleId: article.id,
+    }
+  }
+}
+
+/**
+ * @typedef {import('../../../../contexts/UserGraphqlContext.js').default} UserGraphqlContext
+ */
+```
+
+## `resolve()` — the fixed four steps
+
+`resolve()` never grows a fifth concern. It only:
+
+1. **validate** — `validateInput({ input })`; if it returns an error, `throw` it (fail before any
+   write).
+2. **build** — `generateTransactionCallback({ input, context })` returns the closure; it does not
+   run yet.
+3. **run** — `await <Model>.beginTransaction(callback)` executes the closure in one transaction and
+   returns its result.
+4. **format** — `return this.formatResponse({ ... })`.
+
+Anything else (a post-commit side effect) is an explicit extra line **between step 3 and step 4**,
+never logic hidden inside the four calls. Keep `resolve()` readable top-to-bottom.
+
+- **`context`** carries `now` (request timestamp — use it, do not call `new Date()` yourself so all
+  rows in the request share one time) and the actor (`userId` or `user`). Destructure only what the
+  callback needs, and forward it into `generateTransactionCallback`.
+- **Which model to call `beginTransaction` on?** Any model participating in the write works — pick
+  the primary entity of the operation (create → the model being created; update/delete → the model
+  being changed). The transaction spans all models regardless.
+
+## `createInputValidator` / `validateInput`
+
+Two thin methods, always the same:
+
+- `createInputValidator({ input })` builds the `*InputValidator` with `{ errorHash: this.errorHash,
+  input }` so the validator raises the resolver's own error codes.
+- `validateInput({ input })` runs it and returns the error or `null`.
+
+Keeping them as named methods (rather than inlining) lets tests stub the validator and keeps
+`resolve()` at one altitude. Write the `*InputValidator` itself following the project's
+resolver-validator conventions.
+
+## `formatResponse`
+
+Return the **minimum identifying result**, matching the GraphQL result type:
+
+```js
+// create / update → the id
+formatResponse ({
+  article,
+}) {
+  return {
+    articleId: article.id,
+  }
+}
+
+// delete → id + when it happened
+formatResponse ({
+  article,
+}) {
+  return {
+    articleId: article.id,
+    deletedAt: article.lastModifiedAt,
+  }
+}
+```
+
+Do not assemble a display object here. The mutation reports the write; the frontend re-queries for
+the rendered data. A `formatResponse` that maps/sorts/joins rows is a sign business logic leaked
+out of the transaction callback, or that a Query's job crept into the Mutation — pull it back. (A
+resolver that skips the validator, runs no transaction, and returns a fully-built, sorted list
+straight from `resolve()` is the shape to avoid.)
+
+## Endpoint differences
+
+Only the **context type** and the **import depth** change between endpoints (`user` / `customer` /
+`admin` / `portal`). The class skeleton, method order, and flow are identical. Keep the
+`@typedef` for the context pointing at the right
+`server/graphql/contexts/<Endpoint>GraphqlContext.js`.

--- a/kit/skills/backend/hb-mutation-resolver/references/testing.md
+++ b/kit/skills/backend/hb-mutation-resolver/references/testing.md
@@ -1,0 +1,125 @@
+# Testing a mutation resolver
+
+A mutation resolver is split across **two test locations** by one question: **does the test write to
+the database?** No-write tests go in `tests/__tests__/`; write tests go in `tests/_orders/`.
+Everything else — `test.each`, `describe` structure, unique fake data, AAA, `jest.spyOn` mocks —
+follows the project's jest rules unchanged.
+
+> Examples use a generic `Article` resolver. Swap in your own resolver/model names.
+
+## Placement rule
+
+| Test hits the DB? | Location | Discovered how | Order |
+| --- | --- | --- | --- |
+| **No** (pure / mocked) | `tests/__tests__/` (mirror the resolver's source path) | jest `testMatch` picks up **every `.js`** under `__tests__/` | none (independent) |
+| **Yes** (real transaction) | `tests/_orders/<Category>/mutations/<Resolver>.js` | imported by the category's `_.test.js` | **guaranteed** within the category |
+
+- **Why the split:** `__tests__` tests are independent and run in any order, so jest matches each
+  file directly. `_orders` tests run against the **seeded DB** and mutate shared rows — their outcome
+  depends on running in a fixed sequence. So jest matches **only** each category's `_.test.js`, and
+  that file `import`s the write tests in order. The individual write files are named `<Resolver>.js`
+  (not `*.test.js`) so jest does **not** pick them up on their own — they run only when `_.test.js`
+  imports them.
+
+## What goes in `tests/__tests__/` (no writes)
+
+Mirror the resolver's source location under `tests/__tests__/`, then test the members that need no
+DB — using `.create()` and `jest.spyOn` to substitute collaborators:
+
+```
+server/graphql/resolvers/user/actual/mutations/CreateArticleMutationResolver.js
+  ↔ tests/__tests__/server/graphql/resolvers/user/mutations/CreateArticleMutationResolver.js
+```
+
+Cover here:
+
+- **`.get:schema`** and **`.get:errorCodeHash`** — static getters (single `test()` is fine; static
+  getters are the exception to `test.each` in the project's jest rules).
+- **`#createInputValidator()` / `#validateInput()`** — assert they build/run the validator, with the
+  validator **mocked** (`jest.spyOn(resolver, 'createInputValidator').mockReturnValue(...)`); never
+  reach the real DB.
+- **`#formatResponse()`** — pure shaping; feed an entity, assert the returned ids.
+- **the factory / creators** (§7 DI) — `static create()` defaults and `static createXxx()` seams.
+
+```js
+import CreateArticleMutationResolver from '../../../../../../../server/graphql/resolvers/user/actual/mutations/CreateArticleMutationResolver.js'
+
+describe('CreateArticleMutationResolver', () => {
+  describe('.get:schema', () => {
+    test('returns the schema name', () => {
+      expect(CreateArticleMutationResolver.schema)
+        .toBe('createArticle')
+    })
+  })
+})
+```
+
+## What goes in `tests/_orders/` (writes)
+
+The members that actually persist — **`#generateTransactionCallback()`** (run through
+`Model.beginTransaction(callback)`) and **`#resolve()`** (the full flow) — go under the category of
+the **model the resolver writes to**:
+
+```
+tests/_orders/<Category>/mutations/<Resolver>.js
+```
+
+- **`<Category>` is the primary written model's name**, not the operation's. `CreateArticle` /
+  `UpdateArticle` → `tests/_orders/Article/mutations/`. When the operation writes a different model
+  than its name suggests (e.g. a `publishArticle` that writes an `ArticleStatus` row), the category
+  follows the **written** model — `tests/_orders/ArticleStatus/mutations/`.
+- The file drives the real transaction against the seeded DB:
+
+```js
+import Article from '../../../../sequelize/models/Article.js'
+
+import CreateArticleMutationResolver from '../../../../server/graphql/resolvers/user/actual/mutations/CreateArticleMutationResolver.js'
+
+describe('CreateArticleMutationResolver', () => {
+  describe('#generateTransactionCallback()', () => {
+    // ... cases with unique, explicit-fake seed values ...
+    test.each(cases)('...', async ({
+      params,
+      expected,
+    }) => {
+      const resolver = CreateArticleMutationResolver.create()
+
+      const callback = resolver.generateTransactionCallback(params)
+
+      // real write
+      const actual = await Article.beginTransaction(callback)
+
+      expect(actual)
+        .toEqual(expected)
+    })
+  })
+})
+```
+
+Cover here the write-path behavior: a valid input **creates/updates** the expected row; a missing
+row throws the `204.*` `XxxNotFound`; an ownership violation throws `NotAllowedToXxx`; a no-op input
+throws `CurrentXxxIsSameAsTheNewOne`. Use `describe` (not `if`) to separate the success and failure
+branches — per the project's jest rules.
+
+## The category `_.test.js` (ordering entry point)
+
+Each `tests/_orders/<Category>/` holds one `_.test.js` — the only file jest matches in the category.
+It `import`s the category's write tests in the intended run order:
+
+```js
+// tests/_orders/Article/_.test.js
+import './mutations/CreateArticleMutationResolver.js'
+import './mutations/UpdateArticleMutationResolver.js'
+import './mutations/DeleteArticleMutationResolver.js'
+```
+
+When you add a new write test, create the `<Resolver>.js` file under the category's `mutations/` and
+**add one `import` line to that category's `_.test.js`** in the correct position. Without the import
+line the test never runs.
+
+## Everything else → the project's jest rules
+
+Data conventions (all fields unique, explicit-fake values — `title: 'string'` is weak; prefer
+distinct values), `describe`/`test.each` structure, the AAA layout, and `jest.spyOn` mocking are the
+same as any class test. Follow the project's jest rules; this page only adds
+the **placement** rule specific to resolvers.

--- a/kit/skills/backend/hb-mutation-resolver/references/transaction.md
+++ b/kit/skills/backend/hb-mutation-resolver/references/transaction.md
@@ -1,0 +1,197 @@
+# generateTransactionCallback — one transaction, all writes
+
+`generateTransactionCallback({ input, context })` is where the resolver's real work lives. It
+returns a single **`async transaction => { ... }`** closure that performs **every find and save for
+the request**, and it is run by `Model.beginTransaction(callback)`. This file covers the rules that
+keep that closure correct.
+
+> Examples use a generic `Article` entity (with a `Tag` many-side and a nested `ArticleCategory`
+> association). Swap in your own models — the rules are what transfer.
+
+## The closure is built, then run
+
+`generateTransactionCallback` returns the closure — it does not execute it. `resolve()` hands the
+closure to `beginTransaction`, which opens a managed transaction, invokes the closure with the live
+`transaction`, commits on success, and rolls back if the closure throws.
+
+```js
+const callback = this.generateTransactionCallback({
+  input,
+  context,
+})
+
+// opens the transaction, runs the callback, commits (or rolls back on throw)
+const article = await Article.beginTransaction(callback)
+```
+
+- Destructure `input` and `context` **in the parameter list** of `generateTransactionCallback` so
+  the closure body reads flat. Pull out exactly the fields the writes need (`now`, `userId`, and the
+  input columns).
+- The closure's return value is what `beginTransaction` resolves to and what `resolve()` passes to
+  `formatResponse`.
+
+## Rule 1 — every query takes the same `transaction`
+
+Pass the `transaction` the closure received into **every** `findOne` / `findAll` / `create` /
+`save` inside it. A query without it runs outside the transaction and defeats the point.
+
+```js
+return async transaction => {
+  // every query takes the same `transaction`
+  const article = await this.findArticle({
+    articleId,
+    transaction,
+  })
+
+  // ...
+
+  return article.save({
+    transaction,
+  })
+}
+```
+
+- **Why one transaction for the whole request:** a `find` and its dependent `save` split across two
+  transactions let a concurrent request interleave — `find1 → find2 → save1 → save2` — and write
+  duplicate or stale state. One transaction serializes the read-modify-write.
+
+## Rule 2 — guard state inside the closure; throw to roll back
+
+Existence, ownership, and no-op checks belong **here**, not in the validator (the validator only
+knows input shape, not the DB). Throw the matching `204.*` error from `this.errorHash`; the throw
+rolls the transaction back.
+
+```js
+return async transaction => {
+  const article = await this.findArticle({
+    articleId: input.articleId,
+    transaction,
+  })
+
+  // 204.* — not found
+  if (!article) {
+    throw this.errorHash.ArticleNotFound.create()
+  }
+
+  // 204.* — ownership
+  if (
+    !this.isArticleAuthor({
+      article,
+      context,
+    })
+  ) {
+    throw this.errorHash.NotAllowedToEditArticle.create()
+  }
+
+  // ... proceed with the writes ...
+}
+```
+
+```js
+isArticleAuthor ({
+  article,
+  context,
+}) {
+  return article.CreatedByUserId === context.userId
+}
+```
+
+- **A "nothing changed" guard is legitimate**: if the new values equal the current ones, throw a
+  `CurrentXxxIsSameAsTheNewOne` (`204.*`) rather than issuing a pointless write.
+- Use early `if (...) throw` — no nested branches, no `else`. One guard per `if`.
+
+## Rule 3 — `.set()` + `.save()` to update; `.create()` to insert; never `.update()`
+
+The models use a backup mixin that snapshots the full row, so a partial `.update()` can lose
+fields. Always load, mutate, and save the whole instance.
+
+```js
+// update: load → set → save
+article.set({
+  title,
+  content,
+  LastModifiedByUserId: userId,
+  lastModifiedAt: now,
+})
+
+return article.save({
+  transaction,
+})
+```
+
+```js
+// create: one call, with nested associations via `include`
+return Article.create({
+  title,
+  content,
+  CreatedByUserId: userId,
+  LastModifiedByUserId: userId,
+  lastModifiedAt: now,
+  savedAt: now,
+  isDeleted: false,
+
+  // nested association row
+  ArticleCategory: {
+    CategoryId: categoryId,
+  },
+}, {
+  // list the child model(s) for the nested create
+  include: [
+    ArticleCategory,
+  ],
+  transaction,
+})
+```
+
+- **Nested create:** to insert an entity together with its associations in one statement, put the
+  child object(s) under the association name and list the child model(s) in `include`.
+- **FK columns start uppercase** (`CreatedByUserId`, `CategoryId`) — the association's naming
+  convention, mirrored from the migration/model side.
+- **Bulk existence guard:** when the input carries an id array, dedupe and count before writing —
+
+```js
+const uniqueTagIds = [...new Set(tagIds)]
+
+const tags = await this.findTags({
+  tagIds: uniqueTagIds,
+  transaction,
+})
+
+if (tags.length !== uniqueTagIds.length) {
+  throw this.errorHash.TagNotFound.create()
+}
+```
+
+  Use `map` / `filter` / `Set`, not `Array#forEach` / `for`.
+
+## Extracting attribute-building
+
+When the create payload is large, build it in a separate `buildXxxAttributes({ ... })` method that
+returns the plain object, and keep the closure to *find-guard-create*. Place `buildXxxAttributes`
+next to the closure that calls it. This keeps the transaction closure readable and the attribute
+shape unit-testable on its own.
+
+## Side effects that must run after commit
+
+Work that must observe the **committed** result — refreshing a denormalized read model, updating a
+cache, notifying another system — runs in `resolve()` **after** `beginTransaction` returns, not
+inside the closure. It reads the returned entity and does its own work.
+
+```js
+const article = await Article.beginTransaction(callback)
+
+// after commit: propagate the persisted row to the read side
+await this.refreshReadModel({
+  article,
+})
+
+return this.formatResponse({
+  article,
+})
+```
+
+- **Why after, not inside:** the side effect should reflect data that actually committed; running it
+  in the transaction would act on rows that a later rollback discards.
+- **If the side effect is slow or unreliable** (large re-index, external call, bulk fan-out), do not
+  run it inline at all — enqueue a Worker and return. Decide following the project's
+  execution-placement-pattern conventions.

--- a/kit/skills/backend/hb-post-worker/SKILL.md
+++ b/kit/skills/backend/hb-post-worker/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: hb-post-worker
+description: >
+  Implement a GraphQL post-worker: a hook that fires after a query/mutation resolver has resolved
+  and the response has been sent, to run a side effect that is not part of the API's main
+  processing (send a welcome email after signup, emit an audit log, invalidate a cache). Use this
+  skill whenever the user asks to add or edit a post-worker, wants "run something after this
+  resolver / after the response", or needs to fire-and-forget a side effect right after an API
+  call.
+---
+
+# Post-Worker (a post-response side-effect hook)
+
+A skill for implementing `BaseGraphqlPostWorker`, a hook that runs a side effect — one that is *not*
+part of the API's main processing — **after** the resolver has resolved (after the response has been
+sent). It handles requirements of the form "after this operation, also run …" as a follow-up, without
+polluting the resolver itself.
+
+Deciding the placement itself (whether a post-worker is even the right choice, versus enqueuing inside
+the resolver) is settled in section 2.2 of `hb-execution-placement-pattern`. This skill covers "once
+you've decided on a post-worker, how to implement it". The implementation of the worker body you
+dispatch to belongs to `hb-renchan-job-bullmq`.
+
+## Grand principle: a post-worker is a thin layer that only dispatches — the real work always lives in the worker
+
+The only things you may write in a post-worker's `onResolved()` are **the dispatch to a background
+worker and the branching that precedes it**. **Write no real work at all** — no email-body assembly,
+no external API calls, no DB updates, no heavy loops.
+
+- **Why only dispatch**: a post-worker fires **after** the HTTP response has been fully sent (Express's
+  `res.on('finish')`). Throwing an exception here **never reaches the caller, and neither retry,
+  progress notification, nor monitoring apply**. Put real work here and logic accumulates in a place
+  where failures get swallowed. Keep it to dispatch and the real work runs on the worker's machinery
+  (retries, observability, scaling), while the post-worker stays predictably thin — "just enqueuing".
+- **Why add a post-worker layer at all**: for something like "I don't want to make the signup response
+  wait, but I do want to send a welcome email" — writing a **side effect unrelated to the main
+  processing** into the resolver itself bloats the resolver's responsibility and lets a side-effect
+  failure drag down the main processing's response. Push it out to a post-worker and the resolver can
+  focus on returning its proper result.
+- **If the decision touches "heavy / want to retry", go to the worker.** A post-worker is itself a thin
+  hook that is never re-run, so any processing that must not fail, or that takes time, always belongs
+  in the worker you dispatch to.
+
+```js
+// Good: the post-worker only dispatches (the real work of the side effect is on the worker side)
+/** @override */
+async onResolved ({
+  variables,
+  context,
+  information,
+  response: {
+    output,
+    error,
+  },
+}) {
+  if (error) {
+    return
+  }
+
+  await context.share.jobDispatcherProvider.dispatchJob({
+    DispatcherCtor: SendWelcomeEmailJobDispatcher,
+    body: {
+      customerId: output.customer.id,
+    },
+  })
+}
+```
+
+```js
+// Avoid: writing email-body assembly or sending logic directly in the post-worker
+//   → real work accumulates in a post-response place where failures get swallowed, and neither retry nor monitoring apply. Put the real work in the worker.
+async onResolved ({ output }) {
+  const html = await this.buildWelcomeMailHtml({ output }) // real work
+  await this.mailer.send({ to: output.customer.email, html }) // external I/O — if it fails, no one notices
+}
+```
+
+## Comment language in the sample code
+
+Comments in the `js` examples in this SKILL.md follow the prose language (here, **English**), because
+the examples are *explanation* of the skill. Comments inside the **artifact this skill produces** (the
+real `*PostWorker.js` code) follow the **codebase** language — English — to match the surrounding source.
+
+## 1. How it works (when it fires and what it receives)
+
+A post-worker is a hook **per operation (query / mutation)**. The framework (renchan) fires it in the
+following flow.
+
+1. When the resolver resolves (or throws), the framework stores
+   `{ variables, context, information, response }` bound to the request (`response` is
+   `{ output, error: null }` on success, `{ output: null, error }` on failure).
+2. **After the HTTP response has been fully sent** (`res.on('finish')`), using the stored content, it
+   fires in this order:
+   - first the engine-wide `defineOnResolved()` (a noop by default, **common to all operations**),
+   - then the `onResolved()` of **the post-worker whose name matches that operation**.
+
+- **The correspondence to an operation is by name match.** A post-worker is called only when the string
+  returned by its `static get schema()` matches the fired operation's name (the GraphQL field name,
+  e.g. `signUp`). **One post-worker per operation** (don't define the same `schema` more than once).
+- `onResolved()` receives the **same `context`** as the resolver. This is the key point: because
+  `context` reaches the shared instances (the job dispatcher, etc.), a post-worker can dispatch a worker
+  ([2](#2-dispatch-a-worker-from-contextshare)).
+- `variables` is the operation's input arguments, `output` is the resolver's return value, and
+  `information` is the resolve info (`fieldName`, etc.).
+
+Arguments `onResolved()` receives:
+
+| Argument | Contents |
+| --- | --- |
+| `variables` | The operation's input arguments (the same ones the resolver received) |
+| `context` | The same context as the resolver. `context.share` holds the shared instances ([2](#2-dispatch-a-worker-from-contextshare)) |
+| `information` | GraphQL resolve info (`fieldName` = the operation name, etc.) |
+| `response.output` | The resolver's return value (on success). `null` on failure |
+| `response.error` | The error the resolver threw (on failure). `null` on success |
+
+## 2. Dispatch a worker from `context.share`
+
+A post-worker receives the same `context` as the resolver, and `context` has **`share`**. `share` holds
+the instances the app uses in common, and in many renchan apps it keeps the **renchan-job-bullmq
+dispatch entry point** (`jobDispatcherProvider`). A post-worker uses this to enqueue a worker.
+
+```js
+// Dispatch via share (a JobDispatcherProvider that reuses the connection)
+await context.share.jobDispatcherProvider.dispatchJob({
+  DispatcherCtor: SendWelcomeEmailJobDispatcher, // the Dispatcher of the job to enqueue
+  body: {
+    customerId: output.customer.id, // keep the body minimal (just ids or tokens)
+  },
+})
+```
+
+- **Why use `context.share`**: taking the dispatch entry point from the request-scoped shared instance
+  lets you reuse the connection to Redis, etc. Don't `new` a Dispatcher every time inside the post-worker.
+- The implementation of **the job you dispatch (Manifest / Worker / Dispatcher)** follows
+  `hb-renchan-job-bullmq`. The post-worker side only decides "which Dispatcher, with what
+  body" to enqueue.
+- What's in `share` is app-dependent. Confirm the name of the dispatch entry point
+  (`jobDispatcherProvider`, etc.) in that app's Share implementation. **If it's missing, the right move
+  is to add it to share** — don't create a connection on the fly inside the post-worker.
+
+## 3. Implementation steps
+
+Steps to add one new post-worker.
+
+### Step 1: Create the post-worker class
+
+Extend `BaseGraphqlPostWorker` and override the following two. The file name is `<Operation>PostWorker.js`
+(a name that makes the corresponding operation clear; align it with the resolver's naming).
+
+- `static get schema()`: returns the **operation name** to hook (the GraphQL field name).
+- `async onResolved({ variables, context, information, response })`: write dispatch only (the grand
+  principle at the top of this file).
+
+```js
+import {
+  BaseGraphqlPostWorker,
+} from '@openreachtech/renchan'
+
+import SendWelcomeEmailJobDispatcher from '../../../../app/jobs/send-welcome-email/SendWelcomeEmailJobDispatcher.js'
+
+/**
+ * Post-worker: dispatch a welcome email after signUp resolves.
+ *
+ * @extends {BaseGraphqlPostWorker<*, *, *>}
+ */
+export default class SignUpPostWorker extends BaseGraphqlPostWorker {
+  /**
+   * get: Operation name to hook.
+   *
+   * @override
+   * @returns {string}
+   */
+  static get schema () {
+    return 'signUp'
+  }
+
+  /**
+   * On resolved hook. Dispatch only; the real work lives in the worker.
+   *
+   * @override
+   */
+  async onResolved ({
+    variables,
+    context,
+    information,
+    response: {
+      output,
+      error,
+    },
+  }) {
+    if (error) {
+      return
+    }
+
+    await context.share.jobDispatcherProvider.dispatchJob({
+      DispatcherCtor: SendWelcomeEmailJobDispatcher,
+      body: {
+        customerId: output.customer.id,
+      },
+    })
+  }
+}
+```
+
+### Step 2: Guard against failures and missing values
+
+- **If there's an `error`, return early.** Enqueuing a side effect (like sending an email) when the
+  operation failed creates inconsistency. The standard guard is `if (!output || error) { return }` —
+  treat a missing `output` the same as a failure.
+- **Check that the values you read from `output` exist.** A post-worker runs after the resolver
+  succeeds, but if `output`'s shape differs from what you expect, traverse it defensively like
+  `output?.customer?.id` and don't dispatch when it's absent.
+- **Don't throw from `onResolved()`.** It's after the response has been sent, so no one can catch it.
+  Handle it with branching and return early.
+- **Don't declare an `errorCodeHash` getter on a post-worker.** Unlike a resolver, a post-worker has
+  no error contract with the caller (the response is already sent), so failures are handled by
+  branching and early returns, not by raising error codes.
+
+### Step 3: Wire it into the engine (`postWorkersPath`)
+
+Post-workers are **auto-loaded recursively** from the directory the engine's `config.postWorkersPath`
+points at (only classes extending `BaseGraphqlPostWorker` are picked up). While `postWorkersPath` is
+`null`, post-workers **never fire at all**.
+
+- Following the resolver layout, prepare a per-role directory like
+  `server/graphql/post-workers/<role>/` and point `postWorkersPath` at it.
+
+```js
+// server/graphql/CustomerGraphqlServerEngine.js
+/** @override */
+static get config () {
+  return {
+    // ...existing config...
+    actualResolversPath: rootPath.to('server/graphql/resolvers/customer/actual/'),
+    // Before: postWorkersPath: null,
+    postWorkersPath: rootPath.to('server/graphql/post-workers/customer/'),
+  }
+}
+```
+
+- If you need **engine-wide post-processing (common to all operations)**, override the engine's
+  `defineOnResolved()` rather than a post-worker under `postWorkersPath`. The "dispatch only" principle
+  still applies here too. Use them separately: **a post-worker for a specific operation's
+  post-processing, `defineOnResolved()` for post-processing across all operations.**
+
+## 4. Use cases (what to put in a post-worker)
+
+All of these are **side effects unrelated to the main processing that you don't want to make the
+response wait for**, and in the post-worker you **only dispatch**.
+
+| Use case | Example operation to hook | What the dispatched worker does |
+| --- | --- | --- |
+| Notification email right after signup | `signUp` | Generate and send the welcome email body |
+| Recording an audit log / operation history | Each mutation | Write the changes to the audit store |
+| Syncing to an external system / webhook notification | `createXxx` / `updateXxx` | Push to the external API (external API client) |
+| Cache invalidation / rebuild | Data-updating mutations | Delete and warm up the cache |
+| Sending analytics events | Any operation | Send measurement events to analytics |
+
+- **What a post-worker is not suited for**: processing whose result **the caller waits for / is included
+  in the response** is too late in a post-worker (since it runs after the response). Handle that in the
+  resolver itself, or with enqueuing inside the resolver (`hb-execution-placement-pattern` 2.1).
+
+## 5. Testing
+
+A post-worker has thin logic (dispatch only), so keep its tests thin too. Following the `hc-jest` skill,
+split files per class.
+
+- That it extends `BaseGraphqlPostWorker` (inheritance).
+- That `static get schema()` returns the **correct operation name**.
+- The branching in `onResolved()`:
+  - **On success** (`error: null`, `output` present) → **dispatch is called** with the expected
+    `DispatcherCtor` and `body`.
+  - **On failure** (`error` present) → **dispatch is not called** (early return).
+- Stub the dispatch entry point. Replace `context.share.jobDispatcherProvider.dispatchJob` with a
+  `jest.fn()` and verify the arguments (`DispatcherCtor` / `body`). **Don't actually enqueue a job.**
+
+```js
+// Success case: verify only that dispatch is called with the correct Dispatcher and body
+const dispatchJobSpy = jest.fn()
+const context = {
+  share: {
+    jobDispatcherProvider: {
+      dispatchJob: dispatchJobSpy,
+    },
+  },
+}
+
+await SignUpPostWorker.create({ engine })
+  .onResolved({
+    variables: {},
+    context,
+    information: {},
+    response: {
+      output: {
+        customer: {
+          id: 'fake-customer-id-001',
+        },
+      },
+      error: null,
+    },
+  })
+
+expect(dispatchJobSpy)
+  .toHaveBeenCalledWith({
+    DispatcherCtor: SendWelcomeEmailJobDispatcher,
+    body: {
+      customerId: 'fake-customer-id-001',
+    },
+  })
+```
+
+## Finishing checklist
+
+- [ ] Is what you wrote in `onResolved()` **only dispatch and branching** (did you put the real work in the worker)?
+- [ ] Does `static get schema()` match the **operation name** it hooks (one post-worker per operation)?
+- [ ] Do you return early when there's an `error`, and guard against a missing `output`? Are you not throwing from `onResolved()`?
+- [ ] Is the dispatch via `context.share`'s shared dispatch entry point (not `new`-ing a connection inside the post-worker)?
+- [ ] Did you wire the engine's `postWorkersPath` (it won't fire while it stays `null`)?
+- [ ] Did you use `defineOnResolved()` for post-processing across all operations and a post-worker for a specific operation, appropriately?
+- [ ] In tests, did you verify "dispatched on success / not on failure" with a stub of the dispatch entry point?

--- a/kit/skills/backend/hb-query-resolver/SKILL.md
+++ b/kit/skills/backend/hb-query-resolver/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: hb-query-resolver
+description: >
+  Write GraphQL Query resolvers under
+  server/graphql/resolvers/<endpoint>/{actual,stub}/queries/<Operation>QueryResolver.js, extending
+  BaseQueryResolver from @openreachtech/renchan. Use this skill whenever the user asks to add or
+  edit a read query resolver, including its pagination, association includes, domain-error
+  throwing, and the actual-vs-stub pair. Input validation belongs to the resolver input-validator
+  convention; state-changing operations belong to the mutation resolver convention.
+---
+
+# Query Resolver
+
+A skill for writing the **`*QueryResolver` classes** that answer a GraphQL `Query` field. A query
+resolver **extends `BaseQueryResolver`** (from `@openreachtech/renchan`), is **read-only** (it never
+opens a transaction — that is the mutation side's job), and always follows the same shape: a `schema`
+getter that names the GraphQL field, an `errorCodeHash`, and a `resolve()` that **validates the
+input, reads data, throws domain errors, and formats the response**.
+
+> Examples use a made-up `users` domain (a `User` model with a `UserProfile` / `Department` / `Role`
+> around it) on the `admin` endpoint. They are placeholders — swap in the resource, fields, and
+> endpoint of the query you are writing.
+
+This skill covers the **resolver class itself**. Two related skills own the pieces it delegates to:
+
+- The `*InputValidator` it calls belongs to `hb-resolver-validator` —
+  this skill only shows the wiring, not the validator internals.
+- The unit tests belong to `hc-jest` — see [testing.md](./references/testing.md) for
+  the resolver-specific shape.
+
+> This is the **Query** side. A **Mutation** resolver is a different template (it wraps a
+> transaction callback and returns save results); do not copy this skeleton for a write.
+
+## Core principle: a query resolver is a filled-in template
+
+Every query resolver has the **same skeleton** — `schema` getter → `errorCodeHash` → `resolve()` →
+validation wiring → finders → `formatResponse()` → error creators → a trailing block of `@typedef`s.
+Keep the skeleton identical so review attention goes straight to the **query-specific differences
+(what it reads and how it shapes the result)**. Do not write it cleverly; lean toward the layout of
+the existing resolvers.
+
+`resolve()` reads as a fixed pipeline:
+
+1. **Validate** the input (`validateInput()` returns an error **or `null`**; `throw` it when present).
+2. **Read** the data (finders: `findX()` / `countX()`), passing already-trusted input.
+3. **Throw domain errors** for not-found / empty results, via `this.errorHash.Xxx.create()`.
+4. **Format** the result to the GraphQL schema shape (`formatResponse()`), and `return` it.
+
+```js
+/** @override */
+async resolve ({
+  variables: {
+    input,
+  },
+}) {
+  const validationError = this.validateInput({
+    input,
+  })
+
+  if (validationError) {
+    throw validationError
+  }
+
+  const user = await this.findUser({
+    userId: input.userId,
+  })
+
+  if (!user) {
+    throw this.errorHash.UserNotFound.create()
+  }
+
+  return this.formatResponse({
+    user,
+  })
+}
+```
+
+- **No transaction.** Queries only read. Reach for `.findOne` / `.findByPk` / `.findAll` / `.count`;
+  never `db.transaction(...)` here.
+- **`resolve()` orchestrates; the small methods do the work.** Each `findX` / `buildWhereClause` /
+  `formatResponse` has one job and is unit-testable in isolation. Do not inline a 60-line find or a
+  giant response object into `resolve()`.
+- The full member-by-member template with JSDoc and the typedef block is in
+  [anatomy.md](./references/anatomy.md).
+
+## 1. Directory, class name, and schema linkage
+
+One resolver = one file. Placement encodes the endpoint and whether it is real or a stub:
+
+```
+server/graphql/resolvers/<endpoint>/<actual|stub>/queries/<Operation>QueryResolver.js
+```
+
+- `<endpoint>` is the GraphQL endpoint the resolver serves: `user`, `customer`, `admin`, `portal`,
+  `jobs`. It maps to a `*GraphqlServerEngine` (e.g. `server/graphql/AdminGraphqlServerEngine.js`).
+- `<actual|stub>` — **`actual`** holds the real business logic; **`stub`** returns fixed fake data
+  for the frontend to develop against ([errors-and-context.md](./references/errors-and-context.md)).
+- Class name = `<Operation>QueryResolver` (PascalCase), default-exported, one class per file.
+- **Auto-loaded — no manual registration.** The engine loads every file under `.../queries/` by
+  directory (`actualResolversPath` in the engine config). Adding the file is enough; there is no
+  index to edit.
+- **`schema` getter = the GraphQL `Query` field name** (camelCase). It must match a field declared in
+  `server/graphql/schemas/<endpoint>/*.graphql`, whose `Input!` / `Result!` types become the
+  resolver's `input` and return shape:
+
+  ```graphql
+  # server/graphql/schemas/admin/003-user.graphql
+  type Query {
+    users(input: UsersInput!): UsersResult!
+  }
+  ```
+
+  ```js
+  /** @override */
+  static get schema () {
+    return 'users'
+  }
+  ```
+
+## 2. Member order
+
+Declare members in this fixed order (matches the existing resolvers and the backend guideline):
+
+1. `static get schema ()` — the GraphQL field name. `@override`.
+2. `static get errorCodeHash ()` — spread `...super.errorCodeHash`, then this resolver's codes (§4).
+3. `async resolve ({ variables, context })` — the entrypoint. `@override`.
+4. `validateInput ({ input })` — runs the validator, returns the error or `null`.
+5. `createInputValidator ({ input, errorHash })` — factory for the `*InputValidator`.
+6. **Finders and helpers**, in call order (`findX` / `countX` / `buildWhereClause` / `create*`).
+   Place each helper right after its caller; unrelated helpers go in dictionary order.
+7. `formatResponse ({ ... })` — shape the GraphQL result.
+8. Error creators (`createXxxNotFoundError`), when domain errors are built through helpers.
+
+After the class, a block of `@typedef`s (`ErrorCodeHash`, the `Input` / `Result` aliases, `ErrorHash`,
+`RenchanGraphqlErrorCtor`, and any associated-entity types). See [anatomy.md](./references/anatomy.md).
+
+## 3. Reading data
+
+Finders are thin wrappers over the Sequelize models; keep query-shape logic (where clauses,
+includes, pagination) in their own small methods so `resolve()` stays a pipeline.
+
+- **Single record:** `Model.findByPk(id, { include })` / `Model.findOne({ where, include })`, then a
+  not-found guard that throws a domain error.
+- **List with pagination:** the canonical trio is `buildWhereClause()` → `countX({ whereClause })`
+  (for `totalRecords`) → `findX({ whereClause, pagination })` (with `offset` / `limit` / `order`).
+- **Associations:** pass an `include` tree of models; deep values are pulled out in `formatResponse`
+  with `FieldPathValueExtractor`.
+
+The where-clause / pagination / include / extractor patterns are in
+[data-access.md](./references/data-access.md).
+
+## 4. errorCodeHash and domain errors
+
+`errorCodeHash` maps each error name to a **string code**; `.create()` turns those into the
+`this.errorHash.<Name>` constructors the resolver throws. Spread the parent first:
+
+```js
+/** @override */
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    // Invalid Input Errors (203 prefix)
+    InvalidUserId: '203.Q002.001',
+
+    // Database Errors (204 prefix)
+    UserNotFound: '204.Q002.001',
+  }
+}
+```
+
+- **Leading number = error family.** `203` invalid input, `204` database / not-found, `205` business
+  logic / external API. (Framework standards live above these: `102` unauthorized, `104` database —
+  do not redefine them.)
+- **Middle segment (`Q002`) is a stable per-query identifier**; the trailing `001…` numbers the
+  errors within this resolver. Keep a given resolver on one identifier and add sequentially.
+- **Input-shape errors** (`InvalidXxx`) are raised by the validator via the shared `errorHash`, so
+  their names must exist here. **Domain errors** (`XxxNotFound`, `NoXxxFound`) are thrown from
+  `resolve()` with `this.errorHash.Xxx.create()` (optionally through a `createXxxError()` helper).
+
+The families, the validator↔errorHash contract, and error-creator helpers are in
+[errors-and-context.md](./references/errors-and-context.md).
+
+## 5. Input validation wiring
+
+The resolver does not validate inline — it delegates to a `*InputValidator`
+(`hb-resolver-validator`) through two small methods:
+
+```js
+validateInput ({
+  input,
+}) {
+  const validator = this.createInputValidator({
+    input,
+  })
+
+  return validator.validateInput()
+}
+
+createInputValidator ({
+  input,
+  errorHash = this.errorHash,
+}) {
+  return UsersInputValidator.create({
+    input,
+    errorHash,
+  })
+}
+```
+
+- `validateInput()` returns the error **or `null`**; `resolve()` throws it when present (do not throw
+  from inside `validateInput`). The validator is fed the resolver's own `errorHash`, so its
+  `InvalidXxx` names resolve to the codes declared in §4.
+- A resolver that takes no input (or only auth from `context`) has **no** validator — see the
+  minimal `departments` / `userSummary` resolvers in [anatomy.md](./references/anatomy.md).
+
+## 6. Formatting the response
+
+`formatResponse()` is the **only** place that builds the GraphQL output object. It maps model
+entities to the schema's field names — never returns raw model instances.
+
+- Rename model columns to schema fields (`user.id` → `userId`), map arrays to their output shape, and
+  **echo pagination** (`limit` / `offset` / `sort` / `totalRecords`) for lists.
+- Read deep association values with `FieldPathValueExtractor`; guard optional relations and default
+  missing scalars (`?? ''` / `?? null`) rather than leaking `undefined`
+  ([data-access.md](./references/data-access.md)).
+
+## 7. Testing
+
+Each public member is unit-tested with the `hc-jest` skill: a top-level `describe` per
+member, `test.each` cases, and `Resolver.create()` with no args. `#resolve()` gets both the
+happy path and a throws-case per error code; `.get:schema` asserts the field name. The
+resolver-specific structure (mocking the validator, DB-backed finder cases, `formatResponse` with
+built model instances) is in [testing.md](./references/testing.md).
+
+## Detail files
+
+- [anatomy.md](./references/anatomy.md) — the full canonical resolver (every member with JSDoc, the
+  minimal no-input variant, and the trailing `@typedef` block) (§2)
+- [data-access.md](./references/data-access.md) — finders, `buildWhereClause`, the count+findAll
+  pagination trio, association `include` trees, model `subquery()`, and `FieldPathValueExtractor` (§3, §6)
+- [errors-and-context.md](./references/errors-and-context.md) — the errorCodeHash prefix families, the
+  validator↔errorHash contract, domain-error creators, reading auth/providers off `context`, and
+  actual-vs-stub resolvers (§1, §4)
+- [testing.md](./references/testing.md) — the member-by-member test layout for a query resolver,
+  building on the jest skill (§7)

--- a/kit/skills/backend/hb-query-resolver/references/anatomy.md
+++ b/kit/skills/backend/hb-query-resolver/references/anatomy.md
@@ -1,0 +1,384 @@
+# Anatomy (the full resolver template + typedefs)
+
+The complete member-by-member shape of a query resolver, the minimal no-input variant, and the
+trailing `@typedef` block. Referenced from §2 of [SKILL.md](../SKILL.md).
+
+> The `users` / `User` / `Department` / `Role` names below are placeholder domain names — swap in your
+> resource, fields, and endpoint.
+
+## Full template (a paginated list query)
+
+This is the canonical shape: `schema` getter → `errorCodeHash` → `resolve()` (validate → read →
+format) → validation wiring → finders → `formatResponse()`, then the typedefs. Members appear in the
+fixed order; each does one job.
+
+```js
+import {
+  Op,
+} from 'sequelize'
+
+import {
+  BaseQueryResolver,
+} from '@openreachtech/renchan'
+
+import UsersInputValidator from '../../../../../../app/tools/Validator/forResolver/admin/queries/UsersInputValidator.js'
+
+import User from '../../../../../../sequelize/models/User.js'
+import UserProfile from '../../../../../../sequelize/models/UserProfile.js'
+
+/**
+ * Resolve the users query.
+ *
+ * @extends {BaseQueryResolver}
+ */
+export default class UsersQueryResolver extends BaseQueryResolver {
+  /** @override */
+  static get schema () {
+    return 'users'
+  }
+
+  /**
+   * .get:errorCodeHash
+   *
+   * @override
+   * @returns {ErrorCodeHash}
+   */
+  static get errorCodeHash () {
+    return {
+      ...super.errorCodeHash,
+
+      // Invalid Input Errors (203 prefix)
+      InvalidKeyword: '203.Q001.001',
+      InvalidDepartmentId: '203.Q001.002',
+      InvalidPaginationLimit: '203.Q001.003',
+      InvalidPaginationOffset: '203.Q001.004',
+      InvalidPaginationSort: '203.Q001.005',
+    }
+  }
+
+  /**
+   * Resolve the users query.
+   *
+   * @override
+   * @param {{
+   *   variables: {
+   *     input: server.graphql.admin.UsersInput
+   *   }
+   * }} params
+   * @returns {Promise<server.graphql.admin.UsersResult>}
+   */
+  async resolve ({
+    variables: {
+      input,
+    },
+  }) {
+    const validationError = this.validateInput({
+      input,
+    })
+
+    if (validationError) {
+      throw validationError
+    }
+
+    const {
+      departmentId,
+      keyword,
+      pagination,
+    } = input
+
+    const whereClause = this.buildWhereClause({
+      departmentId,
+      keyword,
+    })
+
+    const totalRecords = await this.countUsers({
+      whereClause,
+    })
+
+    const users = await this.findUsers({
+      whereClause,
+      pagination,
+    })
+
+    return this.formatResponse({
+      users,
+      pagination,
+      totalRecords,
+    })
+  }
+
+  /**
+   * Validate the input of the users query.
+   *
+   * @param {{
+   *   input: server.graphql.admin.UsersInput
+   * }} params
+   * @returns {InstanceType<RenchanGraphqlErrorCtor> | null}
+   */
+  validateInput ({
+    input,
+  }) {
+    const validator = this.createInputValidator({
+      input,
+    })
+
+    return validator.validateInput()
+  }
+
+  /**
+   * Create a UsersInputValidator instance.
+   *
+   * @param {{
+   *   input: server.graphql.admin.UsersInput
+   *   errorHash?: ErrorHash
+   * }} params
+   * @returns {UsersInputValidator}
+   */
+  createInputValidator ({
+    input,
+    errorHash = this.errorHash,
+  }) {
+    return UsersInputValidator.create({
+      input,
+      errorHash,
+    })
+  }
+
+  /**
+   * Build the where clause for the users query.
+   *
+   * @param {{
+   *   departmentId?: number
+   *   keyword?: string
+   * }} params
+   * @returns {object}
+   */
+  buildWhereClause ({
+    departmentId,
+    keyword,
+  }) {
+    const conditions = []
+
+    if (
+      keyword
+      && keyword.trim().length > 0
+    ) {
+      conditions.push({
+        name: {
+          [Op.like]: `${keyword}%`,
+        },
+      })
+    }
+
+    if (departmentId) {
+      conditions.push({
+        DepartmentId: departmentId,
+      })
+    }
+
+    if (conditions.length === 0) {
+      return {}
+    }
+
+    return {
+      [Op.and]: conditions,
+    }
+  }
+
+  /**
+   * Count users.
+   *
+   * @param {{
+   *   whereClause: object
+   * }} params
+   * @returns {Promise<number>}
+   */
+  countUsers ({
+    whereClause,
+  }) {
+    return User.count({
+      where: whereClause,
+    })
+  }
+
+  /**
+   * Find users.
+   *
+   * @param {{
+   *   whereClause: object
+   *   pagination: graphql.NormalPaginationInput
+   * }} params
+   * @returns {Promise<Array<model.User>>}
+   */
+  async findUsers ({
+    whereClause,
+    pagination: {
+      limit,
+      offset,
+      sort = {
+        targetColumn: 'name',
+        orderBy: 'ASC',
+      },
+    },
+  }) {
+    return /** @type {Promise<*>} */ (
+      User.findAll({
+        where: whereClause,
+        offset,
+        limit,
+        order: [
+          [sort.targetColumn, sort.orderBy],
+        ],
+      })
+    )
+  }
+
+  /**
+   * Format the response for the users query.
+   *
+   * @param {{
+   *   users: Array<model.User>
+   *   pagination: graphql.NormalPaginationInput
+   *   totalRecords: number
+   * }} params
+   * @returns {server.graphql.admin.UsersResult}
+   */
+  formatResponse ({
+    users,
+    pagination: {
+      limit,
+      offset,
+      sort = null,
+    },
+    totalRecords,
+  }) {
+    return {
+      users: users
+        .map(user => ({
+          userId: user.id,
+          name: user.name,
+          email: user.email,
+          isActive: user.isActive,
+        })),
+      pagination: {
+        limit,
+        offset,
+        sort,
+        totalRecords,
+      },
+    }
+  }
+}
+
+/**
+ * @typedef {{
+ *   InvalidKeyword: string
+ *   InvalidDepartmentId: string
+ *   InvalidPaginationLimit: string
+ *   InvalidPaginationOffset: string
+ *   InvalidPaginationSort: string
+ * }} ErrorCodeHash
+ */
+
+/**
+ * @typedef {Record<string, RenchanGraphqlErrorCtor>} ErrorHash
+ */
+
+/**
+ * @typedef {typeof import('@openreachtech/renchan').RenchanGraphqlError} RenchanGraphqlErrorCtor
+ */
+```
+
+## Member order (recap)
+
+1. `static get schema ()`
+2. `static get errorCodeHash ()`
+3. `async resolve ()`
+4. `validateInput ()`
+5. `createInputValidator ()`
+6. finders / helpers, **in call order** (`buildWhereClause` → `countX` → `findX`); unrelated helpers
+   in dictionary order
+7. `formatResponse ()`
+8. error creators (`createXxxNotFoundError`), when built through helpers ([errors-and-context.md](./errors-and-context.md))
+
+- A `constructor` / `static create ()` is added **only** when the resolver needs an extra
+  dependency; the framework's `BaseResolver.create()` already builds the instance (injecting
+  `errorHash` from `errorCodeHash`) for the common case, so most resolvers declare neither.
+
+## Minimal variant (no input, no validator)
+
+When the field takes no `input` (or only reads auth off `context`), drop the validation wiring
+entirely. Still declare `schema` and `errorCodeHash`:
+
+```js
+import {
+  BaseQueryResolver,
+} from '@openreachtech/renchan'
+
+import Department from '../../../../../../sequelize/models/Department.js'
+
+export default class DepartmentsQueryResolver extends BaseQueryResolver {
+  /** @override */
+  static get schema () {
+    return 'departments'
+  }
+
+  /** @override */
+  static get errorCodeHash () {
+    return {
+      ...super.errorCodeHash,
+    }
+  }
+
+  /** @override */
+  async resolve () {
+    const departmentEntries = /** @type {Array<*>} */ (
+      await Department.findAll()
+    )
+
+    const departments = departmentEntries
+      .map(({
+        id,
+        name,
+      }) => ({
+        id,
+        name,
+      }))
+
+    return {
+      departments,
+    }
+  }
+}
+```
+
+## The trailing typedef block
+
+Types tied to the DB and the GraphQL schema live in `/types` (`model.*`, `server.graphql.*`); the
+resolver file only **aliases** them and declares its own local shapes. Keep the block at the bottom,
+after the class. A resolver with associations typically declares:
+
+- `ErrorCodeHash` — the keys of `errorCodeHash` (values `string`).
+- `Input` / `Result` aliases — `@typedef {server.graphql.<endpoint>.XxxInput} XxxInput`.
+- `ErrorHash` — `Record<string, RenchanGraphqlErrorCtor>`.
+- `RenchanGraphqlErrorCtor` — `typeof import('@openreachtech/renchan').RenchanGraphqlError`.
+- An **associated-entity** typedef describing the `include` tree, when a finder returns a record with
+  nested associations:
+
+```js
+/**
+ * @typedef {model.UserEntity & {
+ *   UserProfile: model.UserProfileEntity
+ *   Department: model.DepartmentEntity & {
+ *     Office: model.OfficeEntity
+ *   }
+ *   UserRoleAssignments: Array<model.UserRoleAssignmentEntity & {
+ *     Role: model.RoleEntity
+ *   }>
+ * }} UserWithAssociations
+ */
+```
+
+- When the resolver reads auth or injected providers off `context`, also alias the context type:
+  `@typedef {import('../../../../contexts/AdminGraphqlContext.js').default} AdminGraphqlContext`
+  ([errors-and-context.md](./errors-and-context.md)).

--- a/kit/skills/backend/hb-query-resolver/references/data-access.md
+++ b/kit/skills/backend/hb-query-resolver/references/data-access.md
@@ -1,0 +1,248 @@
+# Data access (finders, pagination, includes, extraction)
+
+How a query resolver reads and shapes data: where-clause builders, the count+findAll pagination
+trio, association `include` trees, model `subquery()`, and `FieldPathValueExtractor`. Referenced from
+§3 and §6 of [SKILL.md](../SKILL.md).
+
+> The `User` / `UserProfile` / `Department` / `Office` / `Role` names are placeholder domain names —
+> swap in your own models and fields.
+
+## Finders are thin; the query shape lives in its own method
+
+Keep `resolve()` a pipeline by giving each read its own small method. A finder wraps one Sequelize
+call; the where clause, pagination, and includes are built by dedicated helpers so each is
+independently testable.
+
+- **One record:** `Model.findByPk(id, { include })` or `Model.findOne({ where, include })`, followed
+  by a not-found guard in `resolve()` that throws a domain error
+  ([errors-and-context.md](./errors-and-context.md)).
+- **A list:** `Model.findAll({ where, offset, limit, order })`.
+- **A count:** `Model.count({ where })` — used for `totalRecords`.
+
+```js
+async findUser ({
+  userId,
+  activeRoleId,
+}) {
+  return /** @type {Promise<UserWithAssociations | null>} */ (
+    User.findByPk(userId, {
+      include: [
+        {
+          model: UserRoleAssignment,
+          required: true,
+          where: {
+            RoleId: activeRoleId,
+          },
+        },
+        UserProfile,
+      ],
+    })
+  )
+}
+```
+
+- Cast the Sequelize return to your associated-entity typedef with a `/** @type {...} */ ( ... )`
+  wrapper — the model methods return loosely-typed instances.
+
+## Pagination: the count + findAll trio
+
+A paginated list query is always the same three steps, driven from `resolve()`:
+
+1. `buildWhereClause()` — turn the input filters into a Sequelize `where` object.
+2. `countX({ whereClause })` — total matching rows, **before** paging, for `totalRecords`.
+3. `findX({ whereClause, pagination })` — the page, applying `offset` / `limit` / `order`.
+
+```js
+const whereClause = this.buildWhereClause({ departmentId, keyword })
+const totalRecords = await this.countUsers({ whereClause })
+const users = await this.findUsers({ whereClause, pagination })
+```
+
+- **Both** the count and the find use the **same** `whereClause`, so the total matches the filter.
+- `pagination` is destructured in the finder with a **default sort** so a missing `sort` still
+  produces a deterministic order:
+
+  ```js
+  pagination: {
+    limit,
+    offset,
+    sort = {
+      targetColumn: 'name',
+      orderBy: 'ASC',
+    },
+  },
+  // ...
+  order: [
+    [sort.targetColumn, sort.orderBy],
+  ],
+  ```
+
+- `formatResponse()` **echoes** the pagination back (`limit` / `offset` / `sort` / `totalRecords`) so
+  the client can render the pager ([response formatting](#formatresponse-shape-dont-leak-models)).
+- The allowed `sort` columns are enforced by the `*InputValidator`, not here
+  (`hb-resolver-validator`).
+
+## buildWhereClause: accumulate conditions, combine with Op.and
+
+Build the `where` by pushing each active filter onto a `conditions` array, then combine. Skip a
+filter when its input is absent so an empty input means "no filter" (return `{}`).
+
+```js
+buildWhereClause ({
+  departmentId,
+  keyword,
+}) {
+  const conditions = []
+
+  const keywordInspector = ValueInspector.create({
+    value: keyword,
+  })
+
+  if (
+    keywordInspector.isPresent()
+    && keyword.trim().length > 0
+  ) {
+    conditions.push({
+      [Op.or]: [
+        {
+          id: {
+            [Op.in]: UserProfile.subquery(
+              '?firstName?lastName.UserId',
+              {
+                keyword,
+              }
+            ),
+          },
+        },
+        {
+          name: {
+            [Op.like]: `${keyword}%`,
+          },
+        },
+      ],
+    })
+  }
+
+  if (departmentId) {
+    conditions.push({
+      DepartmentId: departmentId,
+    })
+  }
+
+  if (conditions.length === 0) {
+    return {}
+  }
+
+  return {
+    [Op.and]: conditions,
+  }
+}
+```
+
+- Import `Op` from `sequelize`. Use `[Op.like]` for prefix search (`` `${keyword}%` ``), `[Op.or]`
+  for multi-column keyword match, `[Op.in]` with a subquery for a related-table filter.
+- Import `ValueInspector` from `@openreachtech/mentsu-value-inspector`;
+  `ValueInspector.create({ value: keyword }).isPresent()` guards `null` / `undefined` before
+  `keyword.trim()`. The package has no string/blank inspector (presence + number / integer / date
+  only), so the blank `.trim().length > 0` check stays inline.
+- `Model.subquery('<field-spec>', { keyword })` returns a subquery usable inside `[Op.in]` — it lets a
+  keyword filter reach columns on an associated table (here `UserProfile`) without a join. Match the
+  field-spec string to the model's declared subquery.
+
+## Association includes
+
+Read nested data with an `include` tree passed to the finder. Bare models include the whole
+association; an object form adds `where` / `required` / `as` / nested `include`.
+
+```js
+include: [
+  UserProfile,                          // include the whole association
+  {
+    model: Office,
+    as: 'HomeOffice',                   // aliased association (same model, distinct role)
+  },
+  {
+    model: Office,
+    as: 'BranchOffice',
+  },
+  {
+    model: Department,
+    include: [
+      Office,                           // nested include
+    ],
+  },
+  {
+    model: UserRoleAssignment,
+    required: true,                     // INNER JOIN — filters the parent
+    where: {
+      RoleId: activeRoleId,
+    },
+  },
+]
+```
+
+- `required: true` makes it an inner join (the parent row is dropped when the association is absent) —
+  use it to filter by a related table. Default is a left join.
+- Add `separate: true` to a `hasMany` include that needs its **own `order` / `limit`** — Sequelize
+  runs it as a separate query, which also avoids the N+1 a bare nested `hasMany` can cause on a large
+  parent set.
+- Describe the resulting shape with an associated-entity `@typedef`
+  ([anatomy.md](./anatomy.md#the-trailing-typedef-block)) so the extractor and `formatResponse` are
+  type-checked.
+
+## formatResponse: shape, don't leak models
+
+`formatResponse()` maps the model entities to the schema's field names and is the only place that
+builds the output object. Never return a raw model instance.
+
+- Rename columns to schema fields (`user.id` → `userId`).
+- Map arrays to their output shape; `filter` out records whose required association is missing.
+- Default missing scalars (`?? ''` / `?? null`) — do not leak `undefined`.
+- **Money / decimal fields → strings.** Emit a decimal (money, rate) via `BigNumber(value).toFixed(2)`
+  (compute into a named `const` first), matching the `String!` SDL money type (`hb-graphql-schema`) —
+  never a raw JS number.
+- Echo pagination for lists.
+
+### Deep values via FieldPathValueExtractor
+
+When a value sits several associations deep, pull it with `FieldPathValueExtractor` instead of
+walking `a?.b?.c` by hand. Create one per root entity and read by dotted field path:
+
+```js
+const userFieldPathValueExtractor = FieldPathValueExtractor.create({
+  originEntity: user,
+})
+
+const bio = userFieldPathValueExtractor.extractFieldPathValue({
+  fieldPath: 'User.UserProfile.bio',
+})
+```
+
+- The path starts at the **root model name** and walks association names down to the column.
+- For an optional nested object, extract the id first and branch:
+
+  ```js
+  const departmentId = extractor.extractFieldPathValue({
+    fieldPath: 'User.Department.id',
+  })
+
+  return {
+    department: departmentId
+      ? {
+        departmentId,
+        name: extractor.extractFieldPathValue({ fieldPath: 'User.Department.name' }),
+      }
+      : null,
+  }
+  ```
+
+- Guard array associations with `?? []` before `map`, and drop incomplete records with `filter`:
+
+  ```js
+  roles: (user.UserRoleAssignments ?? [])
+    .filter(record => record?.Role?.name)
+    .map(record => ({
+      roleId: record.Role.id,
+      name: record.Role.name,
+    })),
+  ```

--- a/kit/skills/backend/hb-query-resolver/references/errors-and-context.md
+++ b/kit/skills/backend/hb-query-resolver/references/errors-and-context.md
@@ -1,0 +1,172 @@
+# Errors, context, and actual-vs-stub
+
+The errorCodeHash prefix families, the validator↔errorHash contract, domain-error creators, reading
+auth and injected providers off `context`, and the actual-vs-stub split. Referenced from §1 and §4 of
+[SKILL.md](../SKILL.md).
+
+> The `users` / `User` / `Department` names and the `Q001` / `Q002` identifiers are placeholders —
+> swap in your resource and this resolver's own identifier.
+
+## errorCodeHash: families and identifiers
+
+`errorCodeHash` maps each error **name** to a **string code**; the framework's `create()` turns those
+into the `this.errorHash.<Name>` constructors the resolver and its validator throw. Always spread
+`...super.errorCodeHash` first, then group this resolver's codes with a one-line family comment.
+
+```js
+/** @override */
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    // Invalid Input Errors (203 prefix)
+    InvalidUserId: '203.Q002.001',
+    InvalidDepartmentId: '203.Q002.002',
+
+    // Database Errors (204 prefix)
+    UserNotFound: '204.Q002.001',
+    DepartmentNotFound: '204.Q002.002',
+  }
+}
+```
+
+Code format is `<family>.<identifier>.<seq>`:
+
+- **`<family>`** — the leading number classifies the error:
+  - `203` — invalid input (raised by the `*InputValidator`).
+  - `204` — database / not-found (thrown from `resolve()`).
+  - `205` — business logic / external API.
+  - Framework standards sit above these and are already defined by the engine — do **not** redeclare
+    them: `102` unauthenticated / unauthorized / denied-permission, `104` database, `100` unknown,
+    `101` concrete-member-not-found.
+- **`<identifier>`** (`Q002`, …) is a **stable per-query id**. Keep one resolver on one identifier;
+  the letter tracks the endpoint family (`Q` for the query endpoints).
+- **`<seq>`** (`001`, `002`, …) numbers the errors within this resolver, per family.
+
+## The validator ↔ errorHash contract
+
+Input-shape errors are **not** thrown by the resolver directly — the `*InputValidator` raises them
+through the **same `errorHash`** the resolver passes in. So every `InvalidXxx` the validator can raise
+must have a matching key in the resolver's `errorCodeHash`.
+
+- The resolver's `createInputValidator()` forwards `errorHash = this.errorHash`
+  ([SKILL.md §5](../SKILL.md)); the validator's `ErrorHash` typedef lists those same `InvalidXxx`
+  names (`hb-resolver-validator`).
+- `validateInput()` returns the error or `null`; `resolve()` decides to throw. Keeping the throw in
+  `resolve()` (not the validator) keeps the entrypoint's control flow visible.
+
+## Domain errors: throw from resolve(), optionally via a creator
+
+Not-found and empty-result errors are thrown where they are detected — right after the finder — with
+`this.errorHash.<Name>.create()`:
+
+```js
+const user = await this.findUser({ userId })
+
+if (!user) {
+  throw this.errorHash.UserNotFound.create()
+}
+```
+
+- **Never wrap the read/throw in `try/catch`.** The GraphQL layer maps a thrown declared error to the
+  response; a `try/catch` that swallows or re-wraps it hides which code the caller receives. Let the
+  declared error propagate.
+
+When a resolver throws several domain errors, wrap each in a **creator method** so `resolve()` stays
+readable and the construction is unit-testable. Creators sit at the bottom of the class (after
+`formatResponse`) and default `errorHash` to `this.errorHash`:
+
+```js
+if (users.length === 0) {
+  throw this.createUserNotFoundError()
+}
+
+// ... lower in the class ...
+
+/**
+ * Create a UserNotFoundError instance.
+ *
+ * @param {{
+ *   errorHash?: ErrorHash
+ * }} [params]
+ * @returns {InstanceType<RenchanGraphqlErrorCtor>}
+ */
+createUserNotFoundError ({
+  errorHash = this.errorHash,
+} = {}) {
+  return errorHash.UserNotFound.create()
+}
+```
+
+## Reading context (auth + injected providers)
+
+`resolve()` receives `{ variables, context, information, parent }`. **`context`** carries the
+authenticated principal and request-scoped providers the engine injects. Destructure only what you
+use; omit `context` entirely when the query needs nothing from it.
+
+```js
+async resolve ({
+  context,
+}) {
+  const roleIds = context.employee.EmployeeRoleAssignments
+    .map(employeeRoleAssignment => employeeRoleAssignment.RoleId)
+
+  // ...
+}
+```
+
+```js
+async resolve ({
+  variables: {
+    input,
+  },
+  context: {
+    modelProvider,          // an injected provider, destructured directly
+  },
+}) {
+  // ... use modelProvider ...
+}
+```
+
+- The principal lives under the endpoint's name: `context.user` (user endpoint), `context.customer`
+  (customer endpoint), `context.employee` (admin endpoint), etc. — with its associations preloaded
+  (e.g. `context.employee.EmployeeRoleAssignments`).
+- Request-scoped providers the engine injects also live on `context`.
+- **Authentication/authorization is enforced by the engine before `resolve()` runs** (the `102`
+  standard codes). Do not re-check auth here; just read the trusted principal.
+- Alias the context type in the typedef block:
+  `@typedef {import('../../../../contexts/AdminGraphqlContext.js').default} AdminGraphqlContext`, and
+  reference it from the `resolve()` param JSDoc.
+
+## Actual vs stub
+
+Every endpoint has parallel `actual/` and `stub/` trees; the engine wires each via
+`actualResolversPath` / `stubResolversPath`.
+
+- **`actual/queries/`** — the real resolver: validate, read the DB, throw domain errors, format. This
+  is what this skill describes.
+- **`stub/queries/`** — a same-`schema` resolver returning **fixed fake data** so the frontend can
+  build against the contract before the real query exists. Stubs skip validation and the DB, often
+  `await sleep(...)` to mimic latency, and return literal objects:
+
+  ```js
+  export default class UserSummaryQueryResolver extends BaseQueryResolver {
+    /** @override */
+    static get schema () {
+      return 'userSummary'
+    }
+
+    /** @override */
+    async resolve () {
+      await sleep(200)
+
+      return {
+        totalUsers: 1234,
+        activeUsers: 987,
+      }
+    }
+  }
+  ```
+
+- A stub and its actual share the `schema` name and the GraphQL result shape; only the body differs.
+  Keep stub data **obviously fake** so it is never mistaken for real output.

--- a/kit/skills/backend/hb-query-resolver/references/testing.md
+++ b/kit/skills/backend/hb-query-resolver/references/testing.md
@@ -1,0 +1,241 @@
+# Testing a query resolver
+
+The member-by-member test layout for a `*QueryResolver`, building on the `hc-jest`
+skill. Referenced from §7 of [SKILL.md](../SKILL.md). This file only covers what is
+resolver-specific; describe/test structure, `cases` data rules, AAA, and naming come from the jest
+skill.
+
+> The `Users` / `User` names, the `203.Q001.*` codes, and the `users` schema below are placeholders —
+> swap in your resolver's own names and codes.
+
+## File location and construction
+
+- The test mirrors the resolver path under `tests/__tests__/` but **without the `actual/` segment**:
+  `server/graphql/resolvers/admin/actual/queries/UsersQueryResolver.js`
+  → `tests/__tests__/server/graphql/resolvers/admin/queries/UsersQueryResolver.js`.
+- A DB-backed resolver test reads the seeded database (`npm test` seeds `dev-master` + `development`),
+  so finder cases assert against known seed rows.
+- Build the resolver with the framework factory, **no args**: `const resolver = Resolver.create()`.
+  `create()` injects `errorHash` from `errorCodeHash` for you.
+
+## One top-level describe per member
+
+Per the jest skill, give **each** public member its own top-level `describe('<Resolver>')` →
+`describe('#member()')`. A query resolver typically tests: `#resolve()`, `#validateInput()`,
+`#createInputValidator()`, the finders (`#buildWhereClause()`, `#countX()`, `#findX()`),
+`#formatResponse()`, and `.get:schema`.
+
+## `#resolve()`: happy path + a throws-case per error code
+
+Split valid and error runs into sub-`describe`s. The happy path asserts the whole formatted result;
+the error path asserts the **error code** for each way the query can fail.
+
+```js
+describe('UsersQueryResolver', () => {
+  describe('#resolve()', () => {
+    describe('when input is valid', () => {
+      const cases = [
+        {
+          params: {
+            variables: {
+              input: {
+                keyword: null,
+                departmentId: null,
+                pagination: {
+                  limit: 10,
+                  offset: 0,
+                  sort: {
+                    targetColumn: 'name',
+                    orderBy: 'ASC',
+                  },
+                },
+              },
+            },
+          },
+          expected: {
+            users: [
+              // ... rows from the seed, fully spelled out ...
+            ],
+            pagination: {
+              limit: 10,
+              offset: 0,
+              sort: {
+                targetColumn: 'name',
+                orderBy: 'ASC',
+              },
+              totalRecords: 11,
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('keyword: $params.variables.input.keyword', async ({
+        params,
+        expected,
+      }) => {
+        const resolver = UsersQueryResolver.create()
+
+        const actual = await resolver.resolve(params)
+
+        expect(actual)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should throw error', () => {
+      const cases = [
+        {
+          params: {
+            variables: {
+              input: {
+                keyword: /** @type {*} */ (1),
+                pagination: {
+                  limit: 1,
+                  offset: 0,
+                },
+              },
+            },
+          },
+          errorCode: '203.Q001.001',
+        },
+        {
+          params: {
+            variables: {
+              input: {
+                keyword: null,
+                pagination: {
+                  limit: -1,
+                  offset: 0,
+                },
+              },
+            },
+          },
+          errorCode: '203.Q001.003',
+        },
+      ]
+
+      test.each(cases)('limit: $params.variables.input.pagination.limit', async ({
+        params,
+        errorCode,
+      }) => {
+        const resolver = UsersQueryResolver.create()
+
+        const actual = resolver.resolve(params)
+
+        await expect(actual)
+          .rejects
+          .toThrow(errorCode)
+      })
+    })
+  })
+})
+```
+
+- Assert the **thrown error by its code string** with `.rejects.toThrow('203.Q001.003')`. Cover at
+  least one case per `InvalidXxx` (via bad input) and per domain error (`XxxNotFound`, by asking for a
+  missing id).
+- Cast deliberately-wrong input to `/** @type {*} */ (...)` so the type checker allows the invalid
+  case.
+
+## `#validateInput()` and `#createInputValidator()`
+
+Test the wiring, not the validator's internals (those belong to
+`hb-resolver-validator`'s own test).
+
+- **`#validateInput()`** — `jest.spyOn(resolver, 'createInputValidator')` to return a mock validator
+  whose `validateInput()` is stubbed; assert `#validateInput()` returns exactly what the validator
+  returned (an error or `null`) and that the mock was called.
+- **`#createInputValidator()`** — assert the returned instance `toBeInstanceOf` the expected
+  `*InputValidator` and that its `errorHash` is the resolver's `errorHash` (`toBe(resolver.errorHash)`).
+
+## Finders and `#formatResponse()`
+
+- **Finders** (`#countX`, `#findX`, `#buildWhereClause`) are tested directly against the seed. For
+  `buildWhereClause`, assert the returned Sequelize `where` object with `toEqual` — including `Op`
+  symbol keys and any `Model.subquery(...)` expression, which you reproduce in `expected`.
+- **`#formatResponse()`** is pure and DB-free: **build** model instances with `Model.build({...})` for
+  the input entities, call `formatResponse`, and `toEqual` the exact GraphQL shape (renamed fields,
+  defaulted scalars, echoed pagination).
+
+```js
+describe('UsersQueryResolver', () => {
+  describe('#formatResponse()', () => {
+    /** @type {Array<*>} */
+    const cases = [
+      {
+        params: {
+          users: [
+            User.build({
+              id: 1,
+              name: 'Alpha',
+              email: 'alpha@example.com',
+              isActive: true,
+            }),
+          ],
+          pagination: {
+            limit: 10,
+            offset: 0,
+          },
+          totalRecords: 1,
+        },
+        expected: {
+          users: [
+            {
+              userId: 1,
+              name: 'Alpha',
+              email: 'alpha@example.com',
+              isActive: true,
+            },
+          ],
+          pagination: {
+            limit: 10,
+            offset: 0,
+            sort: null,
+            totalRecords: 1,
+          },
+        },
+      },
+    ]
+
+    test.each(cases)('totalRecords: $params.totalRecords', ({
+      params,
+      expected,
+    }) => {
+      const resolver = UsersQueryResolver.create()
+
+      const actual = resolver.formatResponse(params)
+
+      expect(actual)
+        .toEqual(expected)
+    })
+  })
+})
+```
+
+## `.get:schema`
+
+The static getter is a single-value contract — a plain `test` (no `test.each`) is fine here, per the
+jest skill's exception for argument-less static getters:
+
+```js
+describe('UsersQueryResolver', () => {
+  describe('.get:schema', () => {
+    test('should return correct schema name', () => {
+      const actual = UsersQueryResolver.schema
+
+      expect(actual)
+        .toBe('users')
+    })
+  })
+})
+```
+
+## Reminders from the jest skill
+
+- **Unique, explicitly-fake data** across every field and row; comments in the test `.js` in English.
+- **Do not shrink coverage using implementation knowledge** — test each member's contract as a black
+  box, including `formatResponse`'s field renames and defaulting (feed values that make the transform
+  visible, not no-op values).
+- For a resolver that reads `context`, pass a **stub context** in `params` shaped like the real
+  principal (`{ context: { employee: { EmployeeRoleAssignments: [...] } } }`); see
+  [errors-and-context.md](./errors-and-context.md).

--- a/kit/skills/backend/hb-renchan-job-bullmq/SKILL.md
+++ b/kit/skills/backend/hb-renchan-job-bullmq/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: hb-renchan-job-bullmq
+description: >
+  Write and wire background jobs with @openreachtech/renchan-job-bullmq (BullMQ on Redis). Use
+  this skill whenever the user asks to add or edit a job under app/jobs/** — a Manifest / Worker /
+  Dispatcher triple, a cron or interval (repeatable) job, enqueuing from a GraphQL/REST resolver,
+  publishing progress to a GraphQL subscription, the worker daemon entry point, splitting work
+  across queues, or tuning concurrency / retries / rate limits.
+---
+
+# renchan-job-bullmq
+
+`@openreachtech/renchan-job-bullmq` is this repo's job framework: **BullMQ queues on Redis**, wrapped
+in renchan base classes. A job is a small **template of class files in one directory** under
+`app/jobs/<job-name>/`. Two long-running processes share **one Redis** (`pm2.config.cjs`):
+
+- **GraphQL API** (`server/index.js`) — handles requests and **enqueues** jobs (producer).
+- **Job Daemon** (`scripts/startJobDaemon.js`) — **runs** the workers (consumer) and
+  **publishes progress** back over Redis PubSub to the API's GraphQL subscriptions.
+
+This overview maps each topic to a section; the specifics are in the detail files under
+`references/`. The package's own usage samples live in `samples/confirm-01` (dispatch + daemon) and
+`samples/confirm-02` (cron + interval schedulers) of the `hb-renchan-job-bullmq` package.
+
+## Core principle: a job is a filled-in template of 3–4 files
+
+Each job is a directory `app/jobs/<kebab-job-name>/` holding a fixed set of classes, each extending a
+renchan base, all pointing at one central **Engine**:
+
+| File | Base class | Responsibility |
+| --- | --- | --- |
+| `<Name>JobManifest.js` | `BaseJobManifest` | the **queue name** (`jobName`) + the **body schema** |
+| `<Name>JobWorker.js` | `BaseJobWorker` | **consume**: `executeJob()` + lifecycle hooks |
+| `<Name>JobDispatcher.js` | `BaseJobDispatcher` | **produce**: enqueue + per-queue `optionHash` |
+| `<Name>CronJobScheduler.js` / `<Name>IntervalJobScheduler.js` | `BaseCronJobScheduler` / `BaseIntervalJobScheduler` | (scheduled jobs) register a repeatable job |
+
+Keep the layout identical across jobs so review attention goes to the job's *logic*. Directory =
+kebab = `jobName`; classes are PascalCase with those fixed suffixes. Structural comments are English;
+the domain-explanation comments in the real files are Japanese (they cite the plan, `T-JOB-*`) —
+match the surrounding code.
+
+## 1. Basic usage — the Manifest / Worker / Dispatcher triple
+
+- **Manifest** — `jobName` (the queue name, == the directory) + `bodySchema` (`ScalarHash` scalars
+  `Text` / `Integer` / … from `@openreachtech/mentsu-schema`). Keep the body minimal (ids/tokens).
+- **Worker** — `static get ManifestCtor()` + `async executeJob({ body, context, parcel })` + the four
+  abstract lifecycle hooks (`onJobCompleted` / `onJobFailed` / `onJobProgress` / `onWorkerError`).
+  **`executeJob`'s return value is stored in Redis — return only the minimum**, never entity arrays.
+  Override `buildOptionHash()` for `concurrency` / `limiter`.
+- **Dispatcher** — `static get EngineCtor()` + `static get ManifestCtor()` + optional
+  `static get optionHash()` (BullMQ `QueueOptions`, e.g. `defaultJobOptions.attempts`). To stay DRY,
+  a base app dispatcher can set `EngineCtor` once so each job dispatcher only sets `ManifestCtor`.
+
+```js
+// Manifest — the source of truth for the queue name and payload shape
+export default class SendReportEmailJobManifest extends BaseJobManifest {
+  /** @override */ static get jobName () { return 'send-report-email' }
+
+  /** @override */
+  static get bodySchema () {
+    return {
+      sessionToken: Text,
+    }
+  }
+}
+```
+
+**Enqueue** from a resolver via the request-scope `JobDispatcherProvider` (connection reuse):
+
+```js
+await context.share.jobDispatcherProvider.dispatchJob({
+  DispatcherCtor: SendReportEmailJobDispatcher,
+  body: {
+    sessionToken,
+  },
+})
+```
+
+Standalone (one-off): `const dispatcher = await Dispatcher.createAsync(); await dispatcher.dispatchJob({ body }); await dispatcher.teardown()`
+— `dispatchJob` returns a response with `hasError()` / `hasResponse()` / `createDispatchedAt()`.
+
+Full classes, hooks, the base-app-dispatcher pattern, and the enqueue paths are in
+[job-triple.md](./references/job-triple.md).
+
+## 2. Engine / Share / Context / RedisConnection
+
+- **Engine** (`ContentGenerationJobEngine.js`) —
+  the one config object: `config` = `{ workersPath, schedulersPath, redisConfig }` (both paths point
+  at `app/jobs`), plus `ShareCtor` / `ContextCtor`, error codes, log path. `createAsync({ subscriptionBroker })`
+  injects the progress broker (§4).
+- **Share** — per-**process** DI (holds `subscriptionBroker` or `null`, `env`, `timber`, …).
+- **Context** — per-**job** DI, created for each run and passed to `executeJob`.
+- **RedisConnection** (`app/queue/RedisConnection.js`) —
+  `generateConnectionOptions()` for BullMQ (**`maxRetriesPerRequest: null` required**) and
+  `generatePubSubOptions()` for the broker. **API and Daemon must share one Redis.**
+
+Details and the package-exports table are in [engine-and-infra.md](./references/engine-and-infra.md).
+
+## 3. Entry points — the worker Daemon and the scheduler
+
+**Worker Daemon** — `JobWorkersDaemon` auto-discovers every `BaseJobWorker` under `workersPath`
+(`DeepBulkClassLoader`), binds each to its `jobName`, and installs graceful SIGINT/SIGTERM shutdown.
+Two boot shapes:
+
+- **Simple** (no progress broker): `JobWorkersDaemon.createAsync({ EngineCtor }).then(daemon => daemon.startDaemon())`.
+- **With a broker** (this repo, `scripts/startJobDaemon.js`):
+  build a `SubscriptionBroker`, inject it via `Engine.createAsync({ subscriptionBroker })`, then
+  `JobWorkersDaemon.loadWorkerCtors({ engine })` → `.create({ engine, WorkerCtors }).startDaemon()`.
+
+**Scheduler registration** is a **one-shot** script (`scripts/start-schedule.js`):
+`SchedulerService.createAsync({ EngineCtor })` → `startAllSchedulers()` → exit. It writes repeatable
+jobs to Redis; the Daemon consumes them. `stopAllSchedulers()` removes them without stopping the
+Daemon.
+
+**pm2** (`pm2.config.cjs`) runs `GraphQL API` and `Job Daemon`.
+
+Both boot paths, cron **and interval** schedulers, and the start/stop scripts are in
+[daemon-and-scheduler.md](./references/daemon-and-scheduler.md).
+
+## 4. Integrating with subscriptions (progress → GraphQL)
+
+A worker in the Daemon **publishes** progress on a `channel` namespaced by a `scope`; a GraphQL
+subscription in the API process **subscribes** with the **same channel + scope**, over the shared
+Redis PubSub broker.
+
+- The Daemon injects the broker (§3, Path B); enqueue-only processes pass none → publish is a no-op.
+- AI workers get this automatically from `BaseAgentJobWorker`; the app base
+  `BaseContentGenerationJobWorker.js` sets
+  `channel = 'reportProgress'` and `buildScope` (`accessToken` else `jobId`).
+- The subscriber
+  (`OnReportProgressSubscriptionResolver.js`)
+  must match the channel and scope. This is why the public-lp queue body carries `accessToken` (§5).
+
+The publish/subscribe wiring and checklist are in [subscriptions.md](./references/subscriptions.md).
+
+## 5. Splitting queues
+
+**One queue == one job directory == one Manifest `jobName`.** The repo splits the same content-generation
+work into `content-generation-internal` (`{ jobId }`) and `content-generation-public-lp`
+(`{ jobId, accessToken }`) so they scale and subscribe independently.
+
+- **Share logic** via an app base worker, but **place that base OUTSIDE `workersPath`** — the Daemon
+  boots every `BaseJobWorker` under `app/jobs`, and an abstract base without a `jobName` crashes
+  startup. Only concrete workers go under `app/jobs/**`.
+- Run a **subset** of queues per Daemon with `skipJobHash` (`{ [jobName]: true }`).
+- Tune per queue: Dispatcher `optionHash` (attempts) + Worker `buildOptionHash()` (concurrency,
+  limiter).
+
+Details and the directory diagram are in [queues.md](./references/queues.md).
+
+## 6. Other building blocks
+
+- **Cron / interval jobs** — `BaseCronJobScheduler` (`{ cronExpression }`) or `BaseIntervalJobScheduler`
+  (`{ millisecond, isImmediately }`), listed in `SchedulerService.collectScheduleInputs()` with a
+  `schedulerId` matching the scheduler class. See [daemon-and-scheduler.md](./references/daemon-and-scheduler.md).
+- **Connection reuse** — `JobDispatcherProvider`
+  (`app/tools/JobDispatcherProvider.js`) caches one
+  Dispatcher per `DispatcherCtor` and dispatches with `keepsConnection: true`; the request Share
+  holds one, torn down on process exit. Prefer it over `Dispatcher.createAsync()` per request.
+- **Retries & idempotency** — set `attempts` in `optionHash`; make `executeJob` idempotent (BullMQ may
+  re-run). Expensive AI jobs checkpoint to `content_generations.intermediate_steps_json` and
+  resume on retry.
+- **Concurrency & rate limiting** — `buildOptionHash()` forwards `concurrency` + `limiter`
+  (`app/tools/ContentGenerationRateLimiter.js`).
+- **Testing** — unit-test workers/dispatchers with the `hc-jest` skill.
+
+## Detail files
+
+- [job-triple.md](./references/job-triple.md) — Manifest / Worker / Dispatcher in full, body schema,
+  lifecycle hooks, the return-value-in-Redis rule, base-app-dispatcher DRY, enqueue paths (§1)
+- [engine-and-infra.md](./references/engine-and-infra.md) — Engine config, Share, Context,
+  RedisConnection, package exports (§2)
+- [daemon-and-scheduler.md](./references/daemon-and-scheduler.md) — `JobWorkersDaemon` (both boot
+  paths), `scripts/*`, cron + interval schedulers, the scheduler service, pm2 (§3, §6)
+- [subscriptions.md](./references/subscriptions.md) — progress publish/subscribe, channel + scope,
+  AI-worker plumbing (§4)
+- [queues.md](./references/queues.md) — splitting queues, shared-base placement, `skipJobHash`,
+  per-queue tuning (§5)

--- a/kit/skills/backend/hb-renchan-job-bullmq/references/daemon-and-scheduler.md
+++ b/kit/skills/backend/hb-renchan-job-bullmq/references/daemon-and-scheduler.md
@@ -1,0 +1,182 @@
+# The worker Daemon and the schedulers
+
+Entry points: the worker Daemon (consumer) and the cron/interval scheduler registration. Referenced
+from §3 and §6 of [SKILL.md](../SKILL.md). Draws on this repo's `scripts/` and the package's
+`samples/confirm-01` (daemon) and `samples/confirm-02` (cron + interval schedulers).
+
+## Worker Daemon
+
+`JobWorkersDaemon` boots every `BaseJobWorker` subclass found under the engine's `workersPath`
+(`DeepBulkClassLoader` scans recursively; a new job directory is picked up with no registration),
+binds each to its Manifest's `jobName`, and installs SIGINT/SIGTERM graceful shutdown.
+
+### Path A — simple (`createAsync`), no progress broker
+
+The minimal form (the package `samples/confirm-01` shows this shape) is `createAsync` →
+`startDaemon`:
+
+```js
+import { JobWorkersDaemon } from '@openreachtech/renchan-job-bullmq'
+import SampleJobEngine from '../app/SampleJobEngine.js'
+
+// createAsync builds the engine and auto-discovers every BaseJobWorker under workersPath
+const daemon = await JobWorkersDaemon.createAsync({
+  EngineCtor: SampleJobEngine,
+})
+
+await daemon.startDaemon()
+```
+
+### Path B — with a progress broker (this repo)
+
+When workers publish progress to a subscription, build the broker first and inject it into the
+Engine, then create the daemon from that engine
+(`scripts/startJobDaemon.js`):
+
+```js
+import { SubscriptionBroker } from '@openreachtech/renchan'
+import { JobWorkersDaemon } from '@openreachtech/renchan-job-bullmq'
+import activate from '../sequelize/_.js'
+import ContentGenerationJobEngine from '../app/ContentGenerationJobEngine.js'
+import RedisConnection from '../app/queue/RedisConnection.js'
+
+await activate() // Sequelize (workers touch the DB)
+
+const subscriptionBroker = SubscriptionBroker.create({
+  config: {
+    redisOptions: RedisConnection.create().generatePubSubOptions(),
+  },
+})
+
+const engine = await ContentGenerationJobEngine.createAsync({
+  subscriptionBroker,
+})
+
+const workerCtors = await JobWorkersDaemon.loadWorkerCtors({
+  engine,
+})
+
+await JobWorkersDaemon
+  .create({
+    engine,
+    WorkerCtors: workerCtors,
+  })
+  .startDaemon()
+```
+
+- `startDaemon()` returns the started workers; it `setupWorker()`s each (creates the BullMQ `Worker`,
+  waits until ready, attaches the event sink) and attaches SIGINT/SIGTERM handlers that
+  `teardownWorker()` all workers (graceful `worker.close()`).
+- Use **Path B** whenever a worker publishes progress; **Path A** otherwise.
+
+## Cron and interval schedulers
+
+A scheduler registers a **repeatable job** into Redis (via `queue.upsertJobScheduler`). There are two
+concrete bases (both exported from the package):
+
+| Base class | Schedule value object | `schedule` shape in `collectScheduleInputs` |
+| --- | --- | --- |
+| `BaseCronJobScheduler` | `CronSchedule` | `{ cronExpression: '* * * * *' }` |
+| `BaseIntervalJobScheduler` | `IntervalSchedule` | `{ millisecond: 10000, isImmediately: true }` |
+
+A scheduler class declares `EngineCtor`, `ManifestCtor`, and `schedulerId`:
+
+```js
+import { BaseIntervalJobScheduler } from '@openreachtech/renchan-job-bullmq'
+import SampleJobEngine from '../../SampleJobEngine.js'
+import GammaJobManifest from './GammaJobManifest.js'
+
+export default class GammaIntervalJobScheduler extends BaseIntervalJobScheduler {
+  /** @override */ static get EngineCtor () { return SampleJobEngine }
+  /** @override */ static get ManifestCtor () { return GammaJobManifest }
+  /** @override */ static get schedulerId () { return 'gamma-interval-scheduler' }
+}
+```
+
+(Cron looks identical with `BaseCronJobScheduler`; see
+`purge-expired-content-sessions`.) The
+**Worker** for a scheduled job is a normal `BaseJobWorker` — the schedule only controls *when* a job
+is enqueued.
+
+### The scheduler service — one place listing every schedule
+
+A `BaseJobSchedulerService` subclass returns the schedule inputs. **Each `schedulerId` must match its
+scheduler class's `schedulerId`.**
+
+```js
+import { BaseJobSchedulerService } from '@openreachtech/renchan-job-bullmq'
+
+export default class SampleJobSchedulerService extends BaseJobSchedulerService {
+  /** @override */
+  static async collectScheduleInputs () {
+    return [
+      {
+        schedulerId: 'beta-cron-scheduler',
+        schedule: {
+          cronExpression: '* * * * *',
+        },
+        body: {
+          taskId: 1001,
+          message: 'cron heartbeat',
+        },
+        optionHash: {},
+      },
+      {
+        schedulerId: 'gamma-interval-scheduler',
+        schedule: {
+          millisecond: 10000,
+          isImmediately: true,
+        },
+        body: {
+          batchId: 2001,
+          label: 'interval ping',
+        },
+        optionHash: {},
+      },
+    ]
+  }
+}
+```
+
+### Start / stop registration scripts (one-shot)
+
+Registration is a **one-shot** script — it writes the repeatable-job definitions to Redis and exits;
+the Daemon (separate, long-running process) consumes them.
+
+```js
+// start-schedule.js — register every repeatable job, then exit (one-shot)
+const service = await ContentGenerationJobSchedulerService.createAsync({
+  EngineCtor: ContentGenerationJobEngine,
+})
+
+await service.startAllSchedulers()
+
+process.exit(0)
+```
+
+```js
+// stop-schedule.js — remove every schedule, then exit
+// (does NOT stop the Daemon; it only stops generating new jobs)
+const service = await ContentGenerationJobSchedulerService.createAsync({
+  EngineCtor: ContentGenerationJobEngine,
+})
+
+await service.stopAllSchedulers()
+
+process.exit(0)
+```
+
+- Await the call and exit — this is the module's intended shape, matching this repo's
+  `start-schedule.js`.
+  `ContentGenerationJobSchedulerService.js`
+  registers the hourly purge cron.
+- Both calls return an array of response objects for optional inspection (start: `hasError()` /
+  `hasResponse()` / `jobName` / `createDispatchedAt()`; stop: `hasError()` / `schedulerId` /
+  `removed`). If you iterate them, use `for...of` / `map` / `filter` — **`forEach` is disallowed by
+  our eslint.**
+
+## pm2 processes
+
+`pm2.config.cjs` runs the two long-lived processes: **`GraphQL API`**
+(`server/index.js`, the producer) and **`Job Daemon`** (`scripts/startJobDaemon.js`, the
+consumer). Schedule registration is run on demand, not as a pm2 app.

--- a/kit/skills/backend/hb-renchan-job-bullmq/references/engine-and-infra.md
+++ b/kit/skills/backend/hb-renchan-job-bullmq/references/engine-and-infra.md
@@ -1,0 +1,106 @@
+# Engine / Share / Context / RedisConnection
+
+The shared infrastructure every job points at. Referenced from §2 of [SKILL.md](../SKILL.md).
+
+## Engine — the one config object
+
+A `BaseJobEngine` subclass (`app/ContentGenerationJobEngine.js`)
+is the single place that names paths, Redis, the Share/Context constructors, error codes, and log
+files. Every Dispatcher / Worker / Scheduler references it via `EngineCtor`.
+
+```js
+export default class ContentGenerationJobEngine extends BaseJobEngine {
+  /** @override */
+  static get config () {
+    return {
+      workersPath: rootPath.to('app/jobs'),      // Daemon scans here for BaseJobWorker subclasses
+      schedulersPath: rootPath.to('app/jobs'),   // scheduler registration scans here
+      redisConfig: RedisConnection
+      .create()
+      .generateConnectionOptions(),
+    }
+  }
+
+  /** @override */ static get ShareCtor () { return ContentGenerationJobShare }
+  /** @override */ static get ContextCtor () { return ContentGenerationJobContext }
+
+  /** @override */
+  static get standardErrorCodeHash () {
+    return {
+      Unknown: '100.X000.001',
+      InvalidRequest: '103.X000.001',
+    }
+  }
+
+  /** @override */ static get savingLogFilePath () { return rootPath.to('logs/content-generation-job.log') }
+}
+```
+
+- **`config`** returns `{ workersPath, schedulersPath, redisConfig }`. Both paths point at `app/jobs`
+  (the Daemon and scheduler-registration scan there).
+- **`savingLogFilePath`** is the default per-job log file; **`savingLogFilePathLookup`** (optional) can
+  map specific `jobName`s to their own files.
+- **`createAsync({ subscriptionBroker })`** builds the Share, injecting the progress broker (see
+  [subscriptions.md](./subscriptions.md)). Enqueue-only callers omit it (broker stays `null`).
+- The engine exposes `buildDispatcherConfig()` / `buildSchedulerConfig()` / `buildWorkerConfig()`
+  (all reading `redisConfig`), an `Error` hash built from `standardErrorCodeHash`, and per-role
+  logger pools.
+
+## Share — per-process shared bag
+
+`BaseJobShare` subclass (`app/contexts/ContentGenerationJobShare.js`).
+Created once per process by the engine; holds `processClerk`, `env`, `timber`, and (when injected)
+the `subscriptionBroker`. The getter just returns the stored instance — no side effects. Enqueue-only
+processes construct the Share with `subscriptionBroker: null`.
+
+## Context — per-job DI object
+
+`BaseJobContext` subclass. Created fresh for **each job execution** (`createAsync({ engine })`) and
+handed to `executeJob` as `context`. Put per-job dependency resolution here (loaders, resolvers) so
+the worker stays thin.
+
+## RedisConnection — one Redis, two option shapes
+
+`app/queue/RedisConnection.js` reads `REDIS_HOST` /
+`REDIS_PORT` / `REDIS_PASSWORD` and produces:
+
+- **`generateConnectionOptions()`** — for BullMQ queues/workers. **Must include
+  `maxRetriesPerRequest: null`** (BullMQ requirement).
+- **`generatePubSubOptions()`** — for the subscription broker (no `maxRetriesPerRequest`).
+
+The **GraphQL API process and the Job Daemon must point at the same Redis** — that shared instance is
+both the job queue and the progress-PubSub channel.
+
+## Connections are established once, never per job
+
+Both the subscription broker and each worker's Redis connection are established **once at Daemon
+startup** and reused for the process's lifetime — never re-created inside a worker per job:
+
+- The **subscription broker** is built once in the daemon entry script and injected via
+  `Engine.createAsync({ subscriptionBroker })` → held on the Share. A worker only reads it
+  (`this.subscriptionBroker`); it never constructs one. Enqueue-only processes inject none (`null`).
+- Each **worker's BullMQ connection** is opened once when `JobWorkersDaemon.startDaemon()` builds and
+  `setupWorker()`s the workers; the BullMQ `Worker` is a long-lived consumer. `executeJob` runs per
+  job but reuses that open connection.
+- On the **producer side**, `JobDispatcherProvider` plays the same role — it caches one dispatcher
+  (queue producer connection) per `DispatcherCtor` and reuses it (`keepsConnection: true`), tearing
+  down only at process exit. So do **not** `createAsync()` a fresh dispatcher per request.
+
+This "connect once at boot, reuse per job" model is the framework's intended design.
+
+## Package exports (quick reference)
+
+`@openreachtech/renchan-job-bullmq` exports, among others:
+
+| Export | Role |
+| --- | --- |
+| `BaseJobEngine` | central config |
+| `BaseJobManifest` | queue name + body schema |
+| `BaseJobWorker` | consumer |
+| `BaseJobDispatcher` | producer |
+| `BaseJobScheduler` / `BaseCronJobScheduler` / `BaseIntervalJobScheduler` | schedulers |
+| `BaseJobSchedulerService` | schedule registration service |
+| `BaseJobContext` / `BaseJobShare` | per-job / per-process DI |
+| `JobWorkersDaemon` | worker daemon |
+| `CronSchedule` / `IntervalSchedule` / `BaseSchedule` | schedule value objects |
+| `JobBody`, `RenchanJobError`, `DeepBulkClassLoader`, `ProcessClerk`, `Timber` | tools |

--- a/kit/skills/backend/hb-renchan-job-bullmq/references/job-triple.md
+++ b/kit/skills/backend/hb-renchan-job-bullmq/references/job-triple.md
@@ -1,0 +1,189 @@
+# The job triple (Manifest / Worker / Dispatcher)
+
+The per-job files and how they fit together. Referenced from §1 of [SKILL.md](../SKILL.md). Examples
+draw on both this repo (`app/jobs/**`) and the package's own `samples/confirm-01`.
+
+## Directory layout
+
+One job = one directory `app/jobs/<kebab-job-name>/` holding:
+
+```
+app/jobs/send-report-email/
+├── SendReportEmailJobManifest.js    # queue name + body schema
+├── SendReportEmailJobWorker.js      # consume: executeJob + hooks
+├── SendReportEmailJobDispatcher.js  # produce: enqueue + queue options
+└── .keepDirectory.js
+```
+
+- The directory name is kebab-case and **equals the `jobName`** (the BullMQ queue name).
+- Classes are PascalCase with the fixed suffixes `JobManifest` / `JobWorker` / `JobDispatcher` (and
+  `CronJobScheduler` / `IntervalJobScheduler` for scheduled jobs —
+  [daemon-and-scheduler.md](./daemon-and-scheduler.md)).
+
+## Manifest — queue name + body schema
+
+`BaseJobManifest` subclass. `jobName` is the single source of truth for the queue name; `bodySchema`
+validates the enqueue payload. Scalars come from `ScalarHash` (`Text` / `Integer` / …) of
+`@openreachtech/mentsu-schema`.
+
+```js
+import { BaseJobManifest } from '@openreachtech/renchan-job-bullmq'
+import { ScalarHash } from '@openreachtech/mentsu-schema'
+
+const { Integer, Text } = ScalarHash
+
+export default class ContentGenerationPublicLpJobManifest extends BaseJobManifest {
+  /** @override */ static get jobName () { return 'content-generation-public-lp' }
+
+  /** @override */
+  static get bodySchema () {
+    return {
+      jobId: Integer,
+      accessToken: Text,
+    }
+  }
+}
+```
+
+- The body is normalized/denormalized by the framework for Redis transport, so it may carry rich
+  values (e.g. `Date`, `BigNumber` — see `samples/confirm-01`'s alpha body), not just primitives.
+  Keep the body **minimal** — usually just ids/tokens; load the full row from the DB in the worker.
+
+## Worker — executeJob + lifecycle hooks
+
+`BaseJobWorker` subclass. Point `ManifestCtor` at the Manifest and implement `executeJob`. The four
+lifecycle hooks are **abstract** and must be implemented; use `this.timber` for console logging and
+`this.ensureLogger()` for the per-job file logger.
+
+```js
+import { BaseJobWorker } from '@openreachtech/renchan-job-bullmq'
+import AlphaJobManifest from './AlphaJobManifest.js'
+
+export default class AlphaJobWorker extends BaseJobWorker {
+  /** @override */ static get ManifestCtor () { return AlphaJobManifest }
+
+  /** @override */
+  async executeJob ({
+    body,
+    context,
+    parcel,
+  }) {
+    this.timber.log(`[${this.Ctor.jobName}] started with body:`, body)
+
+    // ... the work ...
+
+    // WARNING: the return value is stored in Redis. Return only the minimum necessary —
+    // never arrays of entities / large blobs (memory pressure + instability).
+    return {
+      executedAt: new Date().toISOString(),
+    }
+  }
+
+  // Implement the four lifecycle hooks too (return null for a fire-and-forget job):
+  //   onJobCompleted / onJobFailed / onJobProgress / onWorkerError
+}
+```
+
+- **`executeJob({ body, context, parcel })`** — `body` is the validated, normalized payload;
+  `context` is the per-job DI object (Context); `parcel` wraps the BullMQ job (`parcel.jobModel.job`
+  for `updateProgress`, token, abort signal).
+- **Return value is persisted in Redis** — keep it tiny.
+- **`buildOptionHash()`** overrides BullMQ `WorkerOptions`; spread `super.buildOptionHash()` (which
+  supplies `connection`) and add `concurrency` / `limiter`:
+
+```js
+/** @override */
+buildOptionHash () {
+  return {
+    ...super.buildOptionHash(),
+
+    concurrency: 5,
+  }
+}
+```
+
+- Lifecycle hooks fire per BullMQ event. For a fire-and-forget job, return `null` from each. To
+  publish progress to a subscription, override `onJobProgress` (see
+  [subscriptions.md](./subscriptions.md)).
+
+## Dispatcher — enqueue + per-queue options
+
+`BaseJobDispatcher` subclass. It needs `EngineCtor` (which Engine/Redis to use) and `ManifestCtor`.
+`static optionHash` sets BullMQ `QueueOptions` (producer defaults such as `attempts`).
+
+```js
+import { BaseJobDispatcher } from '@openreachtech/renchan-job-bullmq'
+import ContentGenerationJobEngine from '../../ContentGenerationJobEngine.js'
+import SendReportEmailJobManifest from './SendReportEmailJobManifest.js'
+
+export default class SendReportEmailJobDispatcher extends BaseJobDispatcher {
+  /** @override */ static get EngineCtor () { return ContentGenerationJobEngine }
+  /** @override */ static get ManifestCtor () { return SendReportEmailJobManifest }
+
+  /** @override */
+  static get optionHash () {
+    return {
+      defaultJobOptions: {
+        attempts: 3,
+      },
+    }
+  }
+}
+```
+
+### DRY: a base app dispatcher
+
+When several dispatchers share one Engine, define a base app dispatcher that sets `EngineCtor` once,
+and let each job dispatcher set only `ManifestCtor` (this is what `samples/confirm-01` does):
+
+```js
+// SampleBaseAppJobDispatcher.js
+export default class SampleBaseAppJobDispatcher extends BaseJobDispatcher {
+  /** @override */ static get EngineCtor () { return SampleJobEngine }
+}
+
+// jobs/alpha/AlphaJobDispatcher.js
+export default class AlphaJobDispatcher extends SampleBaseAppJobDispatcher {
+  /** @override */ static get ManifestCtor () { return AlphaJobManifest }
+}
+```
+
+## Enqueuing
+
+**From a resolver** — use the request-scope `JobDispatcherProvider` (connection reuse; see
+[engine-and-infra.md](./engine-and-infra.md)):
+
+```js
+await context.share.jobDispatcherProvider.dispatchJob({
+  DispatcherCtor: SendReportEmailJobDispatcher,
+  body: {
+    sessionToken,
+  },
+})
+```
+
+**Standalone (one-off script)** — self-boot, dispatch, inspect the response, tear down:
+
+```js
+const dispatcher = await AlphaJobDispatcher.createAsync()
+
+const response = await dispatcher.dispatchJob({
+  body: {
+    // ...
+  },
+})
+
+if (response.hasError()) {
+  // response.errorMessage
+}
+if (response.hasResponse()) {
+  // response.createDispatchedAt()  → Date the job was enqueued
+}
+
+await dispatcher.teardown()
+```
+
+- `dispatchJob({ body })` validates `body` against the Manifest schema, `queue.add`s, and returns a
+  **DispatcherResponse** (`hasError()` / `errorMessage` / `hasResponse()` / `createDispatchedAt()`).
+  It auto-`teardown()`s the queue connection unless `keepsConnection: true` is passed (the provider
+  passes `true` to reuse the connection).

--- a/kit/skills/backend/hb-renchan-job-bullmq/references/queues.md
+++ b/kit/skills/backend/hb-renchan-job-bullmq/references/queues.md
@@ -1,0 +1,74 @@
+# Splitting queues
+
+How to run work across multiple queues, share worker logic safely, and scale queues independently.
+Referenced from §5 of [SKILL.md](../SKILL.md).
+
+## One queue == one job directory == one Manifest `jobName`
+
+To add a queue, add a job directory whose Manifest returns a new `jobName`
+([job-triple.md](./job-triple.md)). The Daemon discovers and listens on every queue whose worker
+lives under `workersPath`; on boot it logs one `Listening: <jobName>` per queue.
+
+This repo splits the *same* content-generation work into two queues so they can be secured, scaled, and
+subscribed-to independently:
+
+| Queue (`jobName`) | Body | Enqueued from | Progress scope |
+| --- | --- | --- | --- |
+| `content-generation-internal` | `{ jobId }` | admin GraphQL + integration REST | `jobId` (no subscription) |
+| `content-generation-public-lp` | `{ jobId, accessToken }` | public LP GraphQL | `accessToken` (customer subscription) |
+
+Both are enqueued the same way, just with a different `DispatcherCtor`:
+
+```js
+// public LP resolver
+await context.share.jobDispatcherProvider.dispatchJob({
+  DispatcherCtor: ContentGenerationPublicLpJobDispatcher,
+  body: { 
+    jobId, 
+    accessToken, 
+  },
+})
+
+// admin / integration
+await context.share.jobDispatcherProvider.dispatchJob({
+  DispatcherCtor: ContentGenerationInternalJobDispatcher,
+  body: { 
+    jobId, 
+  },
+})
+```
+
+## Share logic with a base worker — but place it OUTSIDE `workersPath`
+
+Both workers `extends BaseContentGenerationJobWorker` (the app base) and differ only in
+`ManifestCtor` — so the queues share all the real logic.
+
+- **Gotcha:** that shared abstract base lives in `app/` — **outside `workersPath` (`app/jobs`)**. The
+  Daemon's `DeepBulkClassLoader` boots *every* `BaseJobWorker` subclass found under `workersPath`, and
+  an abstract base has no `jobName`, so leaving it under `app/jobs/**` would crash daemon startup.
+  **Keep only concrete workers under `app/jobs/**`; put shared bases elsewhere in `app/`.**
+
+```
+app/
+├── BaseContentGenerationJobWorker.js        # shared base — NOT under app/jobs
+└── jobs/
+    ├── content-generation-internal/ContentGenerationInternalJobWorker.js   # concrete
+    └── content-generation-public-lp/ContentGenerationPublicLpJobWorker.js  # concrete
+```
+
+## Run a subset of queues per Daemon (`skipJobHash`)
+
+One Daemon process listens on all discovered queues by default. To run a **subset** per process — e.g.
+put a heavy queue on its own machine — the engine/daemon supports a `skipJobHash`
+(`{ [jobName]: true }`) that filters those worker constructors out at boot. Start one Daemon that
+skips the heavy queue and another that runs only it, both against the same Redis.
+
+## Tune each queue independently
+
+- **Producer defaults** — the Dispatcher's `static optionHash` (BullMQ `QueueOptions`), e.g.
+  `defaultJobOptions: { attempts: 3 }`.
+- **Consumer throughput** — the Worker's `buildOptionHash()` (BullMQ `WorkerOptions`), e.g.
+  `concurrency` and `limiter` (rate limiting; see `app/tools/ContentGenerationRateLimiter.js`).
+
+Because these are per class, two queues that share a base worker can still carry different
+concurrency / attempts / limiter settings.

--- a/kit/skills/backend/hb-renchan-job-bullmq/references/subscriptions.md
+++ b/kit/skills/backend/hb-renchan-job-bullmq/references/subscriptions.md
@@ -1,0 +1,113 @@
+# Integrating with subscriptions (progress → GraphQL)
+
+How a worker in the Job Daemon streams progress to a GraphQL subscription in the API process, over
+the shared Redis PubSub broker. Referenced from §4 of [SKILL.md](../SKILL.md).
+
+## The two sides
+
+- **Publisher** = a worker in the **Job Daemon** process.
+- **Subscriber** = a GraphQL subscription resolver in the **GraphQL API** process.
+- **Transport** = one `SubscriptionBroker` (Redis PubSub) that both processes point at (same Redis as
+  the queues — [engine-and-infra.md](./engine-and-infra.md)).
+
+A message is delivered by matching **channel** + **scope**. Scope namespaces the channel so a given
+customer only receives their own job's progress.
+
+## Publish side (worker)
+
+The Daemon builds the broker and injects it into the Engine
+([daemon-and-scheduler.md](./daemon-and-scheduler.md#path-b--with-a-progress-broker-this-repo)); the
+Share then exposes it. Enqueue-only processes never inject a broker, so `subscriptionBroker` is
+`null` and publishing is a no-op.
+
+For AI jobs, `BaseAgentJobWorker` (from `@openreachtech/mentsu-agent-loop-renchan-job`) already turns
+the lifecycle hooks into publishes: `onJobProgress` → `publishProgress({ topic, event })`,
+`onJobCompleted` → `{ phase: 'done', payload: result }`, `onJobFailed` → an error event. It builds the
+`topic` from `channel` + `buildScope({ jobModel })`.
+
+This repo's app base `BaseContentGenerationJobWorker.js`
+customizes it:
+
+```js
+/** @override */
+get channel () {
+  return 'reportProgress' // must equal the subscription resolver's channel
+}
+
+/** @override */
+buildScope ({ 
+  jobModel, 
+}) {
+  const body = jobModel.denormalizedBody
+
+  // public-lp jobs scope by accessToken (the customer's key); internal jobs fall back to jobId
+  if (body.accessToken) {
+    return {
+      accessToken: body.accessToken,
+    }
+  }
+
+  return {
+    jobId: body.jobId,
+  }
+}
+
+/** @override */
+publishProgress ({
+  topic,
+  event,
+}) {
+  if (!this.subscriptionBroker) {
+    return null // enqueue-only process: no broker, no publish
+  }
+
+  // adapt to renchan SubscriptionBroker's { channel, message } signature
+  return this.subscriptionBroker.publish({
+    channel: topic,
+    message: event,
+  })
+}
+```
+
+(It also persists progress / result / failure to the DB inside the overridden `onJob*` hooks, then
+calls `super` to publish.)
+
+## Subscribe side (GraphQL)
+
+The GraphQL server resolves the subscription with a **matching channel and scope**
+(`OnReportProgressSubscriptionResolver.js`):
+
+```js
+export default class OnReportProgressSubscriptionResolver extends BaseAgentProgressSubscriptionResolver {
+  /** @override */ static get schema () { return 'onReportProgress' }
+
+  /** @override */
+  get channel () {
+    return 'reportProgress' // matches the worker's channel
+  }
+
+  /** @override */
+  generateChannelQuery ({
+    variables,
+  }) {
+    // matches the worker's buildScope
+    return {
+      accessToken: variables.input.accessToken,
+    }
+  }
+
+  /** @override */
+  resolve (payload) {
+    return payload // forward the worker's raw progress event
+  }
+}
+```
+
+## Checklist
+
+- **Channel string identical** on both sides (`'reportProgress'`).
+- **Scope keys identical** on both sides (`{ accessToken }`) — this is why the public-lp queue body
+  carries `accessToken` ([queues.md](./queues.md)).
+- **Same Redis** for the Daemon's broker and the API's broker.
+- **Daemon injects the broker** (Path B); the enqueue path does not (publish becomes a no-op).
+- After a `done` / `error` event, the client typically re-queries for the final persisted result.

--- a/kit/skills/backend/hb-resolver-share/SKILL.md
+++ b/kit/skills/backend/hb-resolver-share/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: hb-resolver-share
+description: >
+  Implement the Share class — the per-process container of shared singletons (subscription broker,
+  worker/job dispatcher, authorization service, shared external clients, environment access) that
+  the framework builds once at server boot and hands to every GraphQL resolver as context.share.
+  Use this skill whenever the user asks to add or change what is shared across an API's resolvers,
+  or to decide whether something belongs in Share (per process) or Context (per request).
+---
+
+# Resolver Share
+
+A skill for the **Share class**: the object that holds the instances **shared across every resolver of
+an API** and is reachable from a resolver as `context.share`. The framework builds one Share **once
+per server process** at boot and passes it into each request's Context, so resolvers read shared
+dependencies from it instead of constructing their own.
+
+> This skill states a **general, project-independent rule** — a refined best practice, not a
+> description of any one project's code, so it need not match a given repo's existing notation. The
+> class and property names in it (`CustomerGraphqlShare`, `workerDispatcher`, `permissionService`, …)
+> are **illustrative fakes**; use your project's own names and never hard-code its file paths or domain
+> concepts into the rule. The framework base class is shown as `BaseGraphqlShare`; treat it as "your
+> framework's Share base".
+
+## Grand principle: Share is a per-process container of shared singletons — no request state, no logic
+
+Share holds the instances that are **built once and reused by every request/resolver** of an API:
+the subscription broker, the worker (background-job) dispatcher, the authorization/permission
+service, shared external clients, environment access. The framework constructs it at boot and passes
+it — via the Context — to every resolver as `context.share`. Share's only job is **to hold and expose
+these shared instances**; it runs no business logic and stores no per-request data.
+
+- **Why per-process, built once.** These instances hold connections or are expensive to create
+  (a PubSub broker, a job-queue connection, a permission service). Building them once at boot and
+  sharing them keeps connection counts bounded and startup deterministic — a resolver that built its
+  own broker per call would exhaust connections.
+- **Why no request state.** One Share instance is shared by **all concurrent requests**. Anything
+  request-scoped or per-user (the current principal, the request input, a per-request transaction)
+  belongs in the **Context** (built fresh per request), never on Share — writing it to Share creates
+  data races between concurrent requests.
+- **Why no business logic.** Share is a wiring container. Domain decisions live in resolvers and the
+  services they call; Share only *provides* those services. Keeping it a pure container makes the set
+  of shared dependencies auditable in one place.
+
+**Comment language**: the `js` examples here use English comments. In the Share files you generate,
+keep structural comments in English and write any domain notes in whatever language the project uses
+for domain prose — match the surrounding files. Sample code follows the project's lint style
+(no semicolons, 2-space indent, a space before the parameter parenthesis, trailing commas).
+
+## 1. Share (per process) vs Context (per request)
+
+The two containers split by **lifetime and sharing**:
+
+| | Share | Context |
+| --- | --- | --- |
+| Built | once, at server boot (`createAsync`) | fresh, per request |
+| Shared by | **all** concurrent requests of the process | one request |
+| Holds | shared singletons (broker, dispatcher, permission service, clients, env) | the request principal, per-request state, and a handle to `share` |
+| Reached from a resolver | `context.share.<name>` | `context.<name>` |
+
+- **Decision rule**: is the thing the **same for every request** and safe to reuse concurrently?
+  → Share. Does it **depend on who is calling or on this request**? → Context.
+- The Context carries a reference to the Share, which is why a resolver reaches a shared instance
+  through `context.share`. Share does not know about Context or resolvers — the dependency is
+  one-way (Context → Share).
+
+```js
+// Good: request-scoped principal lives on the Context; shared dispatcher lives on Share
+async resolve ({
+  variables,
+  context,
+}) {
+  const caller = context.principal // per-request → Context
+
+  await context.share.workerDispatcher.dispatchJob({ // shared singleton → Share
+    body: {
+      requestedBy: caller.id,
+    },
+  })
+
+  return {
+    accepted: true,
+  }
+}
+```
+
+```js
+// Avoid: stashing request-scoped state on the shared object
+this.currentPrincipal = authenticatedPrincipal // shared across all concurrent requests → data race
+```
+
+## 2. What belongs in Share (the admission test)
+
+A candidate goes on Share only when it passes **all three**:
+
+1. **Shared** — used across multiple resolvers (often across multiple APIs).
+2. **Concurrency-safe** — stateless, or internally synchronized; holding no per-request data.
+3. **Build-once-worthy** — holds a connection or is expensive to create, so building it per request
+   would be wasteful or wrong.
+
+Typical members (role names, not fixed to any project):
+
+| Member | What it is |
+| --- | --- |
+| `subscriptionBroker` | The PubSub broker that publishes/subscribes GraphQL subscription events across processes. |
+| `workerDispatcher` | The enqueuer that dispatches background jobs to workers (reuses one queue connection). |
+| `permissionService` | The shared authorization/permission service resolvers consult to gate access. |
+| shared external clients | Long-lived clients for external services (reused, connection-pooled). |
+| `env` | Environment/configuration access shared process-wide. |
+
+Do **not** put on Share: request inputs or the current principal (→ Context), resolver/business
+logic, GraphQL entities or query results, or a mutable cache keyed by request.
+
+## 3. The class shape (constructor DI + `create` + `createAsync`)
+
+A Share class extends the framework Share base and follows the standard member order:
+**constructor → `create` (sync factory) → `createAsync` (async boot factory)**. Dependencies are
+**injected through the constructor** and held as read-only properties.
+
+```js
+import {
+  BaseGraphqlShare,
+} from '@openreachtech/renchan'
+
+/**
+ * Shared object for the customer GraphQL API.
+ * Holds process-lifetime instances shared by every resolver of this endpoint.
+ *
+ * @extends {BaseGraphqlShare}
+ */
+export default class CustomerGraphqlShare extends BaseGraphqlShare {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   subscriptionBroker: object
+   *   workerDispatcher: object
+   *   permissionService: object
+   * }} params - Own dependencies; base params are forwarded via rest.
+   */
+  constructor ({
+    subscriptionBroker,
+    workerDispatcher,
+    permissionService,
+    ...restArgs
+  }) {
+    super(restArgs)
+
+    this.subscriptionBroker = subscriptionBroker
+    this.workerDispatcher = workerDispatcher
+    this.permissionService = permissionService
+  }
+
+  /**
+   * Factory method.
+   *
+   * @param {*} params - Same shape as the constructor.
+   * @returns {CustomerGraphqlShare} Instance of this class.
+   */
+  static create ({
+    subscriptionBroker,
+    workerDispatcher,
+    permissionService,
+    ...restArgs
+  }) {
+    return new this({
+      subscriptionBroker,
+      workerDispatcher,
+      permissionService,
+      ...restArgs,
+    })
+  }
+
+  /**
+   * Async factory method. Assembles the shared instances once, at server boot.
+   *
+   * @param {{
+   *   config: object
+   * }} params - Boot configuration.
+   * @returns {Promise<CustomerGraphqlShare>} Instance of this class.
+   */
+  static async createAsync ({
+    config,
+  }) {
+    const subscriptionBroker = this.createBroker({
+      config,
+    })
+
+    const workerDispatcher = await WorkerDispatcher.createAsync({
+      config,
+    })
+
+    const permissionService = PermissionService.create({
+      config,
+    })
+
+    return this.create({
+      env: this.generateEnv(),
+      subscriptionBroker,
+      workerDispatcher,
+      permissionService,
+    })
+  }
+}
+```
+
+- **Constructor = pure assignment** (`super(restArgs)` then assign own deps). No I/O, no building —
+  everything is already built and handed in. This is what makes Share testable ([§6](#6-testing)).
+- **`createAsync` is the single place the shared instances are assembled.** Async because some deps
+  connect (broker, queue). Build them, then call `create`. The framework base commonly supplies
+  helpers for the cross-cutting ones (a broker factory, an env accessor); use them rather than
+  re-implementing.
+- **Properties are read-only after construction** and named for their role (arrays plural, single
+  instances singular). Resolvers read them; nothing reassigns them.
+
+## 4. Lifecycle & wiring (boot → Context → resolver)
+
+The flow is one-directional and happens once at boot, then per request:
+
+1. **Boot**: the API's engine names its Share class; the framework calls `Share.createAsync({ config })`
+   **once**, producing the single per-process Share.
+2. **Per request**: the framework builds a Context for the request and gives it a reference to that
+   Share.
+3. **In the resolver**: code reads shared instances via `context.share.<name>`.
+
+- **Share never imports resolvers or the Context** — the arrows point Context → Share, resolver →
+  `context.share`. Keeping the dependency one-way stops Share from becoming a hub that knows about
+  request handling.
+- **One assembly point.** All shared instances are wired in `createAsync`; a resolver never
+  constructs a broker/dispatcher/client of its own. If a resolver needs a new shared instance, add it
+  to Share (in `createAsync` + a property), don't construct it ad hoc.
+
+## 5. Naming
+
+- **One Share per API/endpoint**, named `<Role>GraphqlShare` (e.g. `CustomerGraphqlShare`,
+  `AdminGraphqlShare`). When several endpoints share the same set of dependencies, factor a common
+  app-level Share base and let each endpoint's Share extend it (add only its extras).
+- **Properties are named for the instance's role** — `subscriptionBroker`, `workerDispatcher`,
+  `permissionService`. Arrays are plural; single instances singular. Avoid the denied vague
+  identifiers (`data` / `info` / `list` / `manager` …).
+
+## 6. Testing
+
+Because every dependency is **constructor-injected**, a Share is trivial to unit-test and, more
+importantly, resolvers become testable: a test builds a Share (or a plain `context.share` stand-in)
+with **fakes**, and asserts the resolver used them.
+
+- Construct the Share via `create({ ... })` with **fake** deps (a fake dispatcher, a fake broker) —
+  never build a real broker/queue/client in a test.
+- Assert the resolver reads/uses the shared instance it should (e.g. the fake `workerDispatcher`
+  received the expected dispatch).
+- Do not exercise `createAsync` against real infrastructure in unit tests; that is integration
+  territory.
+
+## Finishing checklist
+
+- [ ] Everything on Share is **shared, concurrency-safe, and build-once** — it passes the admission test ([§2](#2-what-belongs-in-share-the-admission-test)); nothing request-scoped or per-user is on it.
+- [ ] No business logic on Share — it only **holds and exposes** shared instances.
+- [ ] Class shape is constructor (pure assignment) → `create` → `createAsync`, with all deps **injected via the constructor** ([§3](#3-the-class-shape-constructor-di--create--createasync)).
+- [ ] The shared instances are assembled in **one place** (`createAsync`), built once at boot; resolvers reach them via `context.share.<name>` and never construct their own ([§4](#4-lifecycle--wiring-boot--context--resolver)).
+- [ ] Dependency direction is one-way: Context → Share; Share imports no resolver/Context.
+- [ ] Tests inject **fakes** through the constructor; no real broker/queue/client is built in a unit test ([§6](#6-testing)).

--- a/kit/skills/backend/hb-resolver-validator/SKILL.md
+++ b/kit/skills/backend/hb-resolver-validator/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: hb-resolver-validator
+description: >
+  Implement input-validation classes for GraphQL resolvers under
+  app/validator/forResolver/<endpoint>/{queries,mutations}/, extending BaseInputValidator and
+  delegating value checks to @openreachtech/mentsu-value-inspector. Use this skill whenever the
+  user asks to validate a resolver's input — presence, number, integer, pagination, enum/keyword
+  checks — via a `*InputValidator` class whose failing predicate raises the matching InvalidXxx
+  error.
+---
+
+# Resolver Validator
+
+A skill for writing the **`*InputValidator` classes** that GraphQL resolvers use to reject bad
+input. A validator **extends `BaseInputValidator`** and declares a list of
+`[predicate, ErrorConstructor]` entries; the base runs them and, for the first predicate that
+returns `false`, raises that entry's error. Per-value checks (presence / number / integer /
+positive-integer …) are delegated to **`@openreachtech/mentsu-value-inspector`**, imported directly
+(it is a published module — use it from the package, not a local wrapper).
+
+> Directory layout differs from the current repo on purpose — this is the target convention. The
+> support classes (`BaseInputValidator`, `NormalPaginationInputValidator`) come from the renchan
+> framework / shared layer; the inspectors come from the `@openreachtech/mentsu-value-inspector`
+> module.
+
+## Grand principle: declare `[predicate, error]` entries, let the base run them
+
+A validator is a `BaseInputValidator` subclass whose only required override is
+**`generateValidationEntries()`** — it returns `Array<[() => boolean, RenchanGraphqlErrorCtor]>`.
+Each entry pairs a **predicate** (returns `true` when that rule passes) with the **error
+constructor** to raise when it fails. The base holds `this.input` and `this.errorHash`, iterates the
+entries, and throws the error of the first failing predicate.
+
+- **Predicates are small `isValidX()` methods** that read `this.input` and return a boolean. They
+  use the inspector classes and/or composed sub-validators — they never throw.
+- **Errors come from `this.errorHash`** (the resolver's error hash, injected into the validator), so
+  each `InvalidXxx` maps to the resolver's `errorCodeHash` code.
+- **Reuse shared validators** (e.g. pagination) by composing them inside entries, not by
+  re-implementing limit/offset/sort.
+
+```js
+import {
+  IntegerValueInspector,
+} from '@openreachtech/mentsu-value-inspector'
+
+import BaseInputValidator from '../../BaseInputValidator.js'
+import PaginationInputValidator from '../../NormalPaginationInputValidator.js'
+
+const VALID_SORT_COLUMNS = [
+  'labelName',
+  'fieldPath',
+]
+
+/**
+ * Class for validating input of the emailInsertableVariables query
+ *
+ * @extends {BaseInputValidator<ErrorHash, EmailInsertableVariablesInput>}
+ */
+export default class EmailInsertableVariablesInputValidator extends BaseInputValidator {
+  /**
+   * Generate validation entries
+   *
+   * @override
+   * @returns {Array<[() => boolean, RenchanGraphqlErrorCtor]>}
+   */
+  generateValidationEntries () {
+    const paginationInputValidator = this.createPaginationInputValidator()
+
+    return [
+      [
+        () => paginationInputValidator.isValidLimit(),
+        this.errorHash.InvalidPaginationLimit,
+      ],
+      [
+        () => paginationInputValidator.isValidOffset(),
+        this.errorHash.InvalidPaginationOffset,
+      ],
+      [
+        () => paginationInputValidator.isValidSort(),
+        this.errorHash.InvalidPaginationSort,
+      ],
+      [
+        () => this.isValidKeyword(),
+        this.errorHash.InvalidKeyword,
+      ],
+      [
+        () => this.isValidOriginObjectCategoryId(),
+        this.errorHash.InvalidOriginObjectCategoryId,
+      ],
+    ]
+  }
+
+  // ... isValidX() predicates + create*Inspector helpers (see validator-pattern.md) ...
+}
+```
+
+## Directory & naming
+
+- **Validators:** `app/validator/forResolver/<endpoint>/<operation-kind>/<Operation>InputValidator.js`
+  - `<endpoint>` tracks the GraphQL endpoint the resolver belongs to (`user`, `customer`, `admin`,
+    …) — it changes per endpoint.
+  - `<operation-kind>` is **`queries`** or **`mutations`**.
+  - e.g. `app/validator/forResolver/user/queries/EmailInsertableVariablesInputValidator.js`,
+    `app/validator/forResolver/user/mutations/CreateFooInputValidator.js`.
+- **Shared under `app/validator/forResolver/`:** `BaseInputValidator.js` and reusable validators such
+  as `NormalPaginationInputValidator.js` (default-exported, commonly imported as
+  `PaginationInputValidator`).
+- **Inspectors:** imported directly from `@openreachtech/mentsu-value-inspector` (`ValueInspector` /
+  `NumberValueInspector` / `IntegerValueInspector`)
+  ([inspector-api.md](./references/inspector-api.md)).
+- Class name = `<Operation>InputValidator` (PascalCase, matching the resolver's `schema`).
+
+## Predicates & the inspector
+
+Each rule is an `isValidX()` method. For value-shape checks, build an inspector via a small
+`create*ValueInspector({ value })` helper and call its methods:
+
+```js
+isValidOriginObjectCategoryId () {
+  const inspector = this.createIntegerValueInspector({
+    value: this.input.originObjectCategoryId,
+  })
+
+  // the module has no isPositiveInteger — compose it (string-tolerant *Like)
+  return inspector.isIntegerLike()
+    && inspector.isPositiveNumberLike()
+}
+
+createIntegerValueInspector ({
+  value,
+}) {
+  return IntegerValueInspector.create({
+    value,
+  })
+}
+```
+
+- **Optional field idiom:** return `true` early when the field is absent, then check the shape —
+  e.g. `if (!keyword) { return true }` before `return typeof keyword === 'string'`.
+- The `*Like` methods accept numeric **strings**, which is what you want at the GraphQL boundary;
+  there is no `isPositiveInteger`, so compose it ([inspector-api.md](./references/inspector-api.md)).
+
+## Error hash & resolver wiring
+
+The resolver declares the codes and passes its `errorHash` into the validator:
+
+```js
+/** @override */
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    InvalidKeyword: '400.C001.001',
+    InvalidOriginObjectCategoryId: '400.C001.002',
+    InvalidPaginationLimit: '400.C001.003',
+    InvalidPaginationOffset: '400.C001.004',
+    InvalidPaginationSort: '400.C001.005',
+  }
+}
+
+/** @override */
+async resolve ({
+  variables: {
+    input,
+  },
+  context,
+}) {
+  EmailInsertableVariablesInputValidator
+    .create({
+      input,
+      errorHash: this.errorHash,
+    })
+    .validate()
+
+  // ... input is now trusted ...
+}
+```
+
+`create({ input, errorHash })` and the run entrypoint (shown as `validate()`) are provided by
+`BaseInputValidator` — match the actual base API in your framework.
+
+## Testing
+
+Predicates are pure booleans, so unit-test them (and `generateValidationEntries`) with the
+`hc-jest` skill: feed inputs, assert `isValidX()` results and that invalid input
+raises the expected `InvalidXxx`.
+
+## Detail files
+
+- [inspector-api.md](./references/inspector-api.md) — the `@openreachtech/mentsu-value-inspector`
+  API (strict vs `*Like`, presence / number / integer, composing positive-integer, cheat sheet)
+- [validator-pattern.md](./references/validator-pattern.md) — the full validator template
+  (`generateValidationEntries`, predicates, inspector helpers, composed pagination, typedefs), the
+  `BaseInputValidator` contract, resolver wiring, and testing

--- a/kit/skills/backend/hb-resolver-validator/references/inspector-api.md
+++ b/kit/skills/backend/hb-resolver-validator/references/inspector-api.md
@@ -1,0 +1,115 @@
+# mentsu-value-inspector API
+
+The value-inspection module validators use for per-value checks. Referenced from
+[SKILL.md](../SKILL.md). Full docs: the package README on npm.
+
+Validators **import directly from the module** — it is published, so use it from the package (do not
+hand-roll a local wrapper):
+
+```bash
+npm install @openreachtech/mentsu-value-inspector@1.1.0
+```
+
+```js
+import {
+  IntegerValueInspector,
+} from '@openreachtech/mentsu-value-inspector'
+
+const inspector = IntegerValueInspector.create({
+  value: this.input.originObjectCategoryId,
+})
+```
+
+## Classes & hierarchy
+
+Three classes, each a named export of the package root; each subclass inherits all its parents'
+methods, so instantiate the most specific one you need:
+
+```
+ValueInspector            // presence checks
+└── NumberValueInspector  // + number checks + normalizeValue()
+    └── IntegerValueInspector  // + integer / safe-integer checks
+```
+
+## strict vs `*Like`
+
+Every number/integer check comes in two flavors:
+
+| Flavor | Reads | Accepts numeric strings | Example |
+| :-- | :-- | :-- | :-- |
+| **strict** | the raw value | No | `isNumber('3.14')` → `false` |
+| **`*Like`** | the normalized value | Yes | `isNumberLike('3.14')` → `true` |
+
+`*Like` normalizes first (number/string accepted): `'100'` → `100`, while `true` / `1000n` / `{}` /
+`'abc'` / `null` / `undefined` → `null` and every `*Like` returns `false`. **`''` normalizes to
+`0`** (so `isIntegerLike('')` → `true`). At the GraphQL/REST boundary prefer the string-tolerant
+(`*Like`) checks, since inputs often arrive as strings.
+
+## Presence (`ValueInspector`)
+
+| Method | Returns |
+| :-- | :-- |
+| `isNull()` | `value === null` |
+| `isUndefined()` | `value === undefined` |
+| `isNullish()` | `null` or `undefined` |
+| `isDefined()` | not `undefined` |
+| `isPresent()` | neither `null` nor `undefined` |
+
+## Numbers (`NumberValueInspector`)
+
+| Method | Reads | Meaning |
+| :-- | :-- | :-- |
+| `isNumber()` / `isNumberLike()` | raw / norm | finite number |
+| `isPositiveNumber()` / `isPositiveNumberLike()` | raw / norm | finite `> 0` |
+| `isNegativeNumber()` / `isNegativeNumberLike()` | raw / norm | finite `< 0` |
+| `isZero()` | raw | `value === 0` (incl. `-0`) |
+| `isNaN()` / `isFinite()` / `isInfinite()` | raw | NaN / finite / ±Infinity |
+| `normalizeValue()` | — | normalized `number`, or `null` (lazy + memoized) |
+
+## Integers (`IntegerValueInspector`)
+
+| Method | Reads | Meaning |
+| :-- | :-- | :-- |
+| `isInteger()` / `isIntegerLike()` | raw / norm | integer |
+| `isSafeInteger()` / `isSafeIntegerLike()` | raw / norm | safe integer (`±(2^53 − 1)`) |
+
+## There is no `isPositiveInteger` — compose it
+
+The module has no positive-integer method; combine an integer check with a positive check on the same
+inspector (string-tolerant `*Like` at the boundary):
+
+```js
+const inspector = IntegerValueInspector.create({
+  value: this.input.originObjectCategoryId,
+})
+
+// "positive integer" (accepts '42')
+inspector.isIntegerLike()
+  && inspector.isPositiveNumberLike()
+
+// for an id, also require it to be safe:
+inspector.isSafeIntegerLike()
+  && inspector.isPositiveNumberLike()
+```
+
+## Behavior cheat sheet
+
+| Input | `isNumber` | `isNumberLike` | `isInteger` | `isIntegerLike` | `isSafeIntegerLike` |
+| :-- | :-: | :-: | :-: | :-: | :-: |
+| `42` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `'42'` | ❌ | ✅ | ❌ | ✅ | ✅ |
+| `3.14` | ✅ | ✅ | ❌ | ❌ | ❌ |
+| `'3.14'` | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `Infinity` / `NaN` | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `9007199254740993` | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `1000n` / `true` | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `null` / `undefined` | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## Recipes for predicates
+
+- **Positive integer (id):** `inspector.isIntegerLike() && inspector.isPositiveNumberLike()`
+  (or `isSafeIntegerLike()` for ids).
+- **Optional field:** return `true` early when absent (`if (!value) { return true }`), then check.
+- **Required present:** `inspector.isPresent()`.
+- **Read the coerced number after validating:** `inspector.normalizeValue()` — don't re-parse.
+- **Guard empty string** for required numeric fields, since `''` normalizes to `0`.

--- a/kit/skills/backend/hb-resolver-validator/references/validator-pattern.md
+++ b/kit/skills/backend/hb-resolver-validator/references/validator-pattern.md
@@ -1,0 +1,281 @@
+# Validator pattern (template, base contract, integration, testing)
+
+The full `*InputValidator` template, the `BaseInputValidator` contract, resolver wiring, and testing.
+Referenced from [SKILL.md](../SKILL.md).
+
+## Full template
+
+A validator extends `BaseInputValidator`, overrides `generateValidationEntries()`, and adds one
+`isValidX()` predicate per rule plus small `create*` helpers for the sub-validators / inspectors it
+uses. This is the standard shape (a query validator that reuses pagination):
+
+```js
+import {
+  IntegerValueInspector,
+} from '@openreachtech/mentsu-value-inspector'
+
+import BaseInputValidator from '../../BaseInputValidator.js'
+import PaginationInputValidator from '../../NormalPaginationInputValidator.js'
+
+const VALID_SORT_COLUMNS = [
+  'labelName',
+  'fieldPath',
+]
+
+/**
+ * Class for validating input of the emailInsertableVariables query
+ *
+ * @extends {BaseInputValidator<ErrorHash, EmailInsertableVariablesInput>}
+ */
+export default class EmailInsertableVariablesInputValidator extends BaseInputValidator {
+  /**
+   * Generate validation entries
+   *
+   * @override
+   * @returns {Array<[() => boolean, RenchanGraphqlErrorCtor]>}
+   */
+  generateValidationEntries () {
+    const paginationInputValidator = this.createPaginationInputValidator()
+
+    return [
+      [
+        () => paginationInputValidator.isValidLimit(),
+        this.errorHash.InvalidPaginationLimit,
+      ],
+      [
+        () => paginationInputValidator.isValidOffset(),
+        this.errorHash.InvalidPaginationOffset,
+      ],
+      [
+        () => paginationInputValidator.isValidSort(),
+        this.errorHash.InvalidPaginationSort,
+      ],
+      [
+        () => this.isValidKeyword(),
+        this.errorHash.InvalidKeyword,
+      ],
+      [
+        () => this.isValidOriginObjectCategoryId(),
+        this.errorHash.InvalidOriginObjectCategoryId,
+      ],
+    ]
+  }
+
+  /**
+   * Create a PaginationInputValidator instance
+   *
+   * @param {{
+   *   input?: EmailInsertableVariablesInput
+   * }} [params]
+   * @returns {PaginationInputValidator}
+   */
+  createPaginationInputValidator ({
+    input = this.input,
+  } = {}) {
+    return PaginationInputValidator.create({
+      input,
+      validColumns: VALID_SORT_COLUMNS,
+    })
+  }
+
+  /**
+   * Validate keyword
+   *
+   * @returns {boolean}
+   */
+  isValidKeyword () {
+    const {
+      keyword = null,
+    } = this.input
+
+    if (!keyword) {
+      return true
+    }
+
+    return typeof keyword === 'string'
+  }
+
+  /**
+   * Validate originObjectCategoryId
+   *
+   * @returns {boolean}
+   */
+  isValidOriginObjectCategoryId () {
+    const inspector = this.createIntegerValueInspector({
+      value: this.input.originObjectCategoryId,
+    })
+
+    // the module has no isPositiveInteger — compose it (string-tolerant *Like)
+    return inspector.isIntegerLike()
+      && inspector.isPositiveNumberLike()
+  }
+
+  /**
+   * Create an IntegerValueInspector instance
+   *
+   * @param {{
+   *   value: number | string
+   * }} params
+   * @returns {IntegerValueInspector}
+   */
+  createIntegerValueInspector ({
+    value,
+  }) {
+    return IntegerValueInspector.create({
+      value,
+    })
+  }
+}
+
+/**
+ * @typedef {{
+ *   InvalidKeyword: RenchanGraphqlErrorCtor
+ *   InvalidOriginObjectCategoryId: RenchanGraphqlErrorCtor
+ *   InvalidPaginationLimit: RenchanGraphqlErrorCtor
+ *   InvalidPaginationOffset: RenchanGraphqlErrorCtor
+ *   InvalidPaginationSort: RenchanGraphqlErrorCtor
+ * }} ErrorHash
+ */
+
+/**
+ * @typedef {import('../../BaseInputValidator.js').RenchanGraphqlErrorCtor} RenchanGraphqlErrorCtor
+ */
+
+/**
+ * @typedef {graphql.EmailInsertableVariablesInput} EmailInsertableVariablesInput
+ */
+```
+
+## `BaseInputValidator` contract
+
+The base (`app/validator/forResolver/BaseInputValidator.js`) provides the logic so subclasses
+only declare rules:
+
+- **Instance state:** `this.input` (the resolver input) and `this.errorHash` (the resolver's error
+  constructors), supplied through the factory.
+- **`generateValidationEntries()`** — abstract; the subclass returns
+  `Array<[() => boolean, RenchanGraphqlErrorCtor]>`.
+- **Run entrypoint** — iterates the entries and, for the first entry whose predicate returns
+  `false`, raises that `ErrorCtor`. (Shown as `validate()` in the wiring below; use whatever the
+  actual base names it.)
+- Generic JSDoc `@extends {BaseInputValidator<ErrorHash, InputType>}` documents the error hash and
+  input shapes for that validator.
+
+## Predicate conventions
+
+- **One `isValidX()` per rule**, returning a boolean, reading `this.input`. Never throw inside a
+  predicate — returning `false` is how a rule fails; the base turns that into the error.
+- **Optional fields pass when absent:** destructure with a default and short-circuit, e.g.
+  `const { keyword = null } = this.input; if (!keyword) { return true }`.
+- **Value-shape checks go through an inspector** via a `create*ValueInspector({ value })` helper —
+  e.g. `this.createIntegerValueInspector({ value })` then compose
+  `isIntegerLike() && isPositiveNumberLike()` (there is no `isPositiveInteger` in the module). See
+  [inspector-api.md](./inspector-api.md).
+
+## Compose shared validators (don't re-implement pagination)
+
+Pagination (limit / offset / sort) is validated by the shared `PaginationInputValidator`
+(`NormalPaginationInputValidator.js`). Create it with the input and the allowed sort columns, then
+reference its `isValidLimit()` / `isValidOffset()` / `isValidSort()` from your entries — as the
+template does. Do the same for any other cross-cutting validator rather than duplicating its rules.
+
+## Resolver wiring
+
+The resolver declares the error codes (so each `InvalidXxx` has a code) and runs the validator with
+its own `input` and `errorHash`:
+
+```js
+/** @override */
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    InvalidKeyword: '400.C001.001',
+    InvalidOriginObjectCategoryId: '400.C001.002',
+    InvalidPaginationLimit: '400.C001.003',
+    InvalidPaginationOffset: '400.C001.004',
+    InvalidPaginationSort: '400.C001.005',
+  }
+}
+
+/** @override */
+async resolve ({
+  variables: {
+    input,
+  },
+  context,
+}) {
+  EmailInsertableVariablesInputValidator
+    .create({
+      input,
+      errorHash: this.errorHash,
+    })
+    .validate()
+
+  // ... input is now trusted ...
+}
+```
+
+- The error names in the validator's `ErrorHash` typedef must match keys in the resolver's
+  `errorCodeHash`.
+- `create({ input, errorHash })` and the run entrypoint come from `BaseInputValidator`; align with
+  the actual base API.
+
+## Testing
+
+Predicates are pure, so unit-test them directly with the `hc-jest` skill — no
+resolver, no DB. Instantiate the validator with a stub `errorHash` and assert each `isValidX()`, and
+assert that invalid input raises the matching `InvalidXxx` through the run entrypoint.
+
+```js
+describe('EmailInsertableVariablesInputValidator', () => {
+  describe('isValidOriginObjectCategoryId', () => {
+    /* eslint-disable */
+ },
+      {
+        input: {
+          originObjectCategory    const cases = [
+      {
+        input: {
+          originObjectCategoryId: 1,
+        },
+        expected: true,
+     Id: '1',
+        },
+        expected: true,
+      },
+      {
+        input: {
+          originObjectCategoryId: 0,
+        },
+        expected: false,
+      },
+      {
+        input: {
+          originObjectCategoryId: -1,
+        },
+        expected: false,
+      },
+      {
+        input: {
+          originObjectCategoryId: 'abc',
+        },
+        expected: false,
+      },
+    ]
+    /* eslint-enable */
+
+    test.each(cases)('input $input', ({
+      input,
+      expected,
+    }) => {
+      const validator = EmailInsertableVariablesInputValidator.create({
+        input,
+        errorHash: {},
+      })
+
+      expect(validator.isValidOriginObjectCategoryId()).toBe(expected)
+    })
+  })
+})
+```

--- a/kit/skills/backend/hb-restfulapi-architecture/SKILL.md
+++ b/kit/skills/backend/hb-restfulapi-architecture/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: hb-restfulapi-architecture
+description: >
+  Understand and build the RESTful API layer of a renchan-style backend: the renderer architecture
+  under server/restfulapi/. Use this skill whenever the user asks how the REST API is structured,
+  where a REST endpoint lives, or how to add or edit one — a GET / POST / PUT / PATCH / DELETE
+  Renderer, its route and version, the render() entry point, the response and error hashes, the
+  per-request context and share, the engine's auth filter, and response flushers.
+---
+
+# RESTful API Architecture
+
+A skill for understanding the **REST API layer** of a renchan-style backend — the code under
+`server/restfulapi/`. Structurally it **mirrors the GraphQL layer**: there is a per-request
+**context**, a per-process **share**, an **engine** that wires everything to the server, and an error
+hash declared up front. The difference is the surface: instead of a resolver returning a plain
+object, a **renderer** returns a **`RestfulApiResponse`** carrying an HTTP **status code** plus
+`content` or `error`, and a **flusher** writes it to the response.
+
+> This skill is self-contained. Support classes (`BaseRestfulApiServerEngine`,
+> `BaseGetRenderer` / `BasePostRenderer`, `RestfulApiResponse`, `BaseRestfulApiContext` /
+> `BaseRestfulApiShare`, `BaseRestfulApiResponseFlusher`) come from the framework
+> (`@openreachtech/renchan`). Examples use generic entities (`Article`) and generic routes;
+> substitute your own. Some conventions below are the **target** shape — where the current repo
+> diverges (notably input validation, §5), the improved form is described.
+
+## Core principle: a renderer is a resolver with an HTTP envelope
+
+One request → one **renderer**. A renderer does the same job a GraphQL resolver does — validate,
+touch the DB / an external system, shape a result — but it speaks HTTP:
+
+- Its return value is a **`RestfulApiResponse`** (`statusCode` + `content` / `error`), not a bare
+  object. Errors are **returned**, not thrown: `return this.errorResponseHash.Xxx.createAsError()`.
+- It is bound to an **HTTP method + route** (`GET /v1/articles`), discovered from a **versioned
+  directory** (`renderers/v1/get/…`), not from a schema name.
+- Everything else — the per-request **context** (`now`, `share`, `env`, the authenticated user),
+  the **error hash** declared up front, an optional **DI factory** — is the same idea as the
+  GraphQL side.
+
+Three rules matter most:
+
+1. **Return responses, never throw.** Every exit is a `RestfulApiResponse` — success via
+   `RestfulApiResponse.create({ statusCode, content })`, failure via
+   `this.errorResponseHash.Xxx.createAsError()`. HTTP always needs a status code, so an error
+   without one is meaningless here (§4).
+2. **The engine owns cross-cutting concerns; the renderer owns one endpoint.** Auth (the visa
+   filter), middleware, versioning, and the standard error envelopes live on the engine (§3). The
+   renderer only knows its route, its errors, and its `render()` (§2).
+3. **Validate at the boundary, then delegate.** REST input arrives split across `body` / `query` /
+   path params and is all string-like; normalize and validate it before touching the DB (§5).
+
+- **Comments: English for code, the surrounding language for domain notes.** Match the neighbors.
+
+## Layer map
+
+```
+                        HTTP request
+                             │
+        ┌────────────────────▼─────────────────────┐
+        │ Engine  (BaseRestfulApiServerEngine)      │  app-wide: routes, middleware,
+        │  config: pathPrefix + renderersPath       │  auth filter (visa), Share/Context,
+        │  generateFilterHandler(), visaIssuers     │  standardErrorEnvelopHash
+        └────────────────────┬─────────────────────┘
+                             │ builds per request
+        ┌────────────────────▼─────────────────────┐
+        │ Context (per request) + Share (per proc)  │  now, env, share, user,
+        │  hasAuthenticated / hasAuthorized / …     │  hasPathPermission  (§3)
+        └────────────────────┬─────────────────────┘
+                             │ render input = { body, query, context, request }
+        ┌────────────────────▼─────────────────────┐
+        │ Renderer (BaseGetRenderer/BasePostRenderer)│  routePath, errorStructureHash,
+        │  passesFilter, render() → RestfulApiResponse│  passesFilter, render()  (§1,§2)
+        └────────────────────┬─────────────────────┘
+                             │ returns RestfulApiResponse (status + content/error)  (§4)
+        ┌────────────────────▼─────────────────────┐
+        │ Flusher (BaseRestfulApiResponseFlusher)   │  writes status + headers + body
+        │  Json (default) / Html / Csv / Redirect   │  contentType, flushResponseBody  (§4)
+        └────────────────────┬─────────────────────┘
+                             ▼
+                        HTTP response
+```
+
+## Request lifecycle
+
+For each incoming request the framework's routes builder:
+
+1. Builds the **render input** `{ body, query, context, request }` — `body` is the multer-fulfilled
+   request body, `query` is `expressRequest.query`, `context` is created async (resolves the user +
+   visa), `request` wraps the express request (path-param proxy).
+2. If the renderer's **`passesFilter`** is `true`, skips the filter; otherwise runs the engine's
+   **filter handler** (auth). If the filter returns an error response, that short-circuits `render()`.
+3. Calls **`renderer.render(input)`**, which returns a `RestfulApiResponse`.
+4. Any **thrown** error is caught and converted to a `500` `RestfulApiResponse` (Unknown) — so
+   renderers should still return their own typed errors rather than relying on this.
+5. The renderer's **flusher** writes the response (status, headers, body).
+
+## 1. Directory, versioning, and route binding
+
+Renderers live under `server/restfulapi/renderers/`, split **by version then by HTTP method**:
+
+```
+server/restfulapi/
+  AppRestfulApiServerEngine.js       # the engine (§3)
+  contexts/
+    AppRestfulApiContext.js          # per-request context (§3)
+    AppRestfulApiShare.js            # per-process share (§3)
+  flushers/                          # custom response flushers (§4)
+  renderers/
+    v1/
+      get/   <Name>Renderer.js       # one file per endpoint
+      post/  <Name>Renderer.js
+    v2/
+      get/   …
+      post/  …
+```
+
+- **`renderers/<version>/<method>/<Name>Renderer.js`** — the directory encodes the **version**
+  (`v1`, `v2`) and the **HTTP method** (`get`, `post`, …). Keep the method out of the class name and
+  let the folder carry it (the repo has both `FooRenderer` and `FooGetRenderer` — prefer the
+  folder-only form for new files).
+- **The engine selects the version.** `config.renderersPath` points at **one** version directory
+  (`renderers/v1/`) and `config.pathPrefix` (`/v1`) is prepended to every `routePath`. So
+  `routePath = '/articles'` in `renderers/v1/get/` serves **`GET /v1/articles`**. Serve another
+  version by pointing an engine at `renderers/v2/` with prefix `/v2`.
+- **The route is `pathPrefix + routePath`, method = the renderer's `method`.** The framework
+  discovers every renderer under `renderersPath`, reads its `routePath` and `method`, and registers
+  the express route — you never wire routes by hand.
+
+Detail in [renderers.md](./references/renderers.md).
+
+## 2. The renderer
+
+A renderer extends the method base (`BaseGetRenderer` / `BasePostRenderer` / `BasePutRenderer` / …)
+and implements a small, fixed surface:
+
+```js
+import {
+  BaseGetRenderer,
+  RestfulApiResponse,
+} from '@openreachtech/renchan'
+
+export default class ArticleGetRenderer extends BaseGetRenderer {
+  /** @override */
+  static get routePath () {
+    return '/articles'
+  }
+
+  /** @override */
+  static get errorStructureHash () {
+    return {
+      ArticleNotFound: {
+        statusCode: 404,
+        errorMessage: 'Article not found',
+      },
+    }
+  }
+
+  /** @override */
+  get passesFilter () {
+    return true // public endpoint → skip the engine auth filter
+  }
+
+  /**
+   * @override
+   * @param {RestfulApiType.RenderInput<*, *>} input
+   * @returns {Promise<RestfulApiType.RenderResponse>}
+   */
+  async render ({
+    query,
+    context,
+    request,
+  }) {
+    const article = await this.findArticle({
+      articleId: request.pathParameterHashProxy.articleId,
+    })
+
+    if (!article) {
+      return this.errorResponseHash.ArticleNotFound.createAsError()
+    }
+
+    return RestfulApiResponse.create({
+      statusCode: 200,
+      content: this.formatResponseContent({
+        article,
+      }),
+    })
+  }
+
+  // ... findArticle(), formatResponseContent() ...
+}
+```
+
+- **`render({ body, query, context, request })`** is the entry point. `body` = parsed request body
+  (POST/PUT/PATCH), `query` = query string params, `context` = the per-request context (`now`,
+  `share`, `env`, user — §3), `request` = the wrapped express request (`expressRequest`, and a
+  `pathParameterHashProxy` that returns `null` for missing path params).
+- **`static get routePath()`** — the route (prefixed by the engine, §1).
+- **`get passesFilter()`** — `true` skips the engine's auth filter (public); default `false` runs it.
+- **Dependency injection** — add `constructor` + `static create()` + `static createXxx()` only when
+  a tool must be substitutable in tests (same factory pattern as the GraphQL side).
+
+Method-verb subclasses, `render()` input shape, DI, and file uploads (multer via
+`fileFieldsConfigHash`) are in [renderers.md](./references/renderers.md).
+
+## 3. Engine, context, and share (the app-wide layer)
+
+These three set up the whole REST surface, mirroring the GraphQL engine/context/share:
+
+- **Engine** (`AppRestfulApiServerEngine extends BaseRestfulApiServerEngine`) — declares `config`
+  (`pathPrefix` / `renderersPath` / `staticPath`), wires `static get Share()` / `static get
+  Context()`, the **`standardErrorEnvelopHash`** (cross-cutting errors: `Unknown`,
+  `Unauthenticated`, `Unauthorized`, `Database`, …), the express **middleware**
+  (`collectMiddleware()`), the **auth filter** (`generateFilterHandler()`), and the **visa issuers**
+  (`visaIssuers`: `hasAuthenticated` / `hasAuthorized` / `hasPathPermission`).
+- **Context** (`AppRestfulApiContext extends BaseRestfulApiContext`) — built per request. Override
+  `static async findUser()` to resolve the authenticated user from the access-token header. Exposes
+  `now`, `userId`, `userEntity`, `share`, `env`, and the visa predicates
+  (`hasAuthenticated()` / `hasAuthorized()` / `hasPathPermission()`).
+- **Share** (`AppRestfulApiShare extends BaseRestfulApiShare`) — the per-process object (holds `env`;
+  put shared clients/providers here). Often a `// noop` subclass.
+
+Detail in [engine-and-context.md](./references/engine-and-context.md).
+
+## 4. Response, error hash, and flusher
+
+- **`RestfulApiResponse`** is the return type. Success:
+  `RestfulApiResponse.create({ statusCode, headers?, content })`. Error: from the built error hash,
+  `this.errorResponseHash.Xxx.createAsError()`.
+- **Error hash** — like the GraphQL error code hash, a renderer declares its errors up front in
+  `static get errorStructureHash()`. **Unlike** GraphQL (code only), each REST entry also carries a
+  `statusCode` and `errorMessage`, because an HTTP response needs a status. The framework turns the
+  hash into constructable `RestfulApiResponse` subclasses on `this.errorResponseHash`. Cross-cutting
+  errors live on the engine's `standardErrorEnvelopHash`.
+- **Extending the response** — when you need a non-default body shape or behavior, subclass
+  `RestfulApiResponse` in the app and return that.
+- **Flusher** — a `BaseRestfulApiResponseFlusher` writes the response (status → headers → body).
+  Default is JSON (`{ content, error }`); the framework also ships Html and Csv; a renderer selects
+  one via `static get FlusherCtor()`, and the app can define custom flushers (e.g. a redirect).
+
+Detail in [response-and-flusher.md](./references/response-and-flusher.md).
+
+## 5. Input validation (the target shape)
+
+The current repo validates REST input **ad hoc** inside `render()` (an inline `isValidRequestBody()`).
+The **target** is to validate with the **same validator structure as GraphQL**: a
+`BaseInputValidator` subclass whose `generateValidationEntries()` returns `[predicate, ErrorCtor]`
+pairs and whose `validateInput()` returns the first failing error (or `null`).
+
+The catch is the input shape. A GraphQL validator receives a single typed `input` object; REST input
+arrives split across **`body` / `query` / path params**, all strings. So a REST renderer needs an
+**adapter**: a small class that reads `{ body, query, request }` and produces the normalized `input`
+object the validator expects. The renderer flow becomes **adapter → input → validator → (on failure)
+map to the renderer's `errorResponseHash` entry**.
+
+There is also a **type-mismatch** to bridge: a GraphQL-style validator yields a code-only error,
+while REST needs a **status-bearing** `RestfulApiResponse`. The wiring must map each validation
+failure to the matching `errorStructureHash` entry (status + message).
+
+The adapter, the validator contract, and the error mapping are in
+[validation.md](./references/validation.md).
+
+## Detail files
+
+- [renderers.md](./references/renderers.md) — the renderer file: method-verb subclasses, directory
+  & versioning, `routePath`, `render()` input (`body` / `query` / `context` / `request`),
+  `passesFilter`, the DI factory, and multipart file uploads (§1, §2)
+- [engine-and-context.md](./references/engine-and-context.md) — the engine (`config`,
+  `renderersPath` / `pathPrefix`, `Share` / `Context`, `standardErrorEnvelopHash`, middleware,
+  filter handler, visa issuers) and the per-request context / per-process share (§3)
+- [response-and-flusher.md](./references/response-and-flusher.md) — `RestfulApiResponse`
+  (success / `createAsError`), `errorStructureHash` → `errorResponseHash`, extending the response,
+  and flushers (JSON / Html / Csv / custom, `FlusherCtor`, `contentType`) (§4)
+- [validation.md](./references/validation.md) — the target validator (`BaseInputValidator`,
+  `generateValidationEntries`, `validateInput`), the REST-input → `input` adapter, and mapping a
+  validation failure to a status-bearing response (§5)

--- a/kit/skills/backend/hb-restfulapi-architecture/references/engine-and-context.md
+++ b/kit/skills/backend/hb-restfulapi-architecture/references/engine-and-context.md
@@ -1,0 +1,192 @@
+# Engine, context, and share (the app-wide layer)
+
+Three classes set up the whole REST surface. They mirror the GraphQL engine/context/share: the
+**engine** wires routes, middleware, auth, and the standard errors; the **context** is built fresh
+per request; the **share** is a single per-process object.
+
+## Engine
+
+`AppRestfulApiServerEngine extends BaseRestfulApiServerEngine`. It is the single place that
+configures the REST layer.
+
+```js
+import express from 'express'
+import cors from 'cors'
+
+import {
+  BaseRestfulApiServerEngine,
+} from '@openreachtech/renchan'
+
+import rootPath from '../../app/globals/root-path.js'
+
+import AppRestfulApiShare from './contexts/AppRestfulApiShare.js'
+import AppRestfulApiContext from './contexts/AppRestfulApiContext.js'
+
+export default class AppRestfulApiServerEngine extends BaseRestfulApiServerEngine {
+  /** @override */
+  static get config () {
+    return {
+      pathPrefix: '/v1', // prepended to every routePath; null = none
+      renderersPath: rootPath.to('server/restfulapi/renderers/v1/'),
+      staticPath: rootPath.to('public/'),
+    }
+  }
+
+  /** @override */
+  static get Share () {
+    return AppRestfulApiShare
+  }
+
+  /** @override */
+  static get Context () {
+    return AppRestfulApiContext
+  }
+
+  // ... standardErrorEnvelopHash, generateFilterHandler, visaIssuers, collectMiddleware ...
+}
+```
+
+- **`static get config()`** — `pathPrefix` (route prefix, e.g. `/v1`), `renderersPath` (the **one**
+  version directory whose renderers this engine serves), `staticPath` (static files root). To serve
+  a second version, run an engine pointed at `renderers/v2/` with `pathPrefix: '/v2'`.
+- **`static get Share()` / `static get Context()`** — the app Share / Context classes (below).
+- **`static get standardErrorEnvelopHash()`** — the **cross-cutting** error envelopes, keyed by
+  name, each `{ statusCode, errorMessage }`. The framework requires at least `Unknown`,
+  `ConcreteMemberNotFound`, `Unauthenticated`, `Unauthorized`, `Database`. These back the engine's
+  own `errorResponseHash` (used by the filter handler); per-endpoint errors live on the renderer
+  (`errorStructureHash`).
+
+```js
+/** @override */
+static get standardErrorEnvelopHash () {
+  return {
+    Unknown: {
+      statusCode: 500,
+      errorMessage: 'Unknown error',
+    },
+    Unauthenticated: {
+      statusCode: 401,
+      errorMessage: 'Unauthenticated',
+    },
+    Unauthorized: {
+      statusCode: 403,
+      errorMessage: 'Unauthorized',
+    },
+    // ConcreteMemberNotFound, Database, ...
+  }
+}
+```
+
+- **`collectMiddleware()`** — the express middleware stack (cors, JSON / urlencoded body parsers,
+  static file serving, …). Returns an array applied in order.
+
+## The auth filter: `generateFilterHandler()` + `visaIssuers`
+
+Authentication/authorization is a **cross-cutting filter** run before `render()` for every renderer
+whose `passesFilter` is `false`. Two pieces:
+
+- **`get visaIssuers()`** — async predicates that populate the request's **visa**, each given
+  `{ expressRequest, userEntity, engine }`:
+
+```js
+/** @override */
+get visaIssuers () {
+  return {
+    hasAuthenticated: async ({
+      userEntity,
+    }) => userEntity !== null,
+    hasAuthorized: async ({
+      userEntity,
+    }) => true,
+    hasPathPermission: async ({
+      userEntity,
+    }) => true,
+  }
+}
+```
+
+- **`generateFilterHandler()`** — returns an async `({ body, query, context, request }) => errorResponse | null`.
+  Read the visa via the context and **return an error response to reject**, or `null` to allow:
+
+```js
+/** @override */
+generateFilterHandler () {
+  return async ({
+    context,
+  }) => {
+    if (!context.hasAuthenticated()) {
+      return this.errorResponseHash.Unauthenticated.createAsError()
+    }
+
+    if (!context.hasAuthorized()) {
+      return this.errorResponseHash.Unauthorized.createAsError()
+    }
+
+    return null
+  }
+}
+```
+
+A renderer with `get passesFilter () { return true }` skips this entirely (public endpoint).
+
+## Context (per request)
+
+`AppRestfulApiContext extends BaseRestfulApiContext`. The framework builds it **per request**:
+it extracts the access token from the header (`x-renchan-access-token`), calls `findUser`, and
+builds the visa from the engine's `visaIssuers`.
+
+```js
+import {
+  BaseRestfulApiContext,
+} from '@openreachtech/renchan'
+
+export default class AppRestfulApiContext extends BaseRestfulApiContext {
+  /**
+   * Resolve the authenticated user from the access token.
+   *
+   * @override
+   * @param {{
+   *   expressRequest: ExpressType.Request
+   *   accessToken: string | null
+   *   now?: Date
+   * }} params
+   * @returns {Promise<renchan.UserEntity | null>}
+   */
+  static async findUser ({
+    expressRequest,
+    accessToken,
+    now = new Date(),
+  }) {
+    // look up the token → return the user entity, or null
+  }
+}
+```
+
+The context is what `render()` receives as `context`. It exposes:
+
+- **`now`** — the request timestamp (`requestedAt`); use it so all writes in the request share one
+  time.
+- **`userId` / `userEntity`** — the authenticated user (or `null`).
+- **`share`** — the per-process share (below); **`env`** / **`NODE_ENV`** — configuration.
+- **`hasAuthenticated()` / `hasAuthorized()` / `hasPathPermission()` / `canRender()`** — the visa
+  predicates the filter handler reads.
+- **`uuid`** — a per-request id.
+
+Override `findUser` to do the token → user lookup. Add domain-neutral aliases if useful (e.g. a
+`provider` getter aliasing `userEntity`), but keep app-specific naming out of the base pattern.
+
+## Share (per process)
+
+`AppRestfulApiShare extends BaseRestfulApiShare`. A single object created once at startup, reachable
+as `context.share`. It holds `env` and is the place for **shared, long-lived collaborators** (an
+external-API client, a provider). Often a `// noop` subclass until something needs sharing:
+
+```js
+import {
+  BaseRestfulApiShare,
+} from '@openreachtech/renchan'
+
+export default class AppRestfulApiShare extends BaseRestfulApiShare {
+  // noop
+}
+```

--- a/kit/skills/backend/hb-restfulapi-architecture/references/renderers.md
+++ b/kit/skills/backend/hb-restfulapi-architecture/references/renderers.md
@@ -1,0 +1,204 @@
+# The renderer file
+
+A renderer resolves one HTTP endpoint. It extends a **method-verb base** and implements a fixed
+surface: the route, the errors it can return, whether it skips the auth filter, and `render()`.
+
+> Examples use a generic `Article` resource. Swap in your own.
+
+## Method-verb subclasses
+
+Extend the base for the HTTP method the endpoint answers. The base fixes `static get method()`:
+
+| Base class | method | Notes |
+| --- | --- | --- |
+| `BaseGetRenderer` | `get` | no request body |
+| `BasePostRenderer` | `post` | body-bearing (multer middleware, file uploads) |
+| `BasePutRenderer` | `put` | body-bearing |
+| `BasePatchRenderer` | `patch` | body-bearing |
+| `BaseDeleteRenderer` | `delete` | |
+| `BaseHeadRenderer` / `BaseOptionsRenderer` / … | head / options / … | |
+
+Body-bearing verbs (post/put/patch) extend a request-body base that wires **multer** for
+`multipart/form-data`; the rest extend the plain renderer base directly. All ultimately extend
+`BaseRenderer`, which holds the factory, the error hash, and `flushResponse()`.
+
+## Directory & versioning
+
+One renderer = one file (one class per file):
+
+```
+server/restfulapi/renderers/<version>/<method>/<Name>Renderer.js
+  e.g. server/restfulapi/renderers/v1/get/ArticleGetRenderer.js
+       server/restfulapi/renderers/v1/post/CreateArticleRenderer.js
+```
+
+- The **folder encodes version and method** — the framework reads each renderer's `routePath` and
+  `method` and registers the express route under `config.pathPrefix`. You never wire routes by hand.
+- **Class name** = `<Name>Renderer` (PascalCase). Let the `get/` `post/` folder carry the verb rather
+  than repeating it in the name.
+- A new API **version** is a new directory (`renderers/v2/`) served by an engine pointed at it with
+  its own `pathPrefix` (`/v2`). See [engine-and-context.md](./engine-and-context.md).
+
+## The fixed surface
+
+```js
+import {
+  BasePostRenderer,
+  RestfulApiResponse,
+} from '@openreachtech/renchan'
+
+import Article from '../../../../../sequelize/models/Article.js'
+
+export default class CreateArticleRenderer extends BasePostRenderer {
+  /**
+   * get: Route path.
+   *
+   * @override
+   * @returns {string}
+   */
+  static get routePath () {
+    return '/articles'
+  }
+
+  /**
+   * get: Error structure hash.
+   *
+   * @override
+   * @returns {Record<string, RestfulApiType.ErrorResponseEnvelope>}
+   */
+  static get errorStructureHash () {
+    return {
+      InvalidRequestBody: {
+        statusCode: 400,
+        errorMessage: 'Invalid request body',
+      },
+    }
+  }
+
+  /**
+   * get: Passes filter.
+   *
+   * @override
+   * @returns {boolean}
+   */
+  get passesFilter () {
+    return false // run the engine auth filter before render
+  }
+
+  /**
+   * Render.
+   *
+   * @override
+   * @param {RestfulApiType.RenderInput<*, *>} input
+   * @returns {Promise<RestfulApiType.RenderResponse>}
+   */
+  async render ({
+    body,
+    context: {
+      now,
+      userId,
+    },
+  }) {
+    if (!this.isValidBody({
+      body,
+    })) {
+      return this.errorResponseHash.InvalidRequestBody.createAsError()
+    }
+
+    const article = await this.saveArticle({
+      body,
+      now,
+      userId,
+    })
+
+    return RestfulApiResponse.create({
+      statusCode: 201,
+      content: {
+        articleId: article.id,
+      },
+    })
+  }
+
+  // ... isValidBody(), saveArticle() ...
+}
+```
+
+- **`static get routePath()`** — the route, prefixed by the engine (`/articles` → `/v1/articles`).
+- **`static get errorStructureHash()`** — the errors this renderer can return, each with a
+  `statusCode` + `errorMessage`. See [response-and-flusher.md](./response-and-flusher.md).
+- **`get passesFilter()`** — `true` = public (skip the engine auth filter); default `false` = run it.
+- **`async render(input)`** — the entry point (below).
+
+## `render()` input: `{ body, query, context, request }`
+
+The framework passes one object with four keys:
+
+- **`body`** — the parsed request body (POST/PUT/PATCH). For `multipart/form-data`, multer has
+  already run and files are attached (see file uploads below).
+- **`query`** — `expressRequest.query` (the query-string params, all strings).
+- **`context`** — the per-request context: `now`, `share`, `env`, `userId` / `userEntity`, and the
+  visa predicates. See [engine-and-context.md](./engine-and-context.md).
+- **`request`** — the wrapped express request. `request.expressRequest` is the raw request;
+  `request.pathParameterHashProxy` reads path params (`/articles/:articleId`) and returns **`null`**
+  for a missing key rather than `undefined`.
+
+Destructure only what the endpoint needs. `render()` must **return a `RestfulApiResponse`** on every
+path — success via `RestfulApiResponse.create(...)`, failure via
+`this.errorResponseHash.Xxx.createAsError()`. Do not throw (a thrown error becomes a generic 500).
+
+## Dependency injection (optional)
+
+Like a GraphQL resolver, a renderer needs no constructor unless it depends on a tool that tests must
+substitute (a token/id generator, an external client). Then add the factory triple — and pass the
+error hash through:
+
+```js
+constructor ({
+  randomTextGenerator,
+  errorResponseHash,
+}) {
+  super({
+    errorResponseHash,
+  })
+
+  this.randomTextGenerator = randomTextGenerator
+}
+
+static create ({
+  randomTextGenerator = this.createRandomTextGenerator(),
+  errorStructureHash = this.errorStructureHash,
+} = {}) {
+  const errorResponseHash = this.buildErrorResponseHash({
+    errorStructureHash,
+  })
+
+  return new this({
+    randomTextGenerator,
+    errorResponseHash,
+  })
+}
+
+static createRandomTextGenerator () {
+  return RandomTextGenerator.create()
+}
+```
+
+- Note the base's `create()` builds `errorResponseHash` from `errorStructureHash` via
+  `buildErrorResponseHash()`. When you override `create()`, do that build yourself and pass
+  `errorResponseHash` to `super()` — never drop it.
+
+## File uploads (body-bearing renderers)
+
+A body-bearing renderer (post/put/patch) declares the multipart file fields it accepts via
+`static get fileFieldsConfigHash()` — `{ <fieldName>: <maxCount> }`. The base builds the multer
+middleware from it; with an empty hash multer runs in `.none()` mode (parses fields, no files).
+
+```js
+static get fileFieldsConfigHash () {
+  return {
+    attachment: 1,
+  }
+}
+```
+
+Uploaded files are attached to the request and merged into `body` before `render()` runs.

--- a/kit/skills/backend/hb-restfulapi-architecture/references/response-and-flusher.md
+++ b/kit/skills/backend/hb-restfulapi-architecture/references/response-and-flusher.md
@@ -1,0 +1,118 @@
+# Response, error hash, and flusher
+
+A renderer always returns a **`RestfulApiResponse`** — an HTTP envelope carrying a `statusCode` plus
+`content` (success) or `error` (failure). A **flusher** then writes that envelope to the express
+response. This file covers both, and the error hash that produces error responses.
+
+## RestfulApiResponse
+
+`RestfulApiResponse` holds `{ statusCode, headers, content, error }`.
+
+```js
+// success
+return RestfulApiResponse.create({
+  statusCode: 200,
+  content: {
+    articleId: article.id,
+  },
+})
+```
+
+- **Success** → `RestfulApiResponse.create({ statusCode, headers?, content })`. `content` is the
+  response payload; `error` stays `null`.
+- **Failure** → **do not** `new` an error response by hand; take it from the built error hash:
+  `this.errorResponseHash.Xxx.createAsError()` (below). `createAsError()` fills in the entry's
+  `statusCode` and wraps the message as `{ error: { message } }`.
+- `get status()` aliases `statusCode` (the flusher reads `renderResponse.status`).
+
+## Error hash: `errorStructureHash` → `errorResponseHash`
+
+Like the GraphQL error code hash, a renderer declares every error it can return **up front**. The
+difference: **each REST entry carries a `statusCode` and `errorMessage`**, because an HTTP response
+needs a status — a code alone is not enough.
+
+```js
+/** @override */
+static get errorStructureHash () {
+  return {
+    InvalidRequestBody: {
+      statusCode: 400,
+      errorMessage: 'Invalid request body',
+    },
+    ArticleNotFound: {
+      statusCode: 404,
+      errorMessage: 'Article not found',
+    },
+  }
+}
+```
+
+- The framework's `buildErrorResponseHash()` turns each `{ Name: { statusCode, errorMessage } }`
+  entry into a constructable `RestfulApiResponse` subclass on **`this.errorResponseHash`** (also
+  reachable as `this.Error`). Return one with `this.errorResponseHash.ArticleNotFound.createAsError()`.
+- **Naming = the reason** (`InvalidRequestBody`, `ArticleNotFound`) — read as a sentence at the
+  return site. No `info` / `data` suffixes.
+- **Cross-cutting** errors (`Unauthenticated`, `Unauthorized`, `Unknown`, `Database`) are declared
+  **once on the engine** (`standardErrorEnvelopHash`) and used by the auth filter — do not redeclare
+  them per renderer. See [engine-and-context.md](./engine-and-context.md).
+
+This is the REST analog of "declare errors as a hash, throw by name" — here you **return** by name,
+and each name resolves to a status-bearing response.
+
+## Extending RestfulApiResponse
+
+When the default envelope is not enough — a custom body shape, extra headers, a computed status —
+subclass `RestfulApiResponse` in the app and return that subclass. Override what you need (e.g. a
+fixed `statusCode` getter, or an added factory) while keeping the `{ statusCode, content, error }`
+contract the flusher relies on. Prefer extending over hand-building one-off response objects, so
+every endpoint returns the same recognizable shape.
+
+## Flushers
+
+A **flusher** (`BaseRestfulApiResponseFlusher` subclass) writes the `RestfulApiResponse` to express:
+status → headers → body. The renderer picks one via `static get FlusherCtor()`.
+
+| Flusher | contentType | body |
+| --- | --- | --- |
+| `JsonRestfulApiResponseFlusher` (default) | `application/json` | `{ content, error }` |
+| `HtmlRestfulApiResponseFlusher` | `text/html` | HTML string |
+| `CsvRestfulApiResponseFlusher` | `text/csv` | CSV |
+| app custom (e.g. a redirect flusher) | your choice | your choice |
+
+- **Default is JSON** — a renderer that returns JSON needs no `FlusherCtor` override.
+- **Select a non-default flusher** per renderer:
+
+```js
+/** @override */
+static get FlusherCtor () {
+  return HtmlRestfulApiResponseFlusher
+}
+```
+
+- **Write a custom flusher** by extending `BaseRestfulApiResponseFlusher`: set `static get
+  contentType()` and implement `flushResponseBody()` (or override `flushResponse()` entirely for
+  non-body responses like a redirect). It reads `this.renderResponse` (the `RestfulApiResponse`) and
+  `this.expressResponse`:
+
+```js
+import {
+  BaseRestfulApiResponseFlusher,
+} from '@openreachtech/renchan'
+
+export default class RedirectRestfulApiResponseFlusher extends BaseRestfulApiResponseFlusher {
+  /** @override */
+  static get contentType () {
+    return 'text/html'
+  }
+
+  /** @override */
+  flushResponse () {
+    this.expressResponse.redirect(
+      this.renderResponse.status,
+      this.renderResponse.content?.redirectUrl ?? '/'
+    )
+  }
+}
+```
+
+Place app flushers under `server/restfulapi/flushers/`.

--- a/kit/skills/backend/hb-restfulapi-architecture/references/validation.md
+++ b/kit/skills/backend/hb-restfulapi-architecture/references/validation.md
@@ -1,0 +1,229 @@
+# Input validation (the target shape)
+
+The current repo validates REST input **ad hoc** inside `render()` — a hand-rolled
+`isValidRequestBody()` per renderer. The **target** is to validate with the **same validator
+structure the GraphQL layer uses**, so the two surfaces share one validation approach. Reaching
+that needs two collaborators: an **adapter** that normalizes REST input, and a **validator** that
+runs the rules.
+
+> This page is a target design, not the current repo. Examples use a generic `Article` resource.
+
+## Why validation needs an adapter here
+
+A GraphQL validator receives a single, already-typed `input` object. REST input does not arrive that
+way — it is **split across `body` / `query` / path params**, and it is all **string-like** (query
+and path values are strings; body values are whatever the client sent). Before any rule can run, the
+input has to be **collected and coerced** into the one `input` object the validator expects. That
+collect-and-coerce step is the **adapter**.
+
+So the boundary has two responsibilities, kept in two classes:
+
+- **Adapter** — read `{ body, query, request }`, produce a normalized `input` object (coerce types,
+  default missing values to `null`, merge the sources).
+- **Validator** — take that `input` and decide whether each value is acceptable.
+
+## The validator (same structure as GraphQL)
+
+A validator extends the shared **`BaseInputValidator`** and overrides one method:
+`generateValidationEntries()`, which returns an array of **`[predicate, ErrorIdentity]`** pairs. The
+base's `validateInput()` runs the predicates in order and returns the **first failing** entry's error
+(or `null` when all pass). Predicates are small `isValidX()` methods that read `this.input` and
+return a boolean — they never throw.
+
+```js
+import BaseInputValidator from '../../BaseInputValidator.js'
+
+export default class CreateArticleInputValidator extends BaseInputValidator {
+  /**
+   * @override
+   * @returns {Array<[() => boolean, *]>}
+   */
+  generateValidationEntries () {
+    return [
+      [
+        () => this.isValidTitle(),
+        this.errorHash.InvalidTitle,
+      ],
+      [
+        () => this.isValidTagIds(),
+        this.errorHash.InvalidTagIds,
+      ],
+    ]
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  isValidTitle () {
+    const {
+      title,
+    } = this.input
+
+    return typeof title === 'string'
+      && title.length > 0
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  isValidTagIds () {
+    const {
+      tagIds,
+    } = this.input
+
+    return Array.isArray(tagIds)
+      && tagIds.every(id => Number.isInteger(id))
+  }
+}
+```
+
+This is the **same shape** the GraphQL side uses — `generateValidationEntries()` returning
+`[predicate, error]` pairs, `validateInput()` provided by the base. Only the input it validates
+differs, and that difference is absorbed by the adapter.
+
+## The adapter
+
+One adapter per operation. It reads the three REST sources and returns the normalized `input`.
+
+```js
+export default class CreateArticleInputAdapter {
+  /**
+   * @param {{
+   *   body: RestfulApiType.RenderRequestBody
+   *   query: RestfulApiType.RenderRequestQuery
+   *   request: RestfulApiType.Request
+   * }} params
+   * @returns {CreateArticleInputAdapter}
+   */
+  static create ({
+    body,
+    query,
+    request,
+  }) {
+    return new this({
+      body,
+      query,
+      request,
+    })
+  }
+
+  /**
+   * @param {{
+   *   body: RestfulApiType.RenderRequestBody
+   *   query: RestfulApiType.RenderRequestQuery
+   *   request: RestfulApiType.Request
+   * }} params
+   */
+  constructor ({
+    body,
+    query,
+    request,
+  }) {
+    this.body = body
+    this.query = query
+    this.request = request
+  }
+
+  /**
+   * Normalize REST input into the validator's `input` shape.
+   *
+   * @returns {{
+   *   title: string | null
+   *   tagIds: Array<number>
+   *   articleId: number | null
+   * }}
+   */
+  buildInput () {
+    return {
+      title: this.body.title ?? null,
+      tagIds: this.extractTagIds(),
+      articleId: this.extractArticleId(),
+    }
+  }
+
+  /**
+   * Coerce a comma-joined query string into a number array.
+   *
+   * @returns {Array<number>}
+   */
+  extractTagIds () {
+    const raw = this.query.tagIds ?? ''
+
+    return raw
+      .split(',')
+      .filter(Boolean)
+      .map(Number)
+  }
+
+  /**
+   * Coerce the path parameter into a number.
+   *
+   * @returns {number | null}
+   */
+  extractArticleId () {
+    const raw = this.request.pathParameterHashProxy.articleId
+
+    return raw === null
+      ? null
+      : Number(raw)
+  }
+}
+```
+
+- The adapter is the **only** place that knows input was split across sources and arrived as strings.
+  Everything downstream sees a clean, typed `input`.
+
+## Wiring in the renderer (and the error-type bridge)
+
+The renderer runs **adapter → validator → (on failure) a status-bearing response**:
+
+```js
+async render ({
+  body,
+  query,
+  request,
+}) {
+  const input = CreateArticleInputAdapter.create({
+    body,
+    query,
+    request,
+  })
+    .buildInput()
+
+  const validationResult = this.validateInput({
+    input,
+  })
+
+  if (validationResult) {
+    return validationResult
+  }
+
+  // ... input is now trusted; touch the DB, return RestfulApiResponse ...
+}
+```
+
+There is one bridge to get right. A GraphQL-style validator yields a **code-only** error, but REST
+must return a **status-bearing `RestfulApiResponse`** (§4). Resolve it one of two ways:
+
+- **Map in the renderer (recommended).** Keep `BaseInputValidator` transport-neutral: its
+  `errorHash` entries are error **identities** (names/keys), `validateInput()` returns the failing
+  identity or `null`, and the renderer maps that identity to its own
+  `this.errorResponseHash.Xxx.createAsError()`. The validator stays byte-for-byte the same as the
+  GraphQL one; only the renderer knows about HTTP status.
+- **A REST base validator.** Alternatively, a thin `BaseRestfulApiInputValidator` overrides how the
+  failing entry is instantiated so it returns a `RestfulApiResponse` (via `createAsError()`) directly,
+  and you feed it the renderer's `errorResponseHash`. Use this if you would rather the validator emit
+  the final response.
+
+Either way, keep `createInputValidator()` / `validateInput()` as thin named methods on the renderer,
+mirroring the GraphQL side, so the two surfaces read the same.
+
+## Split of duty
+
+- **Adapter** — shape and type only: collect `body` / `query` / path, coerce strings, default to
+  `null`. No value judgements.
+- **Validator** — value rules on the normalized `input`: presence, format, ranges, enums. Pure
+  booleans; no DB.
+- **Renderer / DB layer** — existence, ownership, and state checks that require the database (a
+  missing row → return a `404`-class response). These stay out of the validator, exactly as on the
+  GraphQL side.

--- a/kit/skills/backend/hb-security-audit/SKILL.md
+++ b/kit/skills/backend/hb-security-audit/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: hb-security-audit
+description: >
+  Run a READ-ONLY, repo-wide security audit of a JavaScript/TypeScript (Node) project and produce
+  a findings list — do not fix anything. Covers injection, missing or over-broad auth on HTTP
+  routes and GraphQL operations, port and datastore exposure, secrets and env hygiene, dependency
+  risk, CORS, rate limiting, logging/PII, uploads, and error leakage. Use when the user asks for a
+  security check or audit of the codebase. For a diff-only review of pending changes, use
+  /security-review.
+---
+
+# Security Audit
+
+A **read-only checklist audit** of a Node (JS/TS) repository. The goal is to **check and list
+places that could become vulnerabilities** — not to fix them. Work through every check, run its
+detection commands, judge each against its finding criteria, and produce a single **findings
+report**.
+
+This skill is **stack-agnostic within the Node ecosystem**: it names common frameworks / ORMs /
+loggers only as *examples*. Discover what the target project uses (read `package.json`, the entry
+point, the config files) and adapt each check's patterns to it. Do not assume any specific file
+layout — detect it.
+
+## Rules (read first)
+
+1. **Read-only. Never edit, never fix.** Only inspect, run non-mutating commands, and report.
+   Suggest a remediation per finding as text, but do not apply it.
+2. **Never print secret values.** When a check surfaces a credential, show the **key name and a
+   masked value** (e.g. `API_KEY=abcd…(masked)`, or `****`). Never paste full tokens / passwords into
+   the report or transcript.
+3. **Do not exfiltrate.** No network calls that send repo contents anywhere. A dependency-advisory
+   check against the registry (e.g. `npm audit`, which sends only package metadata) is fine; sending
+   files is not.
+4. **Every check must appear in the report** — as one or more findings, `PASS`, or `N/A` (with a
+   one-line reason). A gap must never look like "not applicable".
+5. **Detect, don't assume.** Before running a check, confirm which tools the project uses and where
+   the relevant code lives. If a check's subject does not exist in this project, mark it `N/A`.
+
+## How to run
+
+First, **profile the project** (about a minute): read `package.json` (scripts, deps, `engines`,
+`type`), find the server entry point and the config / env files, and identify the HTTP framework, the
+ORM / DB driver, the GraphQL server (if any), and the logger. Then go category by category through
+the [detail files](#checklist--detail-files). For each check: run the detection commands (adapted to
+this project), decide PASS / FINDING / N/A, and record findings in the format below. Prefer
+`git grep` so the search covers tracked source only (no `node_modules`, no build output). Finally,
+print the **summary table** (every check → verdict) followed by the detailed findings, most severe
+first.
+
+## Finding format
+
+```
+### [HIGH|MEDIUM|LOW|INFO] <short title>   (check: <category>/<id>)
+- Location: <file:line, or scope e.g. "the ORM connection config, non-local environments">
+- Evidence: <masked snippet or command output>
+- Risk: <why this is exploitable / what it exposes>
+- Recommendation: <what to change — DO NOT apply it>
+```
+
+Severity guide: **HIGH** = exploitable now / secret exposed / unauthenticated sensitive access.
+**MEDIUM** = weakens the security posture (no transport encryption, weak config, unrestricted upload
+type). **LOW** = hardening gap. **INFO** = worth noting, not a vulnerability.
+
+## Checklist & detail files
+
+| # | Check | Detail file |
+| --- | --- | --- |
+| 1 | Injection (SQL / NoSQL / command) via raw/interpolated input | [code-safety.md](./references/code-safety.md) |
+| 2 | `eval` / dynamic-exec code | [code-safety.md](./references/code-safety.md) |
+| 3 | Malicious / obfuscated code or install hooks | [code-safety.md](./references/code-safety.md) |
+| 4 | Exposed ports / bind address / datastore exposure | [network-and-logging.md](./references/network-and-logging.md) |
+| 5 | Production logging via a redacting logger; no PII | [network-and-logging.md](./references/network-and-logging.md) |
+| 6 | Auth enforced on every endpoint (routes + GraphQL queries/mutations/**subscriptions**) | [auth-and-transport.md](./references/auth-and-transport.md) |
+| 7 | Public / guest allow-list is minimal & intentional (classified) | [auth-and-transport.md](./references/auth-and-transport.md) |
+| 8 | Datastore transport encryption (TLS / SSL) | [auth-and-transport.md](./references/auth-and-transport.md) |
+| 9 | Introspection / playground / debug endpoints disabled in prod | [auth-and-transport.md](./references/auth-and-transport.md) |
+| 10 | CORS scoped (not wildcard in production) | [auth-and-transport.md](./references/auth-and-transport.md) |
+| 11 | Rate limiting on public endpoints (and not bypassable) | [auth-and-transport.md](./references/auth-and-transport.md) |
+| 12 | Env files covered by `.gitignore` (all variants) | [secrets.md](./references/secrets.md) |
+| 13 | No secrets in committed env files; secret-free template present | [secrets.md](./references/secrets.md) |
+| 14 | No hardcoded secrets in code / config | [secrets.md](./references/secrets.md) |
+| 15 | No plaintext passwords / secrets in seed / fixture data | [secrets.md](./references/secrets.md) |
+| 16 | No vulnerable dependencies (advisory audit) | [dependencies.md](./references/dependencies.md) |
+| 17 | Lockfile committed + version-pinning delay + no committed registry tokens | [dependencies.md](./references/dependencies.md) |
+| 18 | Reproducible installs (clean / locked install, not mutating) | [dependencies.md](./references/dependencies.md) |
+| 19 | File-upload validation (type + content + size) | [application-surface.md](./references/application-surface.md) |
+| 20 | No unused / scaffold / boilerplate operations exposed | [application-surface.md](./references/application-surface.md) |
+| 21 | GraphQL query depth / complexity limits | [application-surface.md](./references/application-surface.md) |
+| 22 | Error responses don't leak internals in production | [application-surface.md](./references/application-surface.md) |
+
+## Additional checks worth proposing
+
+Offer these when relevant (report as findings / PASS / N/A like the rest):
+
+- **Secrets in git history** (not just the current tree) — scan `git log -p` for secret patterns and
+  known key shapes; a secret that was ever committed must be rotated even if later removed.
+- **Datastore auth in production** — DB / cache / queue require a password and are not on a public
+  interface.
+- **Cookie / session flags** (`httpOnly` / `secure` / `sameSite`) if cookies are used.
+- **Runtime pinning** (`engines` set; no end-of-life Node version).
+- **Mass-assignment** — endpoints spreading raw request input straight into a DB write.
+
+## Output
+
+End with: (1) the summary table (every check → verdict), (2) findings most-severe-first, (3) the
+count by severity, and (4) a one-line reminder that nothing was changed. If asked, offer to hand
+specific findings to a fix workflow — but this skill itself never modifies code.
+
+Write the report in the language the reader is using, as the documentation convention requires of
+any document generated for a reader.

--- a/kit/skills/backend/hb-security-audit/references/application-surface.md
+++ b/kit/skills/backend/hb-security-audit/references/application-surface.md
@@ -1,0 +1,90 @@
+# Application surface (checks 19–22)
+
+File-upload validation, exposed unused / scaffold operations, GraphQL query depth / complexity, and
+error-response leakage. Referenced from [SKILL.md](../SKILL.md).
+
+## 19. File-upload validation (type + content + size)
+
+Any endpoint that accepts an uploaded file must validate it in **three** ways. Checking only one
+(commonly just size, or just the client-declared MIME type) is insufficient.
+
+1. **Declared type allow-list** — accept only the MIME type(s) / extension(s) the feature needs.
+2. **Content / magic-byte check** — verify the bytes actually match the claimed type. The client-sent
+   MIME type and filename extension are attacker-controlled and trivially spoofed; a real check reads
+   the file's magic number (e.g. `%PDF-` for PDF, `\x89PNG` for PNG, `PK\x03\x04` for zip/office).
+3. **Size limit** — cap the accepted size to bound memory / disk / downstream cost.
+
+```bash
+# Find upload handling (adapt to the stack: multer, busboy, formidable, GraphQL Upload, framework multipart):
+git grep -nE "multer|busboy|formidable|multipart|createReadStream|GraphQLUpload|Upload\b|fileFields|\.file\b|\.files\b" -- '*.js' '*.ts' '*.cjs' | head
+# Evidence of type/content/size validation near uploads:
+git grep -nE "mimetype|mime-type|content-type|fileFilter|magic|%PDF|signature|limits?\s*:|maxFileSize|fileSize|allowed.*[Tt]ype" -- '*.js' '*.ts' '*.cjs' | head
+```
+
+- **FINDING (MEDIUM):** an upload endpoint that validates size only, or trusts the client-declared
+  MIME type without a magic-byte / content check (spoofable). Recommend a type allow-list **plus** a
+  content check **plus** a size cap.
+- **FINDING (MEDIUM/HIGH):** no validation at all on an upload that is stored, parsed, or forwarded
+  (parsing an unexpected type can be an exploitation or DoS vector).
+- A robust content check reads the leading bytes and compares against the expected magic number for
+  the allow-listed type(s), and rejects anything that does not match even if the declared MIME type
+  looks correct.
+- **PASS:** uploads enforce type allow-list + content/magic check + size limit. **N/A:** no uploads.
+
+## 20. No unused / scaffold / boilerplate operations exposed
+
+Generated scaffolding, boilerplate CRUD, and leftover example endpoints are **attack surface** even
+when the product does not use them — they are often less reviewed, may be unauthenticated, and can
+mutate data. Every reachable route / resolver / subscription should correspond to a real product
+feature.
+
+```bash
+# Enumerate all operations, then reconcile against features actually in use:
+git grep -nE "\.(get|post|put|patch|delete)\(\s*['\"]/|type (Query|Mutation|Subscription)|@(Query|Mutation|Subscription|Get|Post|Put|Patch|Delete)\(|static get schema|routePath" -- '*.js' '*.ts' '*.cjs' '*.graphql'
+# Names that smell like scaffolding / examples / unused features:
+git grep -niE "example|sample|scaffold|boilerplate|todo|foobar|test-?only|demo|playground" -- '*.js' '*.ts' '*.cjs' '*.graphql' | head
+```
+
+- Cross-reference each operation with whether the frontend / product actually calls it. Operations
+  with no caller, or clearly generated example CRUD, are candidates for removal.
+- **FINDING (MEDIUM):** an exposed operation that is unused / scaffold and **state-changing or
+  sensitive** — especially if unauthenticated (ties into checks 6–7). Recommend removing it to shrink
+  the attack surface.
+- **FINDING (LOW):** an unused read-only operation left exposed.
+- **PASS:** every exposed operation maps to a real, intended feature.
+- Report the operation inventory so a human can confirm the mapping — do not delete anything (this
+  skill is read-only).
+
+## 21. GraphQL query depth / complexity limits
+
+Without a depth / complexity / cost limit, a client can send a deeply nested or highly branching
+query (e.g. cyclic relations) that forces enormous resolution work — a denial-of-service vector.
+
+```bash
+git grep -nE "depthLimit|graphql-depth-limit|complexity|costAnalysis|createComplexityRule|maxDepth|queryComplexity|validationRules" -- '*.js' '*.ts' '*.cjs' | head
+```
+
+- **FINDING (MEDIUM):** a GraphQL server with **no** depth or complexity limit and a schema that
+  contains nested / cyclic relations. Recommend a depth limit and/or a query-cost / complexity rule
+  as a validation rule.
+- **PASS:** a depth and/or complexity limit is configured. **N/A:** no GraphQL server, or a trivial
+  flat schema with no nesting (note the reasoning).
+
+## 22. Error responses don't leak internals in production
+
+Error responses returned to clients must not include stack traces, raw DB / driver errors, internal
+file paths, or SQL — these leak implementation detail useful to an attacker. Detail belongs in server
+logs (via the redacting logger, check 5), not the HTTP / GraphQL response.
+
+```bash
+git grep -nE "stack|err\.stack|error\.stack|formatError|maskError|debug\s*:\s*true|NODE_ENV|sendError|res\.(json|send)\(\s*err" -- '*.js' '*.ts' '*.cjs' | head
+```
+
+- **Make it actionable:** determine what the client actually receives in **production**. A GraphQL
+  server exposing `error.extensions.exception.stacktrace`, or an HTTP handler returning `err.stack` /
+  the raw error message, is a leak. A production error formatter that maps to a safe message / code
+  while logging detail server-side is correct.
+- **FINDING (MEDIUM):** stack traces / raw internal errors returned to clients in production.
+  Recommend a production error formatter that returns a generic message + a correlation id, and logs
+  the detail server-side.
+- **PASS:** production responses carry only safe, sanitized errors; detail is logged, not returned.

--- a/kit/skills/backend/hb-security-audit/references/auth-and-transport.md
+++ b/kit/skills/backend/hb-security-audit/references/auth-and-transport.md
@@ -1,0 +1,147 @@
+# Auth & transport (checks 6–11)
+
+Authentication / authorization on every endpoint, the public allow-list, datastore transport
+encryption, introspection / debug endpoints, CORS scope, and rate limiting. Referenced from
+[SKILL.md](../SKILL.md).
+
+The right patterns depend on the stack. First identify: the HTTP framework (Express / Fastify / Koa /
+Nest / Hapi …), whether there is a GraphQL server (Apollo / Yoga / Mercurius / a framework
+integration), and how the project expresses "this endpoint is authenticated" (middleware, guard,
+decorator, a per-operation filter, an allow-list of public operations). Then adapt the checks below.
+
+## 6. Auth enforced on every endpoint
+
+The goal: **every route and every GraphQL operation is authenticated by default**, and the set of
+operations reachable **without** auth is small, explicit, and intentional. Two enforcement models are
+common — identify which the project uses:
+
+- **Default-deny** (a global guard / filter authenticates everything; a named allow-list enumerates
+  the public operations). Verify the guard is actually wired, and audit the allow-list (check 7).
+- **Per-endpoint opt-in** (each route/resolver attaches its own auth middleware / guard). Verify none
+  are missing it — the failure mode here is a forgotten guard.
+
+### HTTP routes
+
+```bash
+# How auth is expressed (adapt keyword to the project): middleware, guard, decorator, visa, policy:
+git grep -nE "authenticate|requireAuth|isAuthenticated|ensureAuth|@UseGuards|AuthGuard|passport|verifyToken|visa" -- '*.js' '*.ts' '*.cjs' | head
+# Enumerate routes so you can cross-check each has auth (adapt to the router style):
+git grep -nE "\.(get|post|put|patch|delete)\(\s*['\"]/|route\(|@(Get|Post|Put|Patch|Delete)\(|routePath" -- '*.js' '*.ts' '*.cjs'
+```
+
+- **FINDING (HIGH):** a route exposing sensitive data / actions with no auth middleware / guard.
+- **FINDING (MEDIUM):** a route whose auth status is ambiguous (no clear guard, not an intentional
+  public route).
+- Public routes (health check, an integration webhook, a public form submit) must be **intentional**
+  and otherwise protected (signature verification, IP allow-list, token, captcha).
+
+### GraphQL — queries, mutations, **and subscriptions**
+
+Subscriptions are frequently forgotten: a project may authenticate queries/mutations over HTTP yet
+leave the WebSocket subscription transport (`onConnect` / connection init) unauthenticated. Check all
+three operation types.
+
+```bash
+# The enforcement point (adapt to the server): a context builder, a global validation rule, a filter:
+git grep -nE "authorize|isAuthorized|isAllowed|checkPermission|hasPermission|Unauthenticated|Unauthorized|requireAuth|context\s*:.*auth" -- '*.js' '*.ts' '*.cjs' | head
+# Subscription transport auth (the commonly-missed one):
+git grep -nE "onConnect|connectionParams|context.*subscription|subscriptions\s*:|useServer|SubscriptionServer" -- '*.js' '*.ts' '*.cjs'
+# Enumerate operations to cross-check coverage (adapt to how schemas/resolvers are declared):
+git grep -nE "type (Query|Mutation|Subscription)|@(Query|Mutation|Subscription)\(|static get schema" -- '*.js' '*.ts' '*.cjs' '*.graphql'
+```
+
+- **FINDING (HIGH):** the auth check is missing entirely (everything becomes public), or the
+  subscription transport authenticates on connect differently from (or weaker than) queries/mutations.
+- **FINDING (HIGH):** a **state-changing mutation** reachable unauthenticated that is not an
+  intentional public operation.
+- **FINDING (MEDIUM):** an operation whose coverage is ambiguous (neither clearly guarded nor an
+  intentional public entry).
+
+## 7. Public / guest allow-list is minimal & intentional (classified)
+
+If the project has an explicit list of unauthenticated operations / routes, enumerate it and
+**classify every entry**, because severity depends on what the operation does:
+
+- **Read-only, non-sensitive** public entry (health check, public content query, public form submit)
+  → likely intentional; confirm and mark INFO/PASS.
+- **State-changing** public entry (any mutation that writes data) → **HIGH** unless there is a
+  compensating control (signature, captcha, strict rate limit, idempotency). A public write is an
+  abuse / spam / resource-exhaustion vector.
+- **Sensitive read** (PII, internal data) exposed publicly → **HIGH**.
+
+Report the **full allow-list** so a human can confirm each entry matches product intent. Flag any
+entry that looks like leftover scaffolding rather than a deliberate public endpoint (see check 20).
+
+## 8. Datastore transport encryption (TLS / SSL)
+
+Connections to a managed / remote datastore should be encrypted in transit. For SQL via most ORMs /
+drivers this is a TLS/SSL option on the connection config; for Mongo it is `tls=true` /
+`mongodb+srv`; for Redis it is a `rediss://` URL / `tls` options.
+
+```bash
+# Find the connection config the project uses (adapt filename):
+git grep -lniE "dialect|connection|datasource|createConnection|new Sequelize|new Pool|MongoClient|createClient" -- '*.js' '*.ts' '*.cjs' | head
+# TLS/SSL settings within it:
+git grep -nE "ssl|tls|rejectUnauthorized|sslmode|rediss:|mongodb\+srv" -- '*.js' '*.ts' '*.cjs' '*.json' | head
+```
+
+- **FINDING (MEDIUM):** a **remote / non-local** environment (staging / production) connecting to a
+  datastore with **no TLS/SSL** → traffic is unencrypted. Recommend enabling TLS and, where the
+  driver supports it, verifying the server certificate (e.g. `rejectUnauthorized: true` rather than
+  `false`, which accepts any cert — a weaker MEDIUM).
+- **Severity nuance:** a **local test / dev DB** on loopback (e.g. a sqlite file or a localhost
+  container) does not need TLS — mark **N/A** for that environment, but do not let a local exception
+  hide a missing setting on the production connection.
+- **PASS:** all non-local datastore connections use TLS with certificate verification.
+
+## 9. Introspection / playground / debug endpoints disabled in prod
+
+```bash
+git grep -nE "introspection|playground|graphiql|ApolloServerPluginLandingPage|debug\s*:\s*true|NODE_ENV" -- '*.js' '*.ts' '*.cjs' | head
+```
+
+- **Make it actionable:** determine the **actual production value**, not just that the flag is
+  mentioned. `introspection: true` unconditionally → MEDIUM. Gated on `NODE_ENV !== 'production'` (or
+  a config flag that is off in prod) → PASS; note how it is gated. A landing page / GraphiQL served
+  in production → MEDIUM.
+- **FINDING (MEDIUM):** introspection or an interactive playground / debug console enabled in
+  production. Recommend disabling in prod (keep it in development only).
+- **N/A:** no GraphQL server.
+
+## 10. CORS scoped (not wildcard in production)
+
+```bash
+git grep -nE "cors\(|Access-Control-Allow-Origin|origin\s*:|credentials\s*:\s*true" -- '*.js' '*.ts' '*.cjs' | head
+```
+
+- **FINDING (HIGH):** `origin: '*'` (or reflecting any `Origin`) **together with**
+  `credentials: true` — this is an invalid-but-dangerous combination that browsers partly block yet
+  often leaks in practice; at minimum it signals no origin control.
+- **FINDING (MEDIUM):** wildcard origin in production for anything beyond truly public, credential-less
+  content.
+- **Concrete secure pattern to recommend** (adapt to the app's real domains): allow only the app's
+  own base domain **and its subdomains**, plus localhost for the test / dev environment, driven from
+  an env var rather than hard-coded — e.g. an `origin` function that accepts a request origin when it
+  equals or is a subdomain of the configured base domain, or is a localhost origin, and rejects
+  everything else. Requests with no `Origin` header (server-to-server, curl) can be allowed since CORS
+  is a browser control. Do not reflect arbitrary origins.
+- **PASS:** origins are an explicit allow-list / env-driven and not `*` in production.
+
+## 11. Rate limiting on public endpoints (and not bypassable)
+
+```bash
+git grep -nE "rateLimit|rate-limit|express-rate-limit|RateLimiter|throttle|slow-down|limiter" -- '*.js' '*.ts' '*.cjs' | head
+# Client-IP resolution — the common bypass:
+git grep -nE "x-forwarded-for|X-Forwarded-For|req\.ip|trust proxy|trustProxy|remoteAddress" -- '*.js' '*.ts' '*.cjs' | head
+```
+
+- **Make it actionable:** confirm a limiter is (a) actually **applied** to the public / expensive
+  endpoints (unauthenticated forms, login, upload, AI/LLM calls), not merely imported; and (b) keyed
+  on a **trustworthy client identifier**. If the limiter keys on a **spoofable header**
+  (`X-Forwarded-For`) without a correctly configured `trust proxy` setting, an attacker rotates the
+  header to bypass it.
+- **FINDING (MEDIUM):** no rate limiting on a public, abusable, or expensive endpoint.
+- **FINDING (MEDIUM):** rate limiting keyed on a client-controlled header without a trusted-proxy
+  configuration (bypassable). Recommend keying on the real peer address / a correctly trusted proxy
+  chain.
+- **PASS:** limiter applied to the relevant endpoints and keyed on a trustworthy identifier.

--- a/kit/skills/backend/hb-security-audit/references/code-safety.md
+++ b/kit/skills/backend/hb-security-audit/references/code-safety.md
@@ -1,0 +1,74 @@
+# Code safety (checks 1–3)
+
+Injection (SQL / NoSQL / command), dynamic code execution (`eval`), and malicious / obfuscated code
+or install hooks. Referenced from [SKILL.md](../SKILL.md).
+
+Commands below use `git grep` so the search stays on tracked source (no `node_modules`, no build
+output). Adjust the patterns to the ORM / driver / framework the project uses.
+
+## 1. Injection (SQL / NoSQL / command)
+
+Most ORMs and query builders parameterize by default and are safe. Risk appears where a **raw query
+is built with string interpolation / concatenation from untrusted input** (request body, query
+params, headers, path params, GraphQL variables, message payloads).
+
+```bash
+# Raw SQL entry points (varies by library — include the ones the project uses):
+#   node-postgres/mysql2: .query(  |  Sequelize: sequelize.query / literal( / QueryTypes
+#   Knex: .raw(  |  Prisma: $queryRawUnsafe / $executeRawUnsafe  |  TypeORM: createQueryBuilder / .query(
+git grep -nE "\.query\(|\.raw\(|\\\$queryRawUnsafe|\\\$executeRawUnsafe|literal\(|QueryTypes|createQueryBuilder" -- '*.js' '*.ts' '*.cjs' '*.mjs'
+# The dangerous shape — interpolation/concatenation inside a raw query:
+git grep -nE "\.(query|raw)\(\s*\`[^\`]*\\\$\{" -- '*.js' '*.ts' '*.cjs' '*.mjs'
+git grep -nE "(WHERE|SELECT|INSERT|UPDATE|DELETE)[^\"'\`]*(\+|\\\$\{)" -- '*.js' '*.ts' '*.cjs' '*.mjs'
+# NoSQL (Mongo) operator injection — raw request objects flowing into a filter:
+git grep -nE "\.(find|findOne|updateOne|deleteOne|aggregate)\(\s*(req\.|request\.|input|variables|body|params|query)" -- '*.js' '*.ts'
+```
+
+- **Distinguish the source of interpolated values.** Interpolating a **constant** (e.g. a table name
+  from a file-local constant in a migration) is not injection. Interpolating anything that traces
+  back to **request input** (`variables`, `input`, `req`, `args`, `body`, `params`, `headers`) is.
+- **NoSQL note:** passing a raw request object straight into a Mongo filter allows operator injection
+  (`{ "$gt": "" }`), even without string building. Flag request objects used as query filters
+  without validation / casting.
+- **FINDING (HIGH):** a raw query whose interpolated / concatenated value comes from user input, or a
+  request object used directly as a NoSQL filter. Recommend parameterized queries (placeholders /
+  bind params), the ORM's safe builder, or validating + casting the input first.
+- **FINDING (LOW/INFO):** raw query with only constant interpolation — note it, confirm the value
+  cannot become input-derived.
+- **PASS:** no raw queries, or raw queries use bind params / only constants; NoSQL filters are
+  validated.
+
+## 2. `eval` / dynamic-exec code
+
+```bash
+git grep -nE "\beval\s*\(|new Function\s*\(|vm\.(run|compile|Script)|require\(['\"]vm['\"]\)|from ['\"]vm['\"]" -- '*.js' '*.ts' '*.cjs' '*.mjs'
+git grep -nE "child_process|execSync|spawnSync|\bexec\(|\bspawn\(|\bexecFile\(" -- '*.js' '*.ts' '*.cjs' '*.mjs'
+```
+
+- **FINDING (HIGH):** `eval(` / `new Function(` / `vm` run on any value that could be
+  attacker-influenced; `child_process` exec/spawn with interpolated input (command injection — a
+  shell string built from input is worse than an args array).
+- **FINDING (LOW):** `child_process` with fully-static args (still worth noting).
+- **PASS:** none found, or all uses are on static values.
+
+## 3. Malicious / obfuscated code & install hooks
+
+Look for code that decodes-then-executes, phones home, or runs during install.
+
+```bash
+# Install-time hooks (a common supply-chain foothold) — check root and any workspace package.json:
+git grep -nE "\"(pre|post)?install\"\s*:|\"prepare\"\s*:|\"prepublish(Only)?\"\s*:" -- 'package.json' '**/package.json'
+# Obfuscation / decode-then-run:
+git grep -nE "Buffer\.from\([^)]*base64|atob\(|\\\\x[0-9a-f]{2}|fromCharCode|eval\(.*(atob|Buffer)" -- '*.js' '*.ts' '*.cjs' '*.mjs'
+# Unexpected outbound network / curl|bash in scripts:
+git grep -nE "curl .*\| *(ba)?sh|wget .*\| *(ba)?sh|https?://[^ '\"]+" -- 'package.json' '*.js' '*.ts' '*.cjs' '*.sh' | head
+```
+
+- **FINDING (HIGH):** an `install` / `postinstall` / `prepare` script that downloads or executes
+  remote code; base64 / hex-decoded strings passed to `eval` / `Function`; outbound calls sending
+  repo / secret data to an unknown host.
+- **FINDING (INFO):** hard-coded external URLs — list them so a human can confirm each is expected
+  (API endpoints, docs) and not exfiltration.
+- **PASS:** no install hooks that fetch / execute; no decode-then-run; outbound hosts all expected.
+- Also sanity-check recent history (`git log -p -n 50 -- package.json`) for unexpected additions to
+  build / install scripts.

--- a/kit/skills/backend/hb-security-audit/references/dependencies.md
+++ b/kit/skills/backend/hb-security-audit/references/dependencies.md
@@ -1,0 +1,72 @@
+# Dependencies & install hygiene (checks 16–18)
+
+Vulnerable packages, lockfile / version-pinning / registry-token hygiene, and reproducible installs.
+Referenced from [SKILL.md](../SKILL.md).
+
+First detect the package manager from the committed lockfile: `package-lock.json` → npm,
+`pnpm-lock.yaml` → pnpm, `yarn.lock` → Yarn, `bun.lockb` → Bun. Use that manager's commands below.
+
+## 16. No vulnerable dependencies (advisory audit)
+
+```bash
+# npm:
+npm audit --omit=dev 2>/dev/null || npm audit 2>/dev/null    # registry metadata only; no repo upload
+# pnpm:   pnpm audit --prod 2>/dev/null
+# yarn:   yarn npm audit --environment production 2>/dev/null   (Berry)  |  yarn audit  (classic)
+```
+
+- **FINDING (severity = the advisory's):** report each **high / critical** advisory — package,
+  installed version, advisory title, and the fixed version. Summarize moderate / low as counts.
+- **Remediation guidance to include per advisory:**
+  - If a non-breaking fix exists (patch / minor within the current range), recommend the manager's
+    safe upgrade — e.g. `npm audit fix` (no `--force`), which respects semver ranges.
+  - If the only fix is a **major** bump or requires `--force`, do **not** recommend applying it
+    blindly — call it out as a breaking change needing a compatibility review and testing.
+  - If the vulnerable package is transitive, recommend upgrading the parent, or a pin / override
+    (`overrides` in npm, `resolutions` in Yarn, `pnpm.overrides`) as a stopgap.
+- **PASS:** no high / critical advisories.
+- If the audit cannot reach the registry (offline / private-registry auth), say so and mark the check
+  **BLOCKED** rather than PASS.
+
+## 17. Lockfile committed + version-pinning delay + no committed registry tokens
+
+```bash
+git ls-files | grep -E 'package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb'   # a lockfile must be tracked
+cat .npmrc 2>/dev/null; cat .yarnrc.yml 2>/dev/null                                 # registry / install config
+git grep -nE "min-release-age|minimumReleaseAge|_authToken|_auth=|npmAuthToken|NPM_TOKEN=" -- '.npmrc' '.yarnrc*' '*.npmrc'
+```
+
+- **Lockfile committed** — required for reproducible / clean installs (check 18). Missing lockfile →
+  **MEDIUM**.
+- **Version-pinning delay** — a cooldown before installing a just-published version weakens a class
+  of supply-chain attacks (a malicious release pulled before it is caught). npm supports
+  `min-release-age`; pnpm supports `minimumReleaseAge`. **Recommend ≥ 7 days** where the manager
+  supports it. Missing / `< 7` → **LOW**.
+- **No committed registry credentials** — a private-registry token (`_authToken`, `_auth`,
+  `npmAuthToken`, an inline `NPM_TOKEN=`) committed in `.npmrc` / `.yarnrc.yml` is a **HIGH** finding;
+  such tokens must come from env / CI, not the repo.
+- **PASS:** lockfile tracked, cooldown set (where supported), no committed tokens.
+
+## 18. Reproducible installs (clean / locked install, not mutating)
+
+CI, container builds, and production installs should use the manager's **clean, lockfile-exact**
+install — which fails if the lockfile is out of sync and does not mutate it — rather than a plain
+install that can update the lockfile and pull unpinned versions.
+
+| Manager | Reproducible install | Avoid in CI/build |
+| --- | --- | --- |
+| npm | `npm ci` | `npm install` / `npm i` |
+| pnpm | `pnpm install --frozen-lockfile` | `pnpm install` (writable) |
+| Yarn Berry | `yarn install --immutable` | writable `yarn install` |
+| Yarn classic | `yarn install --frozen-lockfile` | writable `yarn install` |
+
+```bash
+# Where installs happen — CI workflows, scripts, containers, docs:
+git grep -nE "npm (ci|i|install)|pnpm install|yarn install|--frozen-lockfile|--immutable" -- '.github/**' '*.sh' 'package.json' 'Dockerfile*' 'docker-compose*' 'docs/**' 2>/dev/null
+```
+
+- **FINDING (LOW/MEDIUM):** a mutating install used in CI, a container build, or a deploy / setup
+  script where the clean/locked variant is appropriate. Local first-time-setup docs using a plain
+  install are usually acceptable — note but don't over-flag.
+- **PASS:** CI / build / deploy paths use the clean / locked install, and the lockfile is committed
+  (check 17).

--- a/kit/skills/backend/hb-security-audit/references/network-and-logging.md
+++ b/kit/skills/backend/hb-security-audit/references/network-and-logging.md
@@ -1,0 +1,56 @@
+# Network exposure & logging (checks 4–5)
+
+Externally reachable ports / processes, and production logging (redaction / PII). Referenced from
+[SKILL.md](../SKILL.md).
+
+## 4. Exposed ports / bind address / datastore exposure
+
+Find every port reachable from outside and confirm each is intended. Cover container definitions, the
+process/service manager, and the server's bind address. The key risk is a **datastore or internal
+service bound to a public interface** (`0.0.0.0`) instead of loopback / a private network.
+
+```bash
+# Container / orchestration definitions:
+find . -maxdepth 3 \( -iname "Dockerfile*" -o -iname "docker-compose*" -o -iname "compose*.y*ml" -o -iname "*.k8s.y*ml" \) -not -path "*/node_modules/*" 2>/dev/null
+grep -rniE "^EXPOSE |ports:|- \"?[0-9]+:[0-9]+|0\.0\.0\.0" Dockerfile* docker-compose* compose*.y*ml 2>/dev/null
+# What the app / services listen on (bind host + port). Also check the process/service manager
+# config the project uses (e.g. a PM2/systemd/procfile-style file), if present:
+git grep -nE "listen\(|\.PORT|host:|hostname|0\.0\.0\.0|127\.0\.0\.1" -- '*.js' '*.ts' '*.cjs' | head
+# Datastore host/port settings in env files (should point at localhost / a private host):
+grep -rniE "REDIS_HOST|REDIS_PORT|DB_HOST|DB_PORT|DATABASE_HOST|DATABASE_PORT|MONGO|AMQP|QUEUE_HOST" .env* 2>/dev/null
+```
+
+- **FINDING (HIGH):** a datastore (DB / Redis / Mongo / message queue) or an internal-only service
+  published on `0.0.0.0` / a public interface, or a container `ports:` mapping binding a host port
+  with no restriction. Datastores should bind to loopback / a private network only.
+- **FINDING (MEDIUM):** an app port exposed more broadly than needed, or an `EXPOSE` of a debug /
+  admin port.
+- **N/A:** no container / manager files (note it) — but still check the server bind address.
+- List every listening port + its bind scope so a human can confirm each is intentional.
+
+## 5. Production logging via a redacting logger; no PII
+
+Production logs should flow through the project's **structured / redacting logger** (whatever it
+uses), not raw `console.*`. Wherever logging does **not** go through that logger, confirm **no PII is
+written** — email, password, tokens, phone, full name are forbidden; opaque ids and non-personal
+identifiers are OK.
+
+```bash
+# First identify the logger the project uses (pino, winston, bunyan, a wrapper, etc.):
+git grep -nE "require\(['\"].*log.*['\"]\)|from ['\"].*log.*['\"]|pino|winston|bunyan|createLogger" -- '*.js' '*.ts' '*.cjs' | head
+# Raw console logging on production code paths (exclude tests):
+git grep -nE "console\.(log|info|warn|error|debug)" -- '*.js' '*.ts' '*.cjs' \
+  | grep -viE "test|\.spec\.|__tests__|/scripts/|/bin/"
+# PII appearing near a log call:
+git grep -nE "(console|logger|log|error|warn|info)\b[^\"'\`]{0,80}\b(email|password|passwd|accessToken|token|secret|phone|fullName|firstName|lastName|ssn|creditCard)\b" -- '*.js' '*.ts' '*.cjs' \
+  | grep -viE "test|__tests__" | head
+```
+
+- **FINDING (MEDIUM):** raw `console.*` on a production code path (bypasses the logger's redaction /
+  sinks). Recommend routing through the project logger.
+- **FINDING (HIGH):** any log call (logger or not) that writes **PII** (email, password, token,
+  phone, name, and similar). Recommend logging a non-personal id instead.
+- **PASS:** production logging goes through the redacting logger and no PII is logged; logging ids
+  only is fine.
+- If the project's framework logs via an injected logger, treat that as compliant — but still scan
+  those calls for PII in their payloads.

--- a/kit/skills/backend/hb-security-audit/references/secrets.md
+++ b/kit/skills/backend/hb-security-audit/references/secrets.md
@@ -1,0 +1,95 @@
+# Secrets (checks 12–15)
+
+`.gitignore` coverage of env files, secrets in committed env files, hardcoded secrets in code, and
+plaintext passwords in seed / fixture data. Referenced from [SKILL.md](../SKILL.md). **Mask every
+secret value in the report.**
+
+## 12. Env files covered by `.gitignore` (all variants)
+
+A `.gitignore` with a bare `.env` line matches **only** a file named exactly `.env` — it does **not**
+match `.env.development`, `.env.staging`, `.env.production`, `.env.local`, etc. Those variants stay
+trackable and are easily committed with real secrets.
+
+```bash
+ls -a | grep -E '^\.env'                        # which env files exist on disk
+git check-ignore -v .env .env.* 2>/dev/null     # prints the matching rule for each IGNORED file
+git ls-files | grep -E '(^|/)\.env'             # env files TRACKED in git (should usually be only a template)
+```
+
+- **Important:** adding a pattern to `.gitignore` does **not** untrack a file that is already
+  committed — `.gitignore` only affects untracked files. If an env file is already tracked, it must be
+  removed from the index with `git rm --cached <file>` (and the secret rotated). Verify with
+  `git ls-files`, not just by reading `.gitignore`.
+- **FINDING (HIGH if the tracked file holds real secrets, else MEDIUM):** any `.env*` file with
+  secrets is **tracked** or **not ignored**. Recommend a broad ignore (e.g. `.env*` with a
+  `!.env.example` negation), `git rm --cached` for anything already tracked, and — if a secret was
+  ever committed — rotating it and purging history.
+- **PASS:** every secret-bearing env file is ignored; only a secret-free template is tracked.
+
+## 13. No secrets in committed env files; secret-free template present
+
+Committed env files (a template, or any per-env file that is tracked) must not carry real secret
+**values**. Inspect key names and whether their values are populated — **do not echo the values**;
+grep key names and mask.
+
+```bash
+# For each TRACKED env file (from check 12), list secret-bearing key NAMES only:
+git ls-files | grep -E '(^|/)\.env' | while read f; do echo "== $f =="; \
+  grep -oE '^[A-Za-z0-9_]+=' "$f" 2>/dev/null | grep -iE 'PASSWORD|SECRET|TOKEN|API_?KEY|PRIVATE|CREDENTIAL|_KEY|DSN|CONNECTION'; done
+# For each such key, check ONLY whether a value is present, and MASK it, e.g.:
+#   grep -E '^SOME_API_KEY=' <file> | sed -E 's/=.{0,4}.*/=****(masked)/'
+```
+
+- **FINDING (HIGH):** a real secret value sits in a committed env file. Recommend replacing it with a
+  placeholder, moving the real value to an untracked file / secret manager, and rotating.
+- **Best practice to recommend:** keep exactly one committed, **secret-free** template (e.g.
+  `.env.example`) listing every required key with placeholder values, and source **all** real
+  credentials for non-local environments from env / a secret manager — never commit them, and do
+  not leave per-env files (`.env.staging`, `.env.production`) tracked.
+- **PASS:** values are empty / obvious placeholders (`your-key-here`, `changeme`, `xxxx`), and a
+  secret-free template exists.
+
+## 14. No hardcoded secrets in code / config
+
+Search source and non-env config for inline credentials and known key shapes.
+
+```bash
+# Inline credential assignments (exclude ones sourced from env / set to null):
+git grep -nE "(password|passwd|secret|api_?key|apikey|access_?token|client_?secret|private_?key)\s*[:=]\s*['\"][^'\"]+['\"]" -- '*.js' '*.ts' '*.cjs' '*.json' '*.yml' '*.yaml' \
+  | grep -viE "process\.env|env\.|= *null|: *null|placeholder|example|changeme|xxxx"
+# Known provider key prefixes / private keys, anywhere in tracked files:
+git grep -nE "AIza[0-9A-Za-z_-]{20,}|sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+```
+
+- **Pay special attention to connection / datastore config files** — per-environment blocks commonly
+  carry hardcoded `username` / `password`. Hardcoded credentials in a committed config file are a
+  finding **even if they look like placeholders**, because they normalize the pattern; production
+  credentials should come from env / a secret manager.
+- **FINDING (HIGH real / MEDIUM placeholder):** a literal credential in tracked code / config.
+  Recommend sourcing from env / a secret manager; rotate if real.
+- **PASS:** credentials only ever come from `process.env` / a config facade.
+
+## 15. No plaintext passwords / secrets in seed / fixture data
+
+Seed / fixture data that provisions accounts or reference data must not contain plaintext passwords
+or secrets. Distinguish two cases:
+
+- **Production / master seed data** (data that ships to real environments) must contain **no**
+  credentials at all — production accounts are provisioned out-of-band, not seeded.
+- **Development / test fixtures** may create login accounts, but any password must be **hashed**
+  (through the app's real hashing path), never stored as plaintext that reaches the datastore.
+
+```bash
+# Locate seed / fixture directories (names vary: seeders, seeds, fixtures, factories):
+find . -type d \( -iname 'seed*' -o -iname 'fixture*' -o -iname 'factories' \) -not -path '*/node_modules/*' 2>/dev/null
+# Secrets in seed/fixture files (point at the dirs found above):
+git grep -nE "password|passwd|secret|api_?key|token|raw_password" -- '*seed*' '*fixture*' '*factor*' | head
+# Confirm dev fixtures hash rather than store plaintext:
+git grep -nE "hash|bcrypt|argon2|scrypt|pbkdf2|password_hash" -- '*seed*' '*fixture*' | head
+```
+
+- **FINDING (HIGH):** a plaintext `password` / secret literal in production / master seed data.
+  Recommend removing it (provision production credentials out-of-band).
+- **FINDING (MEDIUM):** a dev / test fixture stores a plaintext password that reaches the datastore
+  unhashed.
+- **PASS:** production seeds hold only non-secret reference data; dev fixtures hash any password.

--- a/kit/skills/backend/hb-sequelize-migration/SKILL.md
+++ b/kit/skills/backend/hb-sequelize-migration/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: hb-sequelize-migration
+description: >
+  Write and edit renchan/Sequelize migration files (sequelize/migrations/*.cjs). Use this skill
+  whenever the user asks to create or update a migration — creating a table (createTable), adding
+  or removing a column (addColumn / removeColumn), declaring an index or a unique constraint
+  (addIndex), naming an index, or deciding whether to add a foreign-key column.
+---
+
+# Sequelize Migration
+
+A skill for writing the `sequelize/migrations/*.cjs` files. It defines the **physical schema**
+(tables, columns, indexes); the **logical declarations** layered on top (attributes / association
+/ scope / hook) are written by `hb-sequelize-model`. Keep the two in one-to-one correspondence —
+when you add a column in the migration, add the matching attribute in the model (and vice versa).
+The conventions are split across the detail files below.
+
+This repo does **not** `sync`. The schema is **built entirely by migrations** (dev = SQLite /
+staging = MySQL / live = MariaDB — the dialects differ). A model's `unique: true` and the like are
+only declarations; **the real object is always created by the migration**.
+
+## Grand principle: a migration is a filled-in template
+
+Every migration has the **same skeleton**: `'use strict'` → `require` the factory → `TABLE_NAME` /
+`COLUMN_NAME` constants → `module.exports = { up, down }`, where `up` runs
+`createTable(...factory.ID_BIGINT, <columns>, ...factory.TIMESTAMPS)` → `addIndex`, and `down`
+closes with `dropTable`. This is the same idea as "a model is a filled-in template" in
+`hb-sequelize-model`: keep the skeleton identical so review attention
+goes straight to the **file-specific differences (columns / indexes)**. Do not write it cleverly;
+lean toward the layout of the existing migrations.
+
+- **Comments: English for structural conventions, the surrounding language for domain notes.** A
+  convention comment such as `// ForeignKey must start with upper case.` is written in English (the
+  existing migrations do this, and it matches the model skill). Domain-explanation comments tied to
+  a ticket or a spec are often written in Japanese in this repo — match the surrounding files.
+
+## 1. File skeleton and constants (TABLE_NAME / COLUMN_NAME)
+
+One migration = one file placed directly under `sequelize/migrations/`. The filename is
+`{timestamp}-{seq}-<operation>-<table>[-<column>].cjs`.
+
+- `{timestamp}` is the creation time `YYYYMMDDHHmmss` (14 digits; `date +%Y%m%d%H%M%S`). Files are
+  applied in ascending timestamp order — i.e. in creation-time order.
+- `{seq}` is a **6-digit, zero-padded running number** (`000001`, `000002`, ...). It doubles as the
+  ordering within the same timestamp and as a human-facing identifier.
+- The operation is `create_table` (create a table) / `alter_table` (add / remove / change columns
+  on an existing table).
+- Examples: `20260717135803-000001-create_table-content_generations.cjs` /
+  `20260717140512-000002-alter_table-content_generation_jobs-webhook_url.cjs`
+- `.cjs` (CommonJS). Start with `'use strict'` and `require` the factory, then declare `TABLE_NAME`
+  and `COLUMN_NAME` (the **single source of truth** for physical column names). `COLUMN_NAME` keys
+  are `SCREAMING_SNAKE`, values are the physical names (snake_case). This value is referenced by
+  both the column's `field:` and the index name.
+- Older migrations predate this and use the `<8-digit-seq>-create_table-...` form (no timestamp).
+  Write new files in the new form above.
+
+```js
+// Good example (the whole shape of a create-table migration)
+'use strict'
+
+const MigrationAttributeFactory = require('@openreachtech/renchan-sequelize/lib/tools/MigrationAttributeFactory.cjs')
+
+const TABLE_NAME = 'content_generations'
+const COLUMN_NAME = {
+  CONTENT_GENERATION_JOB_ID: 'content_generation_job_id',
+  RESULT_JSON: 'result_json',
+  MODEL: 'model',
+}
+
+// Define an initialism only for a column whose index name would run long (§4).
+const SHORT_COLUMN_NAME = {
+  CONTENT_GENERATION_JOB_ID: 'cgji',
+}
+
+module.exports = {
+  async up (
+    queryInterface,
+    Sequelize
+  ) {
+    const factory = MigrationAttributeFactory.create(Sequelize)
+
+    await queryInterface.createTable(TABLE_NAME, {
+      ...factory.ID_BIGINT,
+
+      // ForeignKey must start with upper case.
+      ContentGenerationJobId: {
+        type: Sequelize.BIGINT,
+        field: COLUMN_NAME.CONTENT_GENERATION_JOB_ID,
+        allowNull: false,
+      },
+      resultJson: {
+        type: Sequelize.JSON,
+        field: COLUMN_NAME.RESULT_JSON,
+        allowNull: true,
+      },
+      model: {
+        type: Sequelize.STRING(64),
+        field: COLUMN_NAME.MODEL,
+        allowNull: false,
+      },
+
+      ...factory.TIMESTAMPS,
+    })
+
+    // A 1:1 relation is enforced by a UNIQUE index (no DB FK).
+    await queryInterface.addIndex(TABLE_NAME, [
+      COLUMN_NAME.CONTENT_GENERATION_JOB_ID,
+    ], {
+      unique: true,
+      name: [
+        TABLE_NAME,
+        SHORT_COLUMN_NAME.CONTENT_GENERATION_JOB_ID,
+        'unique',
+      ].join('_'),
+    })
+
+    return Promise.resolve()
+  },
+
+  async down (
+    queryInterface,
+    Sequelize
+  ) {
+    return queryInterface.dropTable(TABLE_NAME)
+  },
+}
+```
+
+- `up (queryInterface, Sequelize)` / `down (queryInterface, Sequelize)` take those two arguments in
+  that order. `up` runs `factory.create(Sequelize)` → `createTable` → `addIndex` →
+  `return Promise.resolve()`; `down` is `return queryInterface.dropTable(TABLE_NAME)`.
+- **Each column** is declared with a camelCase key + `field: COLUMN_NAME.X` (the snake physical
+  name). **Always** declare `allowNull`, and add `defaultValue` when the column has a default. The
+  type is `Sequelize.X` (`BIGINT` / `INTEGER` / `STRING(n)` / `TEXT` (long items: `TEXT('medium')`) /
+  `DATE(3)` / `BOOLEAN` / `JSON` / `DECIMAL(p,s)` / `BLOB('long')`). Avoid `ENUM`; use a domain
+  constant + `STRING(n)`.
+  Datetimes default to `DATE(3)`. Keep `allowNull` / `defaultValue` in sync with the same-named
+  column on the model side.
+
+For the constants' rationale, the DataTypes table, and file naming, see
+[notation.md](./references/notation.md).
+
+## 2. created_at / updated_at come from the shared preset
+
+Do not hand-write `created_at` / `updated_at`; spread `...factory.TIMESTAMPS` at the **end** of the
+`createTable` object. The PK follows the same idea — spread `...factory.ID_BIGINT` (or
+`...factory.ID_INTEGER` for an integer PK) at the **top**. Never hand-write `id`.
+
+- `factory.TIMESTAMPS` = `created_at` / `updated_at` (both `DATE(3)`, `allowNull: false`).
+- `factory.TIMESTAMPS_WITH_DELETED_AT` = the above + `deleted_at`. Use it on tables that
+  **soft-delete**, paired with `paranoid: true` on the model side (see the default-methods of
+  `hb-sequelize-model`).
+- `factory.ID_BIGINT` = the four-piece set `bigint` / `autoIncrement` / `primaryKey` /
+  `allowNull:false`.
+
+```js
+// Good example (PK at the top, timestamps at the end — both from the shared preset)
+await queryInterface.createTable(TABLE_NAME, {
+  ...factory.ID_BIGINT,
+
+  // ... business columns ...
+
+  ...factory.TIMESTAMPS_WITH_DELETED_AT, // also creates deleted_at (model side: paranoid:true)
+})
+```
+
+- **Why**: `created_at` / `updated_at` / `deleted_at` are audit / framework-operational columns, and
+  their values are supplied by the model's `timestamps: true`. Routing the column definitions
+  through the shared preset keeps millisecond precision (`DATE(3)`), NOT NULL, and the column names
+  aligned across every table. The model side does **not** put these in its attributes (see the
+  timestamps of `hb-sequelize-model`); only the migration creates the
+  columns.
+
+## 3. FK-like columns (no DB foreign-key constraint)
+
+Create the **FK-like column** (a column holding another table's id), but **do not add a DB
+foreign-key constraint**.
+
+Make the FK-like column's key **start with an uppercase letter** (`ContentGenerationJobId` /
+`CustomerId`) and write `// ForeignKey must start with upper case.` in English immediately above it.
+The type is `BIGINT`.
+
+```js
+// Good example (an FK-like column — column + comment only, no constraint)
+// ForeignKey must start with upper case.
+CustomerId: {
+  type: Sequelize.BIGINT,
+  field: COLUMN_NAME.CUSTOMER_ID,
+  allowNull: false,
+},
+```
+
+- **Why the uppercase start**: the model's association resolves the FK name by the convention
+  "`<associated model name>` + `Id`" (see `hb-sequelize-model`). `field:`
+  maps it to snake (`..._id`).
+
+**Do not write foreign-key constraints.** No `references` on the column, no `onDelete` / `onUpdate`,
+and no `addConstraint` to add an FK constraint (there is not a single FK constraint in the existing
+migrations).
+
+- **1:1** is enforced by a **UNIQUE index**, not an FK (§4).
+  `// A 1:1 relation is enforced by a UNIQUE index (no DB FK).`
+- **Circular FKs** and optional relations are **column-only and nullable** (`content_sessions` ⇄
+  `content_generation_jobs`; `// ForeignKey must start with upper case. (circular FK, column
+  only)`).
+- A set of ids you do not want to make FKs is held as a `JSON` array (`optionIdsJson` /
+  `// An array of ids without an FK.`).
+- FK columns usually get a (plain) index for lookups (§4). The meaning of the relation is left to
+  the model's association.
+
+- **Why**: dev = SQLite / staging = MySQL / live = MariaDB differ, and there is no `sync`. A DB FK
+  constraint pins insert order and makes cloning into backup (`*_bk`) tables and handling circular
+  references awkward. Referential integrity is enforced in the **app layer** (associations,
+  transactions, existence checks). See [foreign-keys.md](./references/foreign-keys.md); for the
+  column notation see [notation.md](./references/notation.md).
+
+## 4. Index naming
+
+Add an index with `queryInterface.addIndex(TABLE_NAME, [columns...], { name, unique? })`. Build the
+`name` by `.join('_')` on an array: **a plain index ends in `'index'`, a UNIQUE one adds
+`unique: true` and ends in `'unique'`**.
+
+```js
+// Good example (a plain index and a UNIQUE one; wrap multiples in Promise.all)
+await Promise.all([
+  queryInterface.addIndex(TABLE_NAME, [
+    COLUMN_NAME.ACCESS_TOKEN,
+  ], {
+    unique: true,
+    name: [TABLE_NAME, COLUMN_NAME.ACCESS_TOKEN, 'unique'].join('_'),
+  }),
+  queryInterface.addIndex(TABLE_NAME, [
+    COLUMN_NAME.STATUS,
+    COLUMN_NAME.EXPIRES_AT,
+  ], {
+    name: [TABLE_NAME, COLUMN_NAME.STATUS, COLUMN_NAME.EXPIRES_AT, 'index'].join('_'),
+  }),
+])
+```
+
+- One index: `await` it directly. Multiple: wrap them in `Promise.all([...])`.
+- For a composite index, list the columns (`..._status_expires_at_index`) or fold them into a
+  meaningful label (`'plan_tier_currency_effective_at'` / `'job_package'`).
+- A UNIQUE named index is the **actual constraint** behind a 1:1 relation or a natural key. A
+  model's `unique: true` is only a declaration (see `hb-sequelize-model`).
+
+### Shortening a long index name (over ~50 chars)
+
+The DB identifier limit is 64 characters. As a safety margin, shorten once a name would run past
+**~50 characters**. Shorten in the **following priority order**, taking the **initial of each
+word**:
+
+1. **First shorten the column name(s)** (`SHORT_COLUMN_NAME`), keeping the table name in full.
+   e.g. `content_generations` + `cgji` (= content_generation_job_id) + `unique`
+   → `content_generations_cgji_unique`
+2. **Only if it is still too long, shorten the table name too** (`SHORT_TABLE_NAME`).
+   e.g. `cgrf` (= content_generation_requirement_files) + `cgji` + `index`
+   → `cgrf_cgji_index`
+
+Initialism examples: `content_generation_job_id`→`cgji`, `chat_room_id`→`cri`,
+`customer_id`→`ci`, `content_generation_requirement_files`→`cgrf`, `content_plan_rates`→`err`.
+Put the abbreviations in `SHORT_COLUMN_NAME` / `SHORT_TABLE_NAME` constants and reference them from
+the `addIndex` `name`. Details and a table of real abbreviations are in
+[indexes.md](./references/indexes.md).
+
+## 5. Adding / removing columns (alter_table)
+
+Add a column to an existing table with `addColumn`, and drop the same column symmetrically in
+`down`. The filename is `{timestamp}-{seq}-alter_table-<table>-<column>.cjs`.
+
+- **Do not use `removeColumn` to drop a column.** Sequelize's `removeColumn` does not work on
+  MariaDB (live), so run raw SQL `ALTER TABLE ... DROP COLUMN` via `queryInterface.sequelize.query`
+  (in `up` or `down`; quote identifiers with backticks).
+- `up` / `down` are **symmetric** (drop in `down` what `up` added). Column adds can be grouped with
+  `Promise.all`, but drops are run as one raw statement per column, sequentially.
+- Put a `/* ... */` block at the top of the file describing the **intent** (ticket number, spec
+  reference, backward-compat notes).
+- When adding a column to a table that already has rows, give it `allowNull: true` or a
+  `defaultValue` (do not add a NOT NULL column after the fact).
+
+```js
+// Good example (intent comment + symmetric up/down; the drop uses raw SQL DROP COLUMN)
+/*
+ * Add webhook_url to content_generation_jobs (TICKET-1234).
+ * When unset, the Worker falls back to integration_clients.default_webhook_url.
+ */
+
+const TABLE_NAME = 'content_generation_jobs'
+const COLUMN_NAME = 'webhook_url'
+
+module.exports = {
+  async up (
+    queryInterface,
+    Sequelize
+  ) {
+    await queryInterface.addColumn(TABLE_NAME, COLUMN_NAME, {
+      type: Sequelize.STRING(500),
+      allowNull: true,
+    })
+  },
+
+  async down (
+    queryInterface,
+    Sequelize
+  ) {
+    // removeColumn does not work on MariaDB, so drop via raw SQL DROP COLUMN.
+    await queryInterface.sequelize.query(`
+      ALTER TABLE \`${TABLE_NAME}\`
+      DROP COLUMN \`${COLUMN_NAME}\`
+    `)
+  },
+}
+```
+
+Details in [alter-table.md](./references/alter-table.md).
+
+## Applying changes to the local DB
+
+After adding or changing a migration, rebuild the local DB to apply it. Use the `package.json`
+scripts:
+
+- `npm run r` (= `npm run db:refresh`) — with `NODE_ENV=development`, runs teardown → migrate →
+  seed:master → seed:dev in one shot. Use this after changing a migration / seeder.
+- Individually: `npm run db:setup` (migrate only) / `npm run db:teardown` (delete the SQLite files).
+
+## Detail files
+
+- [notation.md](./references/notation.md) — file skeleton, `TABLE_NAME`/`COLUMN_NAME`, the PK /
+  timestamps spread, a column's `field`/`allowNull`/`defaultValue`, DataTypes, uppercase-start FK
+  columns (§1–§3)
+- [foreign-keys.md](./references/foreign-keys.md) — why no DB FK, 1:1 via UNIQUE, circular FKs,
+  JSON id arrays, indexing FK columns (§3)
+- [indexes.md](./references/indexes.md) — index naming, UNIQUE, `Promise.all`, composite indexes,
+  the shortening algorithm for long names with a table of real examples (§4)
+- [alter-table.md](./references/alter-table.md) — `addColumn`, dropping a column with raw
+  `DROP COLUMN` (because `removeColumn` fails on MariaDB), symmetric up/down, intent comment (§5)

--- a/kit/skills/backend/hb-sequelize-migration/references/alter-table.md
+++ b/kit/skills/backend/hb-sequelize-migration/references/alter-table.md
@@ -1,0 +1,147 @@
+# Alter Table (adding / removing columns)
+
+How to write migrations that add or remove columns on an existing table. Referenced from §5 of
+`SKILL.md`. The column type / `field` / `allowNull` notation is shared with
+[notation.md](./notation.md).
+
+## Add with addColumn, drop with raw SQL DROP COLUMN (symmetric up/down)
+
+`addColumn` in `up`, and drop the same column in `down` to keep them symmetric. The filename is
+`{timestamp}-{seq}-alter_table-<table>-<column>.cjs`.
+
+**Do not use `removeColumn` to drop a column.** Sequelize's `removeColumn` does not work correctly
+on MariaDB (live), so drop a column — in `up` or `down` — with raw SQL
+`ALTER TABLE ... DROP COLUMN` via `queryInterface.sequelize.query`. Quote identifiers with backticks
+(valid on both SQLite and MariaDB).
+
+```js
+'use strict'
+
+/*
+ * Add webhook_url to content_generation_jobs (TICKET-1234).
+ * The destination that notifies an external system of an integration job's completion / failure.
+ * When unset, the Worker falls back to integration_clients.default_webhook_url.
+ */
+
+const TABLE_NAME = 'content_generation_jobs'
+const COLUMN_NAME = 'webhook_url'
+
+module.exports = {
+  async up (
+    queryInterface,
+    Sequelize
+  ) {
+    await queryInterface.addColumn(TABLE_NAME, COLUMN_NAME, {
+      type: Sequelize.STRING(500),
+      allowNull: true,
+    })
+  },
+
+  async down (
+    queryInterface,
+    Sequelize
+  ) {
+    // removeColumn does not work on MariaDB, so drop via raw SQL DROP COLUMN.
+    await queryInterface.sequelize.query(`
+      ALTER TABLE \`${TABLE_NAME}\`
+      DROP COLUMN \`${COLUMN_NAME}\`
+    `)
+  },
+}
+```
+
+- **Why (symmetry)**: writing `down` symmetrically lets the migration be rolled back (drop in `down`
+  exactly what `up` added). Unlike `createTable`, a column add does not use `MigrationAttributeFactory`
+  (the PK / timestamps already exist on the table), so a `require` is often unnecessary.
+- **Why (raw SQL)**: `queryInterface.removeColumn` does not work correctly on MariaDB. To stay
+  dialect-independent, run `ALTER TABLE ... DROP COLUMN` directly. The add side (`addColumn`) is
+  fine, so keep using it.
+
+## Write an intent comment (`/* ... */`) at the top
+
+A column-adding migration is really about "why is this column being added", so put a `/* ... */`
+block at the top describing the intent. Leave the ticket number, the spec section, and backward-
+compat notes (e.g. why it does not break the existing flow).
+
+- **Why**: even a single-column add cannot be reviewed or rolled back confidently without the
+  background (which feature, which spec). The intent lives only in the comment, not in the code. As
+  a domain note it may be written in Japanese (see the grand principle in `SKILL.md`).
+
+## A single column is a string; multiple columns are a `COLUMN_NAME` object
+
+For a single column, `COLUMN_NAME` may be a string. For multiple, make `COLUMN_NAME` an object. The
+`up` `addColumn`s can be grouped with `Promise.all`, but the `down` column drops are run as **one
+raw statement per column, sequentially** (SQLite can only drop one column per statement, so do not
+merge them into one statement — split per column).
+
+```js
+const TABLE_NAME = 'content_sessions'
+const COLUMN_NAME = {
+  WIZARD_ANSWERS_JSON: 'wizard_answers_json',
+  WIZARD_TEMPLATE_ID: 'wizard_template_id',
+  WIZARD_TEMPLATE_VERSION: 'wizard_template_version',
+}
+
+module.exports = {
+  async up (
+    queryInterface,
+    Sequelize
+  ) {
+    await Promise.all([
+      queryInterface.addColumn(TABLE_NAME, COLUMN_NAME.WIZARD_ANSWERS_JSON, {
+        type: Sequelize.JSON,
+        allowNull: true,
+      }),
+      queryInterface.addColumn(TABLE_NAME, COLUMN_NAME.WIZARD_TEMPLATE_ID, {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      }),
+      queryInterface.addColumn(TABLE_NAME, COLUMN_NAME.WIZARD_TEMPLATE_VERSION, {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      }),
+    ])
+
+    return Promise.resolve()
+  },
+
+  async down (
+    queryInterface,
+    Sequelize
+  ) {
+    // removeColumn does not work on MariaDB, so drop per column with raw SQL DROP COLUMN.
+    await queryInterface.sequelize.query(`
+      ALTER TABLE \`${TABLE_NAME}\`
+      DROP COLUMN \`${COLUMN_NAME.WIZARD_ANSWERS_JSON}\`
+    `)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE \`${TABLE_NAME}\`
+      DROP COLUMN \`${COLUMN_NAME.WIZARD_TEMPLATE_ID}\`
+    `)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE \`${TABLE_NAME}\`
+      DROP COLUMN \`${COLUMN_NAME.WIZARD_TEMPLATE_VERSION}\`
+    `)
+
+    return Promise.resolve()
+  },
+}
+```
+
+## Columns on a table with existing rows use `allowNull: true` or `defaultValue`
+
+When adding a column to a table that already holds data, make it `allowNull: true` or give it a
+`defaultValue`. Do not add a `NOT NULL` column that existing rows cannot satisfy (they would
+violate it and the migration would fail). "All nullable for backward compatibility", as above, is
+the default.
+
+- When adding an FK column later, the notation is the same as in `createTable` — type `BIGINT`,
+  uppercase-starting key, `// ForeignKey must start with upper case.` (see
+  [notation.md](./notation.md)). Do not add a DB FK constraint
+  ([foreign-keys.md](./foreign-keys.md)). If it is used in lookups, `addIndex` it separately (see
+  [indexes.md](./indexes.md)).
+
+## Applying changes
+
+After adding or changing a column, rebuild the local DB with `npm run r` (`db:refresh`) to apply it
+(see the "Applying changes to the local DB" section of `SKILL.md`).

--- a/kit/skills/backend/hb-sequelize-migration/references/foreign-keys.md
+++ b/kit/skills/backend/hb-sequelize-migration/references/foreign-keys.md
@@ -1,0 +1,107 @@
+# Foreign Keys (do not add DB FK constraints)
+
+How to treat FK-like columns, and the policy of not creating DB-level foreign-key constraints.
+Referenced from §3 of `SKILL.md`. For the FK column notation see [notation.md](./notation.md); for
+the UNIQUE index that enforces 1:1 see [indexes.md](./indexes.md).
+
+## Do not write `references` / `onDelete` / `onUpdate` / `addConstraint`
+
+Do **not** create DB-level FK constraints. Do not put `references` on a column definition, do not
+attach `onDelete` / `onUpdate`, and do not add an FK constraint via
+`queryInterface.addConstraint(...)` (there is not a single FK constraint in the existing
+migrations).
+
+```js
+// Good example (an FK-like column but no constraint — just the column + comment + a lookup index)
+// ForeignKey must start with upper case.
+CustomerId: {
+  type: Sequelize.BIGINT,
+  field: COLUMN_NAME.CUSTOMER_ID,
+  allowNull: false,
+},
+// ...
+await queryInterface.addIndex(TABLE_NAME, [
+  COLUMN_NAME.CUSTOMER_ID,
+], {
+  name: [TABLE_NAME, SHORT_COLUMN_NAME.CUSTOMER_ID, 'index'].join('_'),
+})
+```
+
+```js
+// Bad example (adds a DB FK constraint)
+CustomerId: {
+  type: Sequelize.BIGINT,
+  field: COLUMN_NAME.CUSTOMER_ID,
+  allowNull: false,
+  references: { model: 'customers', key: 'id' }, // ← do not write
+  onDelete: 'CASCADE',                            // ← do not write
+},
+```
+
+- **Why**: dev = SQLite / staging = MySQL / live = MariaDB differ, and there is no `sync` either. A
+  DB FK constraint (1) pins insert / delete order, (2) makes cloning into backup (`*_bk`) tables
+  hard, and (3) cannot express circular references. Referential integrity is enforced in the **app
+  layer** (model associations and domain logic).
+
+## Create the FK *column*; express the relation on the model side
+
+Do not add the constraint, but **do create the column** that holds another table's id (`BIGINT`,
+uppercase-starting, `// ForeignKey must start with upper case.`; see [notation.md](./notation.md)).
+Declaring the relation that uses that column is the job of the model's `associate()`
+(`hb-sequelize-model`). The migration goes as far as "column + lookup index"; the meaning of the
+relation belongs to the model.
+
+## Enforce 1:1 with a UNIQUE index, not an FK
+
+A 1:1 relation (a child that has exactly one parent) enforces uniqueness with a **UNIQUE index** on
+the parent-id column, not with an FK constraint (see [indexes.md](./indexes.md)). Attach the comment
+verbatim.
+
+```js
+// A 1:1 relation is enforced by a UNIQUE index (no DB FK).
+await queryInterface.addIndex(TABLE_NAME, [
+  COLUMN_NAME.CONTENT_GENERATION_JOB_ID,
+], {
+  unique: true,
+  name: [TABLE_NAME, SHORT_COLUMN_NAME.CONTENT_GENERATION_JOB_ID, 'unique'].join('_'),
+})
+```
+
+## Circular FKs / optional relations: column-only and nullable
+
+When two tables reference each other (a circular FK), or the relation is optional, keep just the
+**column**, `allowNull: true`. With no constraint, even a cycle is fine, and an unresolved value can
+be null.
+
+```js
+// ForeignKey must start with upper case. (circular FK, column only)
+ContentGenerationJobId: {
+  type: Sequelize.BIGINT,
+  field: COLUMN_NAME.CONTENT_GENERATION_JOB_ID,
+  allowNull: true,
+},
+```
+
+- Example: `content_sessions` and `content_generation_jobs` each hold the other's id. Since no
+  DB FK is added, both can hold the other as a column.
+
+## A set of ids you don't want as FKs → a JSON array
+
+When you want to hold a set of ids but not enough to warrant individual FK columns or a join table,
+hold them in a `JSON`-typed array column. Same idea as having no FK constraint: check referential
+integrity in the app layer.
+
+```js
+// An array of ids without an FK.
+optionIdsJson: {
+  type: Sequelize.JSON,
+  field: COLUMN_NAME.OPTION_IDS_JSON,
+  allowNull: true,
+},
+```
+
+## Index the FK columns
+
+Even without a constraint, an FK column is the starting point of joins and filters, so it usually
+gets a **plain index** (see [indexes.md](./indexes.md)). A 1:1 uses a UNIQUE index, a 1:N uses a
+plain index. A join table's composite key uses a composite UNIQUE index.

--- a/kit/skills/backend/hb-sequelize-migration/references/indexes.md
+++ b/kit/skills/backend/hb-sequelize-migration/references/indexes.md
@@ -1,0 +1,149 @@
+# Indexes (naming, and shortening long names)
+
+How to write `addIndex`, how to build the name, and the shortening algorithm for when a name runs
+long. Referenced from §4 of `SKILL.md`. The fact that a UNIQUE index is the real constraint also
+relates to [foreign-keys.md](./foreign-keys.md).
+
+## `addIndex(TABLE_NAME, [columns...], { name, unique? })`
+
+Add indexes with `queryInterface.addIndex`. The second argument is an array of **physical column
+names** (`COLUMN_NAME.X`). Always give `name` explicitly, built by `.join('_')` on an array.
+
+- **Plain index**: end it with `'index'` → `<table>_<column>_index`
+- **UNIQUE index**: add `unique: true` and end it with `'unique'` → `<table>_<column>_unique`
+
+```js
+// Good example (UNIQUE)
+await queryInterface.addIndex(TABLE_NAME, [
+  COLUMN_NAME.ACCESS_TOKEN,
+], {
+  unique: true,
+  name: [
+    TABLE_NAME,
+    COLUMN_NAME.ACCESS_TOKEN,
+    'unique',
+  ].join('_'),
+})
+```
+
+- **Why**: omitting `name` lets Sequelize auto-name it, which is inconsistent across dialects and
+  renames. The trailing `index` / `unique` makes the kind readable from the name. Taking the column
+  name from `COLUMN_NAME` guarantees it matches the column definition's `field:` spelling.
+
+## Multiple indexes → `Promise.all`; a single one → `await` directly
+
+When adding several indexes to the same table, wrap them in `Promise.all([...])`. For just one,
+`await` it directly.
+
+```js
+// Good example (multiple)
+await Promise.all([
+  queryInterface.addIndex(TABLE_NAME, [
+    COLUMN_NAME.CHAT_ROOM_ID,
+  ], {
+    name: [TABLE_NAME, SHORT_COLUMN_NAME.CHAT_ROOM_ID, 'index'].join('_'),
+  }),
+  queryInterface.addIndex(TABLE_NAME, [
+    COLUMN_NAME.CUSTOMER_ID,
+  ], {
+    name: [TABLE_NAME, SHORT_COLUMN_NAME.CUSTOMER_ID, 'index'].join('_'),
+  }),
+])
+```
+
+## Composite indexes: list the columns, or fold them into a meaningful label
+
+A composite (multi-column) index may list all the columns, or fold them into a single meaningful
+word when that runs long.
+
+```js
+// List the columns
+name: [TABLE_NAME, COLUMN_NAME.STATUS, COLUMN_NAME.EXPIRES_AT, 'index'].join('_')
+//  → content_sessions_status_expires_at_index
+
+// Fold into a meaningful label (a wide composite UNIQUE)
+name: [SHORT_TABLE_NAME, 'plan_tier_currency_effective_at', 'unique'].join('_')
+//  → cpr_plan_tier_currency_effective_at_unique
+name: [SHORT_TABLE_NAME, 'job_package', 'unique'].join('_')
+//  → cgjp_job_package_unique
+```
+
+## Shortening a long index name (over ~50 chars)
+
+The DB identifier limit is 64 characters. As a **safety margin, shorten once a name would run past
+~50 characters**. Shorten in stages, in the **following priority order**.
+
+### Priority 1: shorten the column name(s) first (keep the table name in full)
+
+Define `SHORT_COLUMN_NAME` and swap only the column part of the `name` for it. Keep the table name
+in full.
+
+```js
+const SHORT_COLUMN_NAME = {
+  CONTENT_GENERATION_JOB_ID: 'cgji',
+}
+
+// content_generations_content_generation_job_id_unique (52 chars) is too long
+//  → shorten only the column name
+name: [
+  TABLE_NAME,                                        // content_generations (full)
+  SHORT_COLUMN_NAME.CONTENT_GENERATION_JOB_ID,   // cgji
+  'unique',
+].join('_')
+//  → content_generations_cgji_unique (31 chars)
+```
+
+### Priority 2: if still too long, shorten the table name too
+
+Only when shortening the column name is not enough (the table name itself is long) do you also
+define `SHORT_TABLE_NAME` and shorten the table name.
+
+```js
+const SHORT_TABLE_NAME = 'cgrf'                              // content_generation_requirement_files
+const SHORT_COLUMN_NAME = {
+  CONTENT_GENERATION_JOB_ID: 'cgji',
+}
+
+name: [
+  SHORT_TABLE_NAME,                                 // cgrf
+  SHORT_COLUMN_NAME.CONTENT_GENERATION_JOB_ID,  // cgji
+  'index',
+].join('_')
+//  → cgrf_cgji_index (15 chars)
+```
+
+- **Why this order**: the table name is the first thing a reader of an index uses to tell "which
+  table is this", so keep it in full as long as possible. Shorten the **less-informative column
+  name first**; cut the table name only as a last resort.
+
+### How to shorten = take the initial of each word (split on `_`)
+
+Build the abbreviation by splitting the snake_case name on `_` and concatenating the **first
+character** of each word.
+
+| Original name | Abbreviation |
+| --- | --- |
+| `content_generation_job_id` | `cgji` |
+| `content_generation_requirement_files` | `cgrf` |
+| `content_generation_job_packages` | `cgjp` |
+| `content_plan_rates` | `cpr` |
+| `chat_room_id` | `cri` |
+| `customer_id` | `ci` |
+
+- Always put abbreviations in `SHORT_COLUMN_NAME` / `SHORT_TABLE_NAME` constants and reference them
+  from the `addIndex` `name` (do not inline). If abbreviations collide within a table, add a second
+  letter (etc.) to keep them unique while staying meaningful.
+
+### Shorten only when needed
+
+If it fits within ~50 characters, do not shorten. `.join('_')` the full `TABLE_NAME` / `COLUMN_NAME`
+as in `customers_registered_at_index`. **Do not mechanically initialize just because you can** (it
+hurts readability).
+
+## A UNIQUE named index is "the real constraint"
+
+The uniqueness of a 1:1 relation's FK or a natural key is **actually enforced by this UNIQUE named
+index**. A model's `unique: true` (`hb-sequelize-model`) is only a
+reader-facing declaration and does not create a DB constraint (this repo does not `sync`). For the
+policy of not adding DB FK constraints and enforcing 1:1 with a UNIQUE index, see
+[foreign-keys.md](./foreign-keys.md).

--- a/kit/skills/backend/hb-sequelize-migration/references/notation.md
+++ b/kit/skills/backend/hb-sequelize-migration/references/notation.md
@@ -1,0 +1,215 @@
+# Notation (file skeleton, constants, column notation)
+
+The skeleton of a migration file, the `TABLE_NAME` / `COLUMN_NAME` constants, and how to write a
+column inside `createTable`. Referenced from §1–§3 of `SKILL.md`. For indexes see
+[indexes.md](./indexes.md); for the "no DB FK" rule see [foreign-keys.md](./foreign-keys.md).
+
+## One migration = one file, `.cjs` (CommonJS)
+
+Place one migration per file directly under `sequelize/migrations/`. The extension is `.cjs`; start
+with `'use strict'` and **`require`** `MigrationAttributeFactory` (unlike the model side's `.js` /
+`import`, a migration is CommonJS).
+
+```js
+'use strict'
+
+const MigrationAttributeFactory = require('@openreachtech/renchan-sequelize/lib/tools/MigrationAttributeFactory.cjs')
+```
+
+- **Why**: sequelize-cli loads migrations as CommonJS. Written as `import` / ESM they will not load.
+  The factory `require` path is fixed at `lib/tools/MigrationAttributeFactory.cjs` inside the
+  package.
+
+## Filename `{timestamp}-{seq}-<operation>-<table>[-<column>].cjs`
+
+The filename is itself the execution order (ascending timestamp = creation-time order) and an index
+of the operation.
+
+- `{timestamp}` = creation time `YYYYMMDDHHmmss` (14 digits; obtained from `date +%Y%m%d%H%M%S`).
+- `{seq}` = a 6-digit, zero-padded running number (`000001`…). It doubles as the order within the
+  same timestamp and as a stable number for humans to refer to.
+- The operation is `create_table` (create a table) / `alter_table` (add / remove / change columns on
+  an existing table).
+- Examples: `20260717135803-000001-create_table-content_generations.cjs` /
+  `20260717140512-000002-alter_table-content_generation_jobs-webhook_url.cjs`
+- **Why**: the leading timestamp fixes the apply order uniquely in creation-time order, and even
+  when several people add migrations around the same time they rarely collide. The 6-digit seq is a
+  stable identifier for a human to track "which migration is this".
+
+(Older migrations use the `<8-digit-seq>-create_table-...` form. Write new files in the form above.)
+
+## Declare `TABLE_NAME` and `COLUMN_NAME` at the top (single source of truth for physical names)
+
+Outside `up` / `down`, before `module.exports`, declare `TABLE_NAME` (a string) and `COLUMN_NAME`
+(an object). `COLUMN_NAME` keys are `SCREAMING_SNAKE`, values are the **physical column names
+(snake_case)**. This value is referenced by **both** the column's `field:` and the index name (see
+[indexes.md](./indexes.md)).
+
+```js
+const TABLE_NAME = 'content_plan_rates'
+const COLUMN_NAME = {
+  PLAN: 'plan',
+  TIER: 'tier',
+  UNIT_RATE: 'unit_rate',
+  EFFECTIVE_AT: 'effective_at',
+  IS_ACTIVE: 'is_active',
+}
+```
+
+- **Why**: concentrating the physical names in one place keeps the `field:` and the index name from
+  drifting apart in spelling. When a physical name changes, editing this one place makes both the
+  `field:` and the index name follow. Do not inline string literals into column definitions or
+  indexes.
+
+## `module.exports = { up, down }`, arguments `(queryInterface, Sequelize)`
+
+Both `up` / `down` are `async` and take `(queryInterface, Sequelize)` in that order. Inside `up`,
+build `const factory = MigrationAttributeFactory.create(Sequelize)`.
+
+```js
+module.exports = {
+  async up (
+    queryInterface,
+    Sequelize
+  ) {
+    const factory = MigrationAttributeFactory.create(Sequelize)
+
+    await queryInterface.createTable(TABLE_NAME, {
+      ...factory.ID_BIGINT,
+      // ... columns ...
+      ...factory.TIMESTAMPS,
+    })
+
+    // ... addIndex ...
+
+    return Promise.resolve()
+  },
+
+  async down (
+    queryInterface,
+    Sequelize
+  ) {
+    return queryInterface.dropTable(TABLE_NAME)
+  },
+}
+```
+
+- The `down` of a create-table migration is always `return queryInterface.dropTable(TABLE_NAME)`
+  (drop the whole table). The `down` of a column migration is in [alter-table.md](./alter-table.md).
+- `up` closes with `return Promise.resolve()` (the existing convention).
+
+## Spread the PK with `...factory.ID_BIGINT` at the top
+
+Put `...factory.ID_BIGINT` at the **top** of the object passed to `createTable`. Use
+`...factory.ID_INTEGER` only when you need an integer PK. Never hand-write `id`.
+
+- `factory.ID_BIGINT` returns `{ id: { field:'id', type: BIGINT, allowNull:false,
+  autoIncrement:true, primaryKey:true } }`. It is the shorthand that keeps you from getting that
+  four-piece set wrong.
+- It corresponds one-to-one with `...factory.ID_BIGINT` on the model side
+  (`hb-sequelize-model`).
+
+```js
+// Bad example (hand-writing id)
+await queryInterface.createTable(TABLE_NAME, {
+  id: {
+    type: Sequelize.BIGINT,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  // ...
+})
+```
+
+## Spread the timestamps with `...factory.TIMESTAMPS` at the end
+
+Put `...factory.TIMESTAMPS` at the **end** of the `createTable` object. Do not hand-write
+`created_at` / `updated_at`. For a table that soft-deletes, use
+`...factory.TIMESTAMPS_WITH_DELETED_AT` (which also creates `deleted_at`), paired with
+`paranoid: true` on the model side. See §2 of `SKILL.md`.
+
+| preset | columns created |
+| --- | --- |
+| `factory.ID_BIGINT` | `id` (bigint / autoIncrement / primaryKey / NOT NULL) |
+| `factory.ID_INTEGER` | `id` (integer version) |
+| `factory.TIMESTAMPS` | `created_at` / `updated_at` (`DATE(3)` / NOT NULL) |
+| `factory.TIMESTAMPS_WITH_DELETED_AT` | the above + `deleted_at` (`DATE(3)`) |
+
+## Write columns with a camelCase key + `field:` (snake physical name)
+
+Declare each column with a camelCase key and give `field:` the value `COLUMN_NAME.X`. The type is
+`Sequelize.X`. **Always** write `allowNull`, and write `defaultValue` when there is a default.
+
+```js
+// Good example
+role: {
+  type: Sequelize.STRING(32),
+  field: COLUMN_NAME.ROLE,
+  allowNull: false,
+},
+currency: {
+  type: Sequelize.STRING(8),
+  field: COLUMN_NAME.CURRENCY,
+  allowNull: false,
+  defaultValue: 'JPY',
+},
+```
+
+```js
+// Bad example (field omitted → physical name becomes camelCase; allowNull omitted → defaults to true)
+role: {
+  type: Sequelize.STRING(32),
+},
+```
+
+- **Why**: without `field:`, the physical name becomes camelCase and no longer matches the model
+  (which maps to snake via `underscored:true`). Omitting `allowNull` falls back to Sequelize's
+  default `true`, losing the NOT NULL intent. Keep `allowNull` / `defaultValue` aligned with the
+  same-named column on the model side.
+
+### DataTypes guide
+
+| Type | Use |
+| --- | --- |
+| `BIGINT` | PK / FK-like id |
+| `INTEGER` | small integer PK, quantity, version |
+| `STRING(n)` | variable-length string (identifier `32`, display name / email `191`, etc. — pick by use) |
+| `TEXT` / `TEXT('medium')` | long text (body, message, error). For an item that can grow long, use `TEXT('medium')` |
+| `DATE(3)` | millisecond-precision datetime (`registeredAt` / `expiresAt`, etc.) |
+| `BOOLEAN` | truth value (`isActive`, etc.) |
+| `JSON` | structured data (`resultJson`; an FK-less id array `optionIdsJson`) |
+| `DECIMAL(p, s)` | money / rate (`dailyRate` as `DECIMAL(14, 2)`, etc.) |
+| `BLOB('long')` | binary (uploaded file body) |
+| `ENUM(...)` | **avoid by default**; use a domain constant + `STRING(n)` |
+
+- Datetimes default to `DATE(3)` (millisecond precision by default, for ordering comparisons and
+  history uniqueness).
+- Do not default string lengths to "255 for now". Choose by use, and keep the length identical on
+  the model and migration sides.
+- Plain `TEXT` is capped around 64KB; for a column that may hold long content, use
+  `TEXT('medium')` (MEDIUMTEXT, ~16MB). Reach for `TEXT('long')` (LONGTEXT) only when even that is
+  not enough.
+
+## FK-like columns start with an uppercase letter + a comment (type BIGINT)
+
+A column holding another table's id gets an **uppercase-starting** key
+(`ContentGenerationJobId` / `CustomerId`) with `// ForeignKey must start with upper case.` in
+English immediately above it. The type is `BIGINT`.
+
+```js
+// Good example
+// ForeignKey must start with upper case.
+ContentGenerationJobId: {
+  type: Sequelize.BIGINT,
+  field: COLUMN_NAME.CONTENT_GENERATION_JOB_ID,
+  allowNull: false,
+},
+```
+
+- **Why**: the model's association resolves the FK name by "`<associated model name>` + `Id`", so
+  align on an uppercase start (`hb-sequelize-model`). `field:` maps it
+  to snake (`..._id`).
+- But **do not add a DB FK constraint**. Keep just the column and the comment, and express the
+  relation on the model side ([foreign-keys.md](./foreign-keys.md)). Optional relations / circular
+  FKs use `allowNull: true`, with a note such as
+  `// ForeignKey must start with upper case. (circular FK, column only)` when helpful.

--- a/kit/skills/backend/hb-sequelize-model/SKILL.md
+++ b/kit/skills/backend/hb-sequelize-model/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: hb-sequelize-model
+description: >
+  Write and edit renchan/Sequelize model definitions (sequelize/models/*.js).
+  Use this skill whenever the user asks to create or update a Sequelize model
+  class — its attributes, createOptions, associations, scopes, hooks, or how to
+  wire a MixinModel.
+---
+
+# Sequelize Model
+
+A skill for writing the `sequelize/models/*.js` model definitions used in a renchan project.
+The physical schema is defined by `hb-sequelize-migration`; this
+skill writes the corresponding **logical declarations on top of Sequelize** (attributes /
+association / scope / hook / Mixin). The conventions are split across the detail files below —
+consult them as needed.
+
+## Grand principle: a model is a filled-in template, not free-form code
+
+Every model extends `BaseAppRenchanModel` and has the **same skeleton**. The six extension
+points that form that skeleton (`createAttributes` / `createOptions` / `associate` /
+`defineScopes` / `defineSubqueries` / `setupHooks`) are **always laid out in the same order,
+even when unused**, and any that have no content keep `super.xxx?.()` plus `// noop`
+([default-methods.md](./references/default-methods.md)).
+
+- **Do not "delete to omit"**. Removing a method entirely makes it impossible to tell whether
+  the model "has no such feature (i.e. it was considered)" or someone "forgot to write it".
+  Keeping an explicit noop declares "considered, and not applicable". This is the same idea as
+  the QA stance in `hc-jest` ("do not cut coverage using implementation
+  knowledge") — to avoid mistaking *a gap* for *not-applicable*, always keep the extension
+  points visible.
+- Because the skeleton is identical across every model, review attention goes straight to the
+  **model-specific differences** (attributes / associations). When the structure varies from
+  model to model, it becomes impossible to read what is intentional and what is an omission.
+- When in doubt, **lean toward the template**. Do not try to write it "cleverly" with custom
+  static methods or a changed initialization order. Extend via a Mixin
+  ([mixins.md](./references/mixins.md)) or a framework extension point.
+
+## Write code comments in English
+
+Comments inside model code (`.js`) — such as `// ForeignKey must start with upper case.` — are
+written in **English**, to match the other comments in the codebase.
+
+- This applies to comments inside the model code generated into `sequelize/models/` (the `//`
+  and `/* */` in `.js`). They are artifacts, so English.
+- The explanatory prose of this skill (the body text of each Markdown file) is in English as
+  well.
+- The comments inside **this skill's own examples** (```js``` blocks) are also in English.
+
+## Keep a one-to-one correspondence with the migration
+
+A model's attributes must correspond one-to-one with the columns of the matching
+`hb-sequelize-migration`. The camelCase attribute keys on the model side map
+to the snake_case physical columns (`field:`) on the migration side via `underscored: true`
+([default-methods.md](./references/default-methods.md#createoptions-spreads-supercreateoptions-and-adds-only-extras)).
+
+- **Why**: adding only one side produces an inconsistency — an attribute exists but the column
+  does not (queries fail), or a column exists but the model cannot touch it. Always add or change
+  columns in the migration and the model together.
+- Timestamp columns are the exception; **do not** write them in the model's attributes
+  ([timestamps.md](./references/timestamps.md)).
+
+## Detail files
+
+- [notation.md](./references/notation.md) — class skeleton, imports, attribute declarations
+- [default-methods.md](./references/default-methods.md) — the six override methods and `createOptions`
+- [timestamps.md](./references/timestamps.md) — do not include `created_at` / `updated_at` in the model
+- [associations.md](./references/associations.md) — how to write `associate()` (relations via `this._`)
+- [mixins.md](./references/mixins.md) — kinds of MixinModel and how to pass them (all 6)

--- a/kit/skills/backend/hb-sequelize-model/references/associations.md
+++ b/kit/skills/backend/hb-sequelize-model/references/associations.md
@@ -1,0 +1,218 @@
+# Associations (how to write associate())
+
+Conventions for declaring relations between models in `associate()`. Referenced from `SKILL.md`.
+For method ordering and the `super`-call template see
+[default-methods.md](./default-methods.md#even-unused-extension-points-call-super-and-keep-a-noop);
+for FK column notation see
+[notation.md](./notation.md#fk-like-columns-start-with-an-uppercase-letter-and-carry-a-comment).
+
+## Reference the associated model via `this._.<ModelName>`
+
+Always reference the associated model via **`this._.<ModelName>`**. `this._` is the
+`sequelize.models` (the hash of registered models) returned by the base `RenchanModel`.
+
+- **Why**: models cross-reference each other across files, so a direct import causes a circular
+  dependency. `this._` is resolved after all models are registered, so it pulls the associated
+  model while avoiding the cycle. The reference name matches the class name = filename
+  ([notation.md](./notation.md#one-model-per-file-filename-matches-class-name)), so you spell it
+  `this._.Customer`.
+- Remember to put `super.associate?.()` first (so a Mixin's relations are not swallowed;
+  [default-methods.md](./default-methods.md#even-unused-extension-points-call-super-and-keep-a-noop)).
+
+```js
+// Good example
+/**
+ * Define model associations
+ */
+static associate () {
+  super.associate?.()
+
+  this.belongsTo(this._.Customer)
+}
+```
+
+```js
+// Bad example (directly importing the associated model, inviting a circular dependency)
+import Customer from './Customer.js'
+// ...
+this.belongsTo(Customer)
+```
+
+## Choose the association type to match the relationship
+
+Pick among Sequelize's four methods by which side holds the FK column in the DB and by
+multiplicity. The FK column is defined on the **side that holds the FK**, following the
+[notation.md](./notation.md#fk-like-columns-start-with-an-uppercase-letter-and-carry-a-comment)
+convention (uppercase start).
+
+| Method | Meaning | Side holding the FK |
+| --- | --- | --- |
+| `this.belongsTo(this._.X)` | I reference one X (I hold the FK) | **me** |
+| `this.hasOne(this._.X)` | X references me once (1:1) | the other (X) |
+| `this.hasMany(this._.X)` | X references me many times (1:N) | the other (X) |
+| `this.belongsToMany(this._.X, { through: this._.Y })` | many-to-many with X (through join table Y) | the join table (Y) |
+
+- `belongsTo` and `hasOne` / `hasMany` are **two sides of the same coin**. Write `belongsTo` on
+  the child side that holds the FK, and `hasOne` / `hasMany` on the parent side (you may declare
+  both sides).
+- `belongsToMany` must be given the join model in `through`. The join model itself is an ordinary
+  model with a `belongsTo` to each side ([the join-table example](#a-join-table-has-a-belongsto-to-each-side)).
+
+```js
+// Good example (parent CustomerOrder side — children hold the FK, so hasOne / hasMany / belongsToMany)
+/**
+ * Define model associations
+ */
+static associate () {
+  super.associate?.()
+
+  this.hasOne(this._.CustomerOrderTotalPrice)
+  this.hasOne(this._.CustomerOrderLatestStatus)
+
+  this.hasMany(this._.CustomerOrderProduct)
+
+  this.belongsToMany(this._.BrandShipment, {
+    through: this._.BrandShipmentOrder,
+  })
+}
+```
+
+```js
+// Good example (child CustomerOrder side — it holds CustomerId, so belongsTo)
+/**
+ * Define model associations
+ */
+static associate () {
+  super.associate?.()
+
+  this.belongsTo(this._.Customer)
+}
+```
+
+## Pass association options only when the default inference is wrong
+
+Sequelize resolves the FK by the convention "`<associated model name>` + `Id`"
+([notation.md](./notation.md#fk-like-columns-start-with-an-uppercase-letter-and-carry-a-comment)).
+When the FK column follows that convention, call the association method with the model alone.
+Pass an options object only when the default inference is wrong — `through` for `belongsToMany`
+(previous section), and `foreignKey` when the FK attribute departs from the convention.
+
+- **Why**: restating an option the inference already gets right is noise that hides the real
+  signal ("this association is irregular"). Conversely, when a model holds a **role-named FK**
+  (or two FKs pointing at the same model), the inferred `<ModelName>Id` does not exist, the
+  relation silently binds the wrong column, and `include` fails — so name the FK explicitly.
+
+```js
+// Good example (the FK follows the convention; no options)
+this.belongsTo(this._.Customer)
+
+// Good example (the child's FK is role-named, so inference fails; name it explicitly)
+this.hasMany(this._.TabGroupDisplayTab, {
+  foreignKey: 'DisplayTabOriginCategoryId',
+})
+```
+
+```js
+// Bad example (restating the option the inference already resolves)
+this.belongsTo(this._.Customer, {
+  foreignKey: 'CustomerId',
+})
+```
+
+## A declared association is read off the instance by the model name
+
+An association declared in `associate()` determines the property name under which `include`
+attaches the loaded rows: `belongsTo` / `hasOne` attach under the **singular model name**,
+`hasMany` / `belongsToMany` under the **pluralized model name**.
+
+- **Why**: the property comes from the association declaration, not from the FK column, so
+  knowing this mapping tells you what an `include` produces without inspecting the result. It is
+  also why the reference name must match the class name
+  ([notation.md](./notation.md#one-model-per-file-filename-matches-class-name)).
+
+```js
+// The declaration determines the property name on a loaded instance
+const order = await CustomerOrder.findOne({
+  include: [
+    CustomerOrderTotalPrice,
+    CustomerOrderProduct,
+  ],
+})
+
+order.CustomerOrderTotalPrice // hasOne / belongsTo → singular model name
+order.CustomerOrderProducts // hasMany / belongsToMany → pluralized model name
+```
+
+## A join table has a belongsTo to each side
+
+A many-to-many join-table model writes a **`belongsTo` to each end**. It holds the FK columns
+(each end's `<Model>Id`) as attributes, and adds `paranoid`
+([default-methods.md](./default-methods.md#when-to-add-paranoid)) when it soft-deletes.
+
+- **Why**: `belongsToMany(..., { through })` goes through the join table, but the join table
+  itself must know its relations to both ends. Linking the join table as an ordinary model with a
+  `belongsTo` to each end lets you find the join table directly and include both ends.
+
+```js
+// Good example (BrandShipmentOrder — the join table between CustomerOrder and BrandShipment)
+export default class BrandShipmentOrder extends BaseAppRenchanModel {
+  /**
+   * Define model attributes
+   *
+   * @param {import('sequelize').DataTypes} DataTypes - Sequelize DataTypes
+   * @returns {object} Model attributes
+   */
+  static createAttributes (DataTypes) {
+    const factory = ModelAttributeFactory.create(DataTypes)
+
+    return {
+      ...factory.ID_BIGINT,
+
+      CustomerOrderId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+      },
+      BrandShipmentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+    }
+  }
+
+  /**
+   * Define model options
+   *
+   * @param {import('sequelize').Sequelize} sequelizeClient - Sequelize instance
+   * @returns {object} Model options
+   */
+  static createOptions (sequelizeClient) {
+    return {
+      ...super.createOptions(sequelizeClient),
+
+      paranoid: true, // for deleted_at column
+    }
+  }
+
+  /**
+   * Define model associations
+   */
+  static associate () {
+    super.associate?.()
+
+    this.belongsTo(this._.CustomerOrder)
+    this.belongsTo(this._.BrandShipment)
+  }
+
+  // defineScopes / defineSubqueries / setupHooks are noop
+}
+```
+
+## Do not add DB foreign-key constraints (enforce in the app layer)
+
+Express relations with Sequelize associations **only**. Do not add DB foreign-key constraints
+(`references` / `onDelete` / `onUpdate`)
+(`hb-sequelize-migration`).
+
+- **Why**: referential integrity is enforced in the app layer (transactions, existence checks).
+  Not adding constraints keeps migration ordering, record deletion, and sqlite tests simple. A
+  model's `belongsTo` etc. are **declarations for JOIN and include**, independent of DB constraints.

--- a/kit/skills/backend/hb-sequelize-model/references/default-methods.md
+++ b/kit/skills/backend/hb-sequelize-model/references/default-methods.md
@@ -1,0 +1,244 @@
+# Default Methods (the six override methods and createOptions)
+
+The template for the static methods that form a model's skeleton. Rooted in the
+[grand principle](../SKILL.md#grand-principle-a-model-is-a-filled-in-template-not-free-form-code)
+in `SKILL.md` (keep the extension points, leave a noop rather than deleting). For the contents of
+the attributes see [notation.md](./notation.md); for the details of `associate()` see
+[associations.md](./associations.md).
+
+## Lay out the six methods in a fixed order, each with JSDoc
+
+Every model defines the following six methods **in this order**, with a **JSDoc block** stating
+the purpose, arguments, and return value immediately above each. Do not delete unused methods;
+keep them with the template (below).
+
+1. `createAttributes (DataTypes)`
+2. `createOptions (sequelizeClient)`
+3. `associate ()`
+4. `defineScopes (Op)`
+5. `defineSubqueries ()`
+6. `setupHooks ()`
+
+- **Why**: fixing the order across every model puts the same responsibility in the same position
+  in every file. The reader never has to hunt for "where does this model wire relations, where
+  does it add a scope". A JSDoc that records the purpose, `@param`, and `@returns` on each method
+  makes each extension point's responsibility readable even in a declaration-only layer, and the
+  `@param` type annotation prevents mixing up `DataTypes` / `Op` / `sequelizeClient`.
+- `createAttributes` is **abstract** — the base `throw`s. Always implement it (if unimplemented,
+  it fails in `initWithSequelizeClient`). The other five have a default implementation on the
+  base; overriding them is for "adding this model's own declarations".
+
+```js
+// Good example (the skeleton; unused extension points are kept as noop)
+export default class CustomerOrder extends BaseAppRenchanModel {
+  /**
+   * Define model attributes
+   *
+   * @param {import('sequelize').DataTypes} DataTypes - Sequelize DataTypes
+   * @returns {object} Model attributes
+   */
+  static createAttributes (DataTypes) {
+    const factory = ModelAttributeFactory.create(DataTypes)
+
+    return {
+      ...factory.ID_BIGINT,
+      // ... attributes (notation.md)
+    }
+  }
+
+  /**
+   * Define model options
+   *
+   * @param {import('sequelize').Sequelize} sequelizeClient - Sequelize instance
+   * @returns {object} Model options
+   */
+  static createOptions (sequelizeClient) {
+    return {
+      ...super.createOptions(sequelizeClient),
+    }
+  }
+
+  /**
+   * Define model associations
+   */
+  static associate () {
+    super.associate?.()
+
+    this.belongsTo(this._.Customer)
+  }
+
+  /**
+   * Define model scopes
+   *
+   * @param {import('sequelize').Op} Op - Sequelize operators
+   */
+  static defineScopes (Op) {
+    super.defineScopes?.(Op)
+
+    // noop
+  }
+
+  /**
+   * Define subqueries
+   */
+  static defineSubqueries () {
+    super.defineSubqueries?.()
+
+    // noop
+  }
+
+  /**
+   * Setup model hooks
+   */
+  static setupHooks () {
+    super.setupHooks?.()
+
+    // noop
+  }
+}
+```
+
+## Even unused extension points call super and keep a noop
+
+`associate` / `defineScopes` / `defineSubqueries` / `setupHooks` are **not deleted** even when
+this model adds nothing to them. Reduce the body to two lines: `super.xxx?.()` (an optional call)
+plus `// noop`.
+
+- **Why**: per the
+  [grand principle](../SKILL.md#grand-principle-a-model-is-a-filled-in-template-not-free-form-code),
+  to avoid mistaking *a gap* for *not-applicable*. A noop reads as "no relation / no scope — and
+  that was considered". Putting `super.xxx?.()` first is so a Mixin ([mixins.md](./mixins.md))
+  does not get its base-defined behavior (Backup's `afterSave`, etc.) **swallowed** — each method
+  on `RenchanModel` calls the Mixin's same-named handler via `mixinsApplier`, so if the override
+  does not call `super`, the Mixin is disabled.
+- Calling with `?.` (optional) is so it passes safely even when the base has no such method.
+
+```js
+// Good example (a defineScopes with nothing to add)
+/**
+ * Define model scopes
+ *
+ * @param {import('sequelize').Op} Op - Sequelize operators
+ */
+static defineScopes (Op) {
+  super.defineScopes?.(Op)
+
+  // noop
+}
+```
+
+```js
+// Bad example 1 (deleting the whole method — can't tell not-applicable from forgotten)
+// defineScopes is not written
+
+// Bad example 2 (not calling super — swallows the Mixin's scope / hook)
+/**
+ * Setup model hooks
+ */
+static setupHooks () {
+  // noop (without super.setupHooks?.(), Backup's afterSave etc. won't run)
+}
+```
+
+## createOptions spreads super.createOptions() and adds only extras
+
+`createOptions()` **spreads `...super.createOptions(sequelizeClient)`** and adds only this model's
+own options. The base `RenchanModel` returns
+`{ modelName, sequelize, syncOnAssociation:false, timestamps:true, underscored:true }` as defaults.
+
+- **Why**: `timestamps:true` ([timestamps.md](./timestamps.md)) and `underscored:true` (mapping
+  camelCase attributes → snake columns;
+  [SKILL.md](../SKILL.md#keep-a-one-to-one-correspondence-with-the-migration)) are shared
+  assumptions for every model. Do not rewrite them per model; use the base defaults. The two
+  below are the typical additions.
+- If you add nothing else, finish in the three lines of the spread alone (most models do this).
+
+```js
+// Good example (adds nothing)
+/**
+ * Define model options
+ *
+ * @param {import('sequelize').Sequelize} sequelizeClient - Sequelize instance
+ * @returns {object} Model options
+ */
+static createOptions (sequelizeClient) {
+  return {
+    ...super.createOptions(sequelizeClient),
+  }
+}
+```
+
+### When to add tableName
+
+Add an explicit `tableName` only for a table that differs from the "physical name = plural /
+model name = singular" rule. A backup table (`*Bk`) is the typical case.
+
+- **Why**: normally Sequelize infers the (plural) table name from the (singular) model name, so no
+  `tableName` is needed. But a backup table is named **`<original table name>_bk`** (original
+  table `customer_orders` → `customer_orders_bk`), so its tail is `_bk` (singular), differing from
+  the rule. Sequelize would infer `customer_orders_bks` from the model `CustomerOrdersBk`, which
+  clashes with the real table `customer_orders_bk`. Left alone it queries a nonexistent table, so
+  declare `tableName`. Conversely, do not write it for a model whose inference is already correct
+  (`CustomerOrder → customer_orders`); that is redundant.
+
+```js
+// Good example (Bk table; inferred customer_orders_bks ≠ real customer_orders_bk)
+/**
+ * Define model options
+ *
+ * @param {import('sequelize').Sequelize} sequelizeClient - Sequelize instance
+ * @returns {object} Model options
+ */
+static createOptions (sequelizeClient) {
+  return {
+    ...super.createOptions(sequelizeClient),
+
+    tableName: 'customer_orders_bk',
+  }
+}
+```
+
+### When to add paranoid
+
+Add `paranoid: true` only for a table that uses `deleted_at` soft delete.
+
+- **Why**: with `paranoid` on, Sequelize stamps `deleted_at` on delete and excludes such rows
+  from default finds. This works together with the migration creating a `deleted_at` column via
+  `...factory.TIMESTAMPS_WITH_DELETED_AT` (`hb-sequelize-migration`). Adding `paranoid` without
+  the column makes queries fail.
+
+```js
+// Good example (a join table that soft-deletes)
+/**
+ * Define model options
+ *
+ * @param {import('sequelize').Sequelize} sequelizeClient - Sequelize instance
+ * @returns {object} Model options
+ */
+static createOptions (sequelizeClient) {
+  return {
+    ...super.createOptions(sequelizeClient),
+
+    paranoid: true, // for deleted_at column
+  }
+}
+```
+
+## defineScopes / defineSubqueries / setupHooks are framework extension points
+
+Understand the role of these three extension points (when you use them, add to them while keeping
+`super.xxx?.()` first).
+
+| Method | What it is for | API used |
+| --- | --- | --- |
+| `defineScopes(Op)` | add named scopes (reusable units of filtering / ordering) | `this.addScope(name, options)` |
+| `defineSubqueries()` | register correlated subqueries by name so `this.subquery(name, ...)` can use them | `this.addSubquery({ name, generator })` |
+| `setupHooks()` | add lifecycle hooks (before/after save and find) | `this.beforeFind` / `this.afterSave` / `this.addHook(...)` |
+
+- The routine behaviors of `defineScopes` / `setupHooks` are better pushed into a **Mixin** than
+  hand-written per model ([mixins.md](./mixins.md)). For example, "clone to a history table on
+  every save" is not written directly in `setupHooks`; you pass `BackupMixinModel`. Add a scope /
+  hook per model only for one-off requirements a Mixin cannot express.
+- `defineSubqueries` is implemented in models that need a correlated subquery (e.g.
+  `CustomerOrder.js`; read the physical column name via the attribute's `.field`). Leave it as a
+  noop in models that do not use it.

--- a/kit/skills/backend/hb-sequelize-model/references/mixins.md
+++ b/kit/skills/backend/hb-sequelize-model/references/mixins.md
@@ -1,0 +1,247 @@
+# Mixins (kinds of MixinModel and how to pass them)
+
+Conventions for the MixinModels that compose routine behavior onto `RenchanModel`. Referenced
+from `SKILL.md`. For how a Mixin injects features into the extension points (why `super.xxx?.()`
+is kept) see
+[default-methods.md](./default-methods.md#even-unused-extension-points-call-super-and-keep-a-noop).
+
+## Pass mixins as an array from the Mixins getter
+
+To make Mixins take effect on a model, **override `static get Mixins ()` to return an array of
+MixinModels**. Import Mixins from `@openreachtech/renchan-sequelize`. You can pass several.
+
+- **Why**: at each of the `associate` / `defineScopes` / `defineSubqueries` / `setupHooks`
+  extension points, `RenchanModel` walks `Mixins` and composes the Mixin's same-named handler
+  (`mixinsApplier`). That is why **routine behavior is declared as a Mixin rather than
+  hand-written in the model** — "clone to a history table on every save", "include the latest
+  status on find", and the like. Keeping `super.xxx?.()` first in the six methods is what makes
+  this composition work
+  ([default-methods.md](./default-methods.md#even-unused-extension-points-call-super-and-keep-a-noop)).
+- The `Mixins` getter, and the abstract getters a Mixin requires (next section), go **after the
+  six methods** (at the end). The "extensions added to this model" then sit together after the
+  skeleton
+  ([SKILL.md](../SKILL.md#grand-principle-a-model-is-a-filled-in-template-not-free-form-code)).
+
+```js
+// Good example (Mixins goes after the six methods)
+import {
+  BackupMixinModel,
+  ModelAttributeFactory,
+} from '@openreachtech/renchan-sequelize'
+
+import BaseAppRenchanModel from '../baseModel/BaseAppRenchanModel.js'
+
+export default class CustomerOrder extends BaseAppRenchanModel {
+  // ... createAttributes through setupHooks (the six methods)
+
+  /**
+   * get: Mixin models to apply
+   *
+   * @returns {Array<Function>} Mixin models
+   */
+  static get Mixins () {
+    return [
+      BackupMixinModel,
+    ]
+  }
+
+  // ↓ the abstract getter the Mixin requires (next section)
+}
+```
+
+## Implement the abstract getter a mixin requires to pass it
+
+Each Mixin declares "which model it relates to" and "which column it orders by" via an **abstract
+getter** that `throw`s on the base. Overriding that getter on the model side to inject the
+concrete value is how you **pass input** to the Mixin.
+
+- **Why**: a Mixin is a reusable frame and does not know the model-specific counterpart (backup
+  target, status table, etc.). If you do not implement the abstract getter, the moment that
+  Mixin's handler runs it fails with `".get:XxxModel" must be inherited`. Which getter to pass
+  is fixed per Mixin (table below).
+- Return the related model with **`this._.<ModelName>`**, same as
+  [associations.md](./associations.md#reference-the-associated-model-via-this_modelname) (to avoid
+  a circular import).
+
+```js
+// Good example (implement BackupModel required by BackupMixinModel = pass the backup target)
+/**
+ * get: Backup model for BackupMixinModel
+ *
+ * @returns {typeof import('./CustomerOrdersBk')} Backup model declaration
+ */
+static get BackupModel () {
+  return this._.CustomerOrdersBk
+}
+```
+
+```js
+// Bad example (passed to Mixins but the abstract getter is unimplemented — throws on save)
+static get Mixins () {
+  return [
+    BackupMixinModel,
+  ]
+}
+// no BackupModel getter → afterSave: ".get:BackupModel" must be inherited
+```
+
+## Mixin catalog (kinds and required abstract getters)
+
+`index.js` exports six MixinModels. `BaseMixinModel` is the base of all Mixins and is never passed
+directly; implement the abstract getters below and pass a Mixin to `Mixins` when a use arises.
+
+| Mixin | Purpose | Required abstract getter | Optional override (default) |
+| --- | --- | --- | --- |
+| `BackupMixinModel` | clone/append business attributes to another table on every save (history) | `BackupModel` | — |
+| `LatestStatusMixinModel` | keep a status history; auto-include on find and get the latest | `StatusModel` / `StatusPhaseModel` | `orderAttributeOfStatusPhaseModel` (`'savedAt'`) |
+| `SuiteVersionMixinModel` | fetch a versioned "suite" per version | `SuiteModel` | `versionKey` (`'startedAt'`) / `getSuiteSorter` |
+| `PaginationMixinModel` | provide `findAllWithPagination()` and a paging scope | none | — |
+| `ReferralMixinModel` | referral tree via invite codes (Fertile Forest) | `InviteCodeModel` / `ReferralNodeModel` | `inviteCodeAttributeOfInviteCodeModel` and others |
+| `AttributesLinearizerMixinModel` | flatten an included nested structure into each node's `dataValues` | none | — |
+
+## How to pass each mixin
+
+### BackupMixinModel (in use)
+
+In the `afterSave` hook it `build`s → `save`s the body's business attributes (all attributes
+except `id` / `createdAt` / `updatedAt` / `deletedAt`; the same exclusion as
+[timestamps.md](./timestamps.md)) into the `BackupModel` table, appending a generation. **Pass it
+to the body table (`CustomerOrder`), and `BackupModel` returns the backup table
+(`CustomerOrdersBk`)**.
+
+```js
+// Good example (body table CustomerOrder; cloned to CustomerOrdersBk on every save)
+export default class CustomerOrder extends BaseAppRenchanModel {
+  // ... the six methods (e.g. this.belongsTo(this._.Customer) in associate)
+
+  /**
+   * get: Mixin models to apply
+   *
+   * @returns {Array<Function>} Mixin models
+   */
+  static get Mixins () {
+    return [
+      BackupMixinModel,
+    ]
+  }
+
+  /**
+   * get: Backup model for BackupMixinModel
+   *
+   * @returns {typeof import('./CustomerOrdersBk')} Backup model declaration
+   */
+  static get BackupModel () {
+    return this._.CustomerOrdersBk
+  }
+}
+```
+
+- The backup table (`CustomerOrdersBk`) side is an ordinary model holding the body's business
+  attributes plus a save time (`savedAt`). Because its name clashes with the pluralized inference
+  of the class name, it declares `tableName`
+  ([default-methods.md](./default-methods.md#when-to-add-tablename)).
+
+### LatestStatusMixinModel
+
+Relates a status table via `belongsToMany(StatusModel, { through: StatusPhaseModel })`,
+auto-includes it in `beforeFind`, and returns the latest (head of `savedAt` descending) from the
+instance's `latestStatus`. To change the ordering column, override
+`orderAttributeOfStatusPhaseModel`.
+
+```js
+// How to pass (pass StatusModel / StatusPhaseModel to the body table)
+static get Mixins () {
+  return [
+    LatestStatusMixinModel,
+  ]
+}
+
+static get StatusModel () {
+  return this._.OrderStatus
+}
+
+static get StatusPhaseModel () {
+  return this._.OrderStatusPhase
+}
+```
+
+### SuiteVersionMixinModel
+
+Manages the `hasMany(SuiteModel)` "suite" by version and provides `findCurrentSuite()` /
+`findAllSuites()` / `createWithSuite()`. The version basis column is `versionKey` (default
+`'startedAt'`), pulling the latest version at or before that point. Override `getSuiteSorter` to
+change the ordering.
+
+```js
+// How to pass (pass SuiteModel; override versionKey to change it)
+static get Mixins () {
+  return [
+    SuiteVersionMixinModel,
+  ]
+}
+
+static get SuiteModel () {
+  return this._.PriceTableRow
+}
+
+static get versionKey () {
+  return 'effectiveAt' // when overriding the default 'startedAt'
+}
+```
+
+### PaginationMixinModel
+
+Adds `findAllWithPagination({ pagination, options })` and a `&pagination` scope. It builds
+`findOptions` from a `RequestPagination` and returns a `ResponsePagination` with the records. **No
+abstract getter needed** (just pass it in the array).
+
+```js
+// How to pass (just pass it; no extra getter needed)
+static get Mixins () {
+  return [
+    PaginationMixinModel,
+  ]
+}
+```
+
+### ReferralMixinModel
+
+Handles a referral tree by invite code. Provides `createByInviteCode()` / `buildByInviteCode()`,
+resolves the parent node from the invite code in `beforeCreate`, and `sprout`s a Fertile Forest
+node in `afterCreate`. Pass `InviteCodeModel` (the invite-code table) and `ReferralNodeModel` (the
+tree node).
+
+- The tree-node model returned by `ReferralNodeModel` extends `FertileForestModel` (the exception
+  in [notation.md](./notation.md#extend-baseapprenchanmodel-and-default-export)).
+
+```js
+// How to pass (pass the invite-code table and the node table)
+static get Mixins () {
+  return [
+    ReferralMixinModel,
+  ]
+}
+
+static get InviteCodeModel () {
+  return this._.CustomerInviteCode
+}
+
+static get ReferralNodeModel () {
+  return this._.CustomerReferralNode // a node table extending FertileForestModel
+}
+```
+
+### AttributesLinearizerMixinModel
+
+An instance mixin that **flattens** the nested structure read via include (the nested `entity`)
+into an array on each node's `dataValues`. Use it when you want to treat a record with relations
+as raw values at each level. **No abstract getter needed**.
+
+```js
+// How to pass (just pass it)
+static get Mixins () {
+  return [
+    AttributesLinearizerMixinModel,
+  ]
+}
+```

--- a/kit/skills/backend/hb-sequelize-model/references/notation.md
+++ b/kit/skills/backend/hb-sequelize-model/references/notation.md
@@ -1,0 +1,225 @@
+# Notation (class skeleton, imports, attribute declarations)
+
+How to declare the model class, imports, and the attributes inside `createAttributes()`.
+Referenced from `SKILL.md`. For the method ordering see [default-methods.md](./default-methods.md).
+
+## One model per file, filename matches class name
+
+One class per file, placed directly under `sequelize/models/`. The filename is the
+**(singular) PascalCase class name** (`CustomerOrder.js` / `OriginObjectCategory.js`).
+
+- **Why**: the `SequelizeActivator` in `sequelize/_.js` scans `modelsPath` and registers each
+  model by its class name. Because filename, class name, and registered name all match, other
+  models can reference it as `this._.CustomerOrder` ([associations.md](./associations.md)). If the
+  names drift apart, association resolution grabs `undefined`.
+
+## Extend BaseAppRenchanModel and default-export
+
+A model extends the shared app base **`BaseAppRenchanModel`**
+(`sequelize/baseModel/BaseAppRenchanModel.js`) and is exposed with `export default class`.
+`BaseAppRenchanModel` extends `RenchanModel` from `@openreachtech/renchan-sequelize` and is the
+layer that adds app-specific shared implementation. The class body consists only of the six
+override methods ([default-methods.md](./default-methods.md)).
+
+- **Why**: a model must never extend Sequelize's `Model` directly, nor even `RenchanModel`
+  directly. When you want to add shared behavior (helpers, default options, etc.), routing every
+  model through `BaseAppRenchanModel` lets you extend it in **one place**. Default to the more
+  extensible `BaseAppRenchanModel`; when you need to add app-specific implementation on top of
+  `RenchanModel`, define and collect it in this `BaseAppRenchanModel`.
+
+```js
+// Good example
+import {
+  ModelAttributeFactory,
+} from '@openreachtech/renchan-sequelize'
+
+import BaseAppRenchanModel from '../baseModel/BaseAppRenchanModel.js'
+
+/**
+ * CustomerOrder model
+ *
+ * @class CustomerOrder
+ * @extends {BaseAppRenchanModel}
+ */
+export default class CustomerOrder extends BaseAppRenchanModel {
+  // createAttributes / createOptions / associate / defineScopes / defineSubqueries / setupHooks
+}
+```
+
+- **Exception**: only models that handle a tree (Fertile Forest) extend `FertileForestModel`
+  (exported as `FertileForestModel` from the package; `CustomerReferralNode` is one). This
+  delegates the tree's queue/depth operations to the framework. Ordinary master / transaction
+  tables always use `BaseAppRenchanModel`.
+
+## Import only the package, the app base, and domain constants
+
+Imports are limited to the shared app base `BaseAppRenchanModel` (relative path),
+`@openreachtech/renchan-sequelize` (`ModelAttributeFactory` / Mixins / etc.), and **domain
+constants** that hold the values used in place of `ENUM` (`app/domain/*`).
+
+- **Why**: a model is a declaration-only layer. Importing business logic or external I/O gives
+  the model side effects and breaks initialization order and tests. When you need a set of
+  allowed values, pull it from a domain constant instead of a DB `ENUM` (as in
+  [timestamps.md](./timestamps.md), "values are managed in the app layer / constants").
+
+## Spread the PK from the factory
+
+Spread `...factory.ID_BIGINT` at the **top** of the object returned by `createAttributes()`. Use
+`...factory.ID_INTEGER` when you need an integer PK. Never hand-write `id`.
+
+- Build the factory with `const factory = ModelAttributeFactory.create(DataTypes)`.
+- **Why**: so you never get the `bigint` / `autoIncrement` / `primaryKey` / `allowNull:false`
+  four-piece set wrong. The PK declaration reads as a single token across every model and lines
+  up with `...factory.ID_BIGINT` on the migration side
+  (`hb-sequelize-migration`).
+
+```js
+// Good example
+static createAttributes (DataTypes) {
+  const factory = ModelAttributeFactory.create(DataTypes)
+
+  return {
+    ...factory.ID_BIGINT,
+
+    registeredAt: {
+      type: DataTypes.DATE(3),
+      allowNull: false,
+    },
+  }
+}
+```
+
+```js
+// Bad example (hand-writing id)
+return {
+  id: {
+    type: DataTypes.BIGINT,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  // ...
+}
+```
+
+## Attribute keys are camelCase, types come from DataTypes
+
+Attribute keys are **camelCase** (`registeredAt` / `questionsJson`). Do not write the physical
+column name (snake_case) on the model side — `underscored: true` maps it automatically
+([default-methods.md](./default-methods.md#createoptions-spreads-supercreateoptions-and-adds-only-extras)).
+Use the `DataTypes` in the table below.
+
+| Type | Use |
+| --- | --- |
+| `BIGINT` | PK / FK-like id |
+| `INTEGER` | small integer PK, quantity, version |
+| `STRING(n)` | variable-length string (`191` is the default length; pick `8`/`16`/`32`/`64` by use) |
+| `TEXT` | long text (body, message) |
+| `DATE(3)` | millisecond-precision datetime (`registeredAt` / `savedAt`, etc.) |
+| `BOOLEAN` | truth value (`isActive`, etc.) |
+| `JSON` | structured data (`questionsJson` / `resultJson`) |
+| `DECIMAL(p, s)` | money / rate (`dailyRate`, etc.) |
+| `BLOB('long')` | binary (uploaded file body) |
+| `ENUM(...)` | **avoid by default**. Use a domain constant + `STRING(n)` instead |
+
+- Datetimes default to `DATE(3)`. Make millisecond precision the default rather than plain `DATE`
+  (for ordering comparisons and history uniqueness).
+- Do not default string lengths to "255 for now"; choose by use (identifiers `STRING(32)`,
+  display names / emails and the like `STRING(191)`). Match the migration's physical column length.
+- **Prefer defining the TypeScript type (interface) in `type.d.ts`** and collecting it into the
+  TypeScript global namespace `model`. Do not use a JSDoc `@typedef` at the bottom of the model
+  file. Express the DataType-to-TS-type mapping on that `type.d.ts` side.
+
+## Always declare allowNull, and defaultValue when a default exists
+
+Declare **`allowNull`** on every attribute. Declare **`defaultValue`** on any column that has a
+default.
+
+- **Why**: omitting `allowNull` falls back to Sequelize's default (`true`), so the NOT NULL
+  intent is not conveyed to the reader and diverges from the migration (which declares
+  `allowNull`). Omitting `defaultValue` means the code cannot tell "what goes in when unspecified".
+- Keep the declared `allowNull` / `defaultValue` in sync with the identically named column in the
+  migration.
+
+```js
+// Good example
+category: {
+  type: DataTypes.STRING(64),
+  allowNull: false,
+  defaultValue: 'default',
+},
+isActive: {
+  type: DataTypes.BOOLEAN,
+  allowNull: false,
+  defaultValue: true,
+},
+version: {
+  type: DataTypes.INTEGER,
+  allowNull: false,
+  defaultValue: 1,
+},
+```
+
+```js
+// Bad example (allowNull omitted, default unclear)
+category: {
+  type: DataTypes.STRING(64),
+},
+```
+
+## FK-like columns start with an uppercase letter and carry a comment
+
+For a foreign-key-like column, make the attribute key **start with an uppercase letter**
+(`CustomerOrderId` / `TenantBrandId`) and write **`// ForeignKey must start with upper case.`
+immediately above it**. The type is `BIGINT`.
+
+- **Why**: Sequelize associations ([associations.md](./associations.md)) resolve the FK name by
+  the convention "`<associated model name>` + `Id`". Aligning on an uppercase start lets
+  `belongsTo(this._.CustomerOrder)` bind `CustomerOrderId` automatically; lowerCamel
+  (`customerOrderId`) fails to wire the relation. The migration side follows the same convention
+  (uppercase key + the same comment) and maps `field:` to snake (`customer_order_id`).
+- Do not drop the leading comment either, so the column reads as an FK at a glance.
+
+```js
+// Good example
+// ForeignKey must start with upper case.
+CustomerOrderId: {
+  type: DataTypes.BIGINT,
+  allowNull: false,
+},
+// A nullable FK (optional relation) also declares allowNull explicitly.
+// ForeignKey must start with upper case.
+TenantBrandId: {
+  type: DataTypes.BIGINT,
+  allowNull: true,
+},
+```
+
+```js
+// Bad example (lowerCamel, no comment; the association cannot resolve the FK)
+customerOrderId: {
+  type: DataTypes.BIGINT,
+  allowNull: false,
+},
+```
+
+## Unique constraints are enforced by the migration's named index
+
+For a column that is unique (a 1:1 relation FK, a natural key), you **may** add `unique: true`
+to the model attribute to **state intent**. The **actual constraint, however, is enforced by the
+migration's named unique index**
+(`hb-sequelize-migration`).
+
+- **Why**: the schema is built by migrations, not by `sync`. `unique: true` on the
+  model alone does not create a constraint (it has no effect on the DB). The model side is a
+  reader-facing declaration that "this column is meant to be unique"; the DB constraint is the
+  migration's job. When you write it on both sides, keep them consistent.
+
+```js
+// Good example (1:1 relation FK; the real constraint is the migration's unique index)
+// ForeignKey must start with upper case.
+CustomerOrderId: {
+  type: DataTypes.BIGINT,
+  allowNull: false,
+  unique: true,
+},
+```

--- a/kit/skills/backend/hb-sequelize-model/references/timestamps.md
+++ b/kit/skills/backend/hb-sequelize-model/references/timestamps.md
@@ -1,0 +1,74 @@
+# Timestamps (do not include created_at / updated_at in the model)
+
+Conventions for how to treat `created_at` / `updated_at` (and `deleted_at`) in the model
+declaration. Referenced from `SKILL.md`. For the migration side, see
+`hb-sequelize-migration`.
+
+## Do not write timestamp columns in attributes
+
+Do **not** put `createdAt` / `updatedAt` / `deletedAt` in the return value of
+`createAttributes()`. Leave column creation to the migration (`...factory.TIMESTAMPS`) and value
+management to `timestamps: true`
+([default-methods.md](./default-methods.md#createoptions-spreads-supercreateoptions-and-adds-only-extras)).
+
+- **Why**: these are operational columns **the application does not use** (for auditing / the
+  framework). Putting them in attributes makes them look like values you read and write in
+  business logic, and double-manages the assumptions of `practicalAttributeNames` (the list of
+  real attributes the base `RenchanModel` returns with `createdAt` / `updatedAt` / `deletedAt`
+  excluded) and `BackupMixinModel` (which excludes those same three columns when cloning).
+  Centralize column definition in the migration and value supply in the framework, and keep the
+  model's attributes to **business attributes only**.
+- `timestamps: true` is already returned by the base `createOptions()`. Do not touch `timestamps`
+  on the model side ([default-methods.md](./default-methods.md)).
+
+```js
+// Good example (business attributes only; do not write timestamps)
+static createAttributes (DataTypes) {
+  const factory = ModelAttributeFactory.create(DataTypes)
+
+  return {
+    ...factory.ID_BIGINT,
+
+    registeredAt: {
+      type: DataTypes.DATE(3),
+      allowNull: false,
+    },
+  }
+}
+```
+
+```js
+// Bad example (createdAt / updatedAt placed in attributes)
+return {
+  ...factory.ID_BIGINT,
+
+  registeredAt: {
+    type: DataTypes.DATE(3),
+    allowNull: false,
+  },
+  createdAt: {
+    type: DataTypes.DATE(3),
+    allowNull: false,
+  },
+  updatedAt: {
+    type: DataTypes.DATE(3),
+    allowNull: false,
+  },
+}
+```
+
+## If you need a business "saved-at" time, use a dedicated datetime column
+
+When you want to treat "when it was saved" as part of the business, do not repurpose `createdAt`;
+define a dedicated column with a clear meaning (`savedAt` / `postedAt` / `registeredAt` /
+`modifiedAt` / `generatedAt` / `effectiveAt`, etc., `DATE(3)`) in the attributes.
+
+- **Why**: `createdAt` is the framework's audit column and makes no guarantee about when it
+  changes operationally (backfill during migration, etc.). Split any datetime that business logic
+  may depend on into a dedicated column whose intent shows in its name. The `savedAt` / `startedAt`
+  that `BackupMixinModel` / `LatestStatusMixinModel` / `SuiteVersionMixinModel`
+  ([mixins.md](./mixins.md)) use for ordering are also such dedicated datetime columns.
+- Every name above ends with `At` because it carries a **time of day**; an attribute whose meaning
+  stops at the **calendar date** ends with `On` instead (`billedOn`). A range is two attributes
+  keeping the suffix (`modifiedAtFrom` / `modifiedAtTo`) — `From` / `To` mark the ends of a range,
+  so a single instant that means "in effect from this moment" is `effectiveAt`, not `effectiveFrom`.

--- a/kit/skills/backend/hb-sequelize-seeder/SKILL.md
+++ b/kit/skills/backend/hb-sequelize-seeder/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: hb-sequelize-seeder
+description: >
+  Write and edit renchan/Sequelize seeder files (sequelize/seeders/**/*.cjs). Use this
+  skill whenever the user asks to create or update a seeder — inserting master or
+  development data with bulkInsert / bulkDelete, choosing which directory
+  (master / dev-master / development), naming a seeder file, allocating seed-row ids,
+  or wiring TimestampSeedsSupplier. Covers the three-directory split and the db:seed:*
+  scripts, the file skeleton, filename / numbering, and the per-file id-block
+  numbering rule.
+---
+
+# Sequelize Seeders
+
+A skill for writing the `sequelize/seeders/**/*.cjs` files. Where
+`hb-sequelize-migration` builds the **physical schema** (tables,
+columns, indexes), a seeder **fills those tables with rows** via `bulkInsert`. A seed row is a plain
+object keyed by the **physical (snake_case) column names** — the same names the migration declares
+as `field:` — so a seeder is coupled to the migration, not to the model's camelCase attributes.
+
+> A concise overview. Each numbered section links to a detail file under `references/` for depth.
+
+## Core principle: a seeder is a filled-in template
+
+Every seeder has the **same skeleton**: `'use strict'` → `require` `TimestampSeedsSupplier` (+ any
+domain constants) → an intent comment → `TABLE_NAME` → one or more `seeds` arrays → `module.exports
+= { up, down }`, where `up` is `bulkInsert(TABLE_NAME, TimestampSeedsSupplier.supplyAll(seeds), {})`
+and `down` is `bulkDelete(TABLE_NAME, { id: seeds.map(it => it.id) })`. Keep the skeleton identical
+across files (the same idea as in `hb-sequelize-migration` and
+`hb-sequelize-model`) so review attention goes to the **data**, not the
+plumbing.
+
+- **Deterministic, explicit ids.** Every seed row carries an explicit `id` (never rely on
+  auto-increment), so `down` can `bulkDelete` exactly the rows `up` inserted, and so foreign-key
+  columns in other seeds can point at a known id. The id scheme is the heart of this skill (§4).
+- **Rows use physical (snake_case) column names** (`customer_id`, `unit_rate`, `is_active`) — the
+  migration's `field:` names, not the model's camelCase. `bulkInsert` writes raw columns.
+- **Comments**: structural comments in English (matching the model / migration skills); the
+  domain-explanation comments in the real seeders of this repo are often Japanese (they cite the
+  design doc / implementation plan) — match the surrounding files.
+
+```js
+// Good example (a whole single-table master seeder)
+'use strict'
+
+const TimestampSeedsSupplier = require('@openreachtech/renchan-sequelize/lib/tools/TimestampSeedsSupplier.cjs')
+
+/*
+ * Development sample: content plan rates (dev-master).
+ * In production these are created via the admin CRUD. 3 plans × 3 tiers (JPY, per month).
+ */
+
+const TABLE_NAME = 'content_plan_rates'
+
+const EFFECTIVE_AT = new Date('2024-01-01T00:00:00.000Z')
+
+const seeds = [
+  { id: 500001, plan: 'basic', tier: 'small', unit_rate: 50000, currency: 'JPY', effective_at: EFFECTIVE_AT, is_active: true },
+  { id: 500002, plan: 'basic', tier: 'medium', unit_rate: 70000, currency: 'JPY', effective_at: EFFECTIVE_AT, is_active: true },
+  { id: 500003, plan: 'basic', tier: 'large', unit_rate: 100000, currency: 'JPY', effective_at: EFFECTIVE_AT, is_active: true },
+  // ...
+]
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert(TABLE_NAME, TimestampSeedsSupplier.supplyAll(seeds), {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete(TABLE_NAME, { id: seeds.map(it => it.id) })
+  },
+}
+```
+
+## 1. Directory structure (release-split master / dev-master / development)
+
+Seeders live under `sequelize/seeders/` in three kinds of directory, each seeded by its own
+`db:seed:*` script (`--seeders-path` picks the directory). What separates them is **environment**
+(production vs dev / CI) and **kind of data** (canonical master vs operational fixtures).
+
+| Directory | Script | Environment | Purpose |
+| --- | --- | --- | --- |
+| `master-000001/`, `master-000002/`, … | `db:seed:prod` | production | **Production canonical master** data, split **one directory per release** (6-digit sequence). Applied in ascending release order. Ids are stable / meaningful, often from `app/constants/*` or small sequential. |
+| `dev-master/` | `db:seed:dev-master` | dev / CI (local + CI tests) | The **master** data used in the dev / CI environment. Re-exports the production master files (DRY), plus a few dev-only master samples that production creates via admin CRUD. |
+| `development/` | `db:seed:dev` | dev / CI (local + CI tests) | **Operational fixture** data for unit tests — rows that in production are created at runtime through operations (user lists, payment lists, …), **not** master data. Organized as `*-suite` bundles. Large blocked ids (§4). |
+
+- **Release-split master.** Each release gets its own `master-<6-digit>/` directory holding the
+  master data introduced or changed in that release; `db:seed:prod` applies the `master-*`
+  directories in ascending order, so later releases build on earlier ones and each release's master
+  additions are isolated and traceable. (The repo currently has a single pre-split `master/`; the
+  release split is the convention from here on.)
+- **dev-master vs development.** `dev-master` is the *same kind of canonical / config data as
+  production master*, just loaded for dev / CI. `development` is *operationally-created data* (users,
+  payments, …) that production never seeds — it exists only to give unit tests (local + CI)
+  something to read. Both run only in dev / CI, never in production.
+- `.directorykeeper.cjs` — a noop seeder (`up`/`down` do nothing) that keeps an otherwise-empty
+  directory tracked and safe for the runner. Do not delete it.
+- **`db:refresh` (alias `npm run r`)** rebuilds the local DB: `NODE_ENV=development` → teardown →
+  migrate → **seed:dev-master** → **seed:dev**. It does **not** run `seed:prod` — the `master-*`
+  set is for production.
+- **Re-export for DRY**: a `dev-master/` file that must be identical to production is just
+  `module.exports = require('../master-<release>/<same-name>.cjs')`, with a comment naming the
+  production master as the source of truth. Do not copy-paste the data.
+
+Details — the `.directorykeeper` no-op, the `db:seed:*` scripts table, and the full re-export
+example — are in [directory-structure.md](./references/directory-structure.md).
+
+## 2. File notation (skeleton)
+
+- **Require `TimestampSeedsSupplier`** from `@openreachtech/renchan-sequelize/lib/tools/...` (a
+  `.cjs`; seeders are CommonJS). Optionally `require` domain constants (`app/constants/*.cjs`) for
+  ids / names, so the seed and the app share one source of truth.
+- **Intent comment** (`/* ... */`) near the top: what this seed is, and its design-doc / plan
+  reference. Domain prose is Japanese in this repo.
+- **`TABLE_NAME`** is a string for a single table, or an **object** (`{ CUSTOMERS: 'customers', ...
+  }`) when one seeder fills several related tables (a "suite").
+- **`seeds` arrays** hold plain row objects: explicit `id` first, then snake_case columns. Do **not**
+  put `created_at` / `updated_at` in the rows (§5).
+- **`up`** runs `bulkInsert(TABLE, TimestampSeedsSupplier.supplyAll(seeds), {})`; **`down`** runs
+  `bulkDelete(TABLE, { id: seeds.map(it => it.id) })`.
+- **Suites insert parent → child and delete child → parent** (reverse order), so a child's FK column
+  always sees its parent row, and deletes don't orphan. (There are no DB FK constraints —
+  `hb-sequelize-migration` — but ordering still keeps the data
+  coherent and mirrors real usage.)
+- **Async fulfillment**: when a value must be computed (e.g. hashing a password via `Encipher`),
+  build the fulfilled array with `await Promise.all(seeds.map(fulfillX))` inside `up` before
+  `bulkInsert`; keep the plain `seeds` array for `down`'s id list.
+
+The full skeleton, the suite example (parent → child insert / child → parent delete), and the
+async-fulfillment example (e.g. password hashing) are in [notation.md](./references/notation.md).
+
+## 3. Naming
+
+A new seeder filename is `{timestamp}-{6-digit-seq}-{table_name}.cjs`, matching the migration
+convention (e.g. `20260717135803-000001-customers.cjs`,
+`20260717141020-000002-customers_suite.cjs`).
+
+- **`{timestamp}`** is the creation time `YYYYMMDDHHmmss` (14 digits; `date +%Y%m%d%H%M%S`); files
+  run in **ascending timestamp = creation order** (same as migrations). **`{6-digit-seq}`** is a
+  zero-padded running number (`000001`, …). **`{table_name}`** is the physical table name in
+  snake_case (a suite uses `<domain>_suite`).
+- **Order parents before children**: within a suite the file inserts parent → child; across files,
+  create the parent's seeder first so its timestamp is earlier and it runs first.
+- **Older seeders** use the previous `<8-digit-seq>-<kebab-entity>.cjs` form; leave them, and write
+  new files in the timestamp form (the
+  `hb-sequelize-migration`
+  skill made the same transition).
+- A `dev-master/` re-export **keeps the same filename** as the `master-*/` file it re-exports.
+
+Details in [naming.md](./references/naming.md).
+
+## 4. Id numbering (a 10,000-wide id block per seeder / per table)
+
+**Every seed row has an explicit `id`, and each table's rows are given a distinct id block whose
+step is 10,000.** Bases are 6-digit multiples of 10,000 **starting at `100000`** (`100000`,
+`110000`, `120000`, …); rows increment by 1 within the block, so one block holds up to ~10,000 rows.
+The same base may be reused across different suites — safe, because the rows land in different
+tables.
+
+**Development suites (`development/`)** give each table *within the suite* its own 10,000-step base
+(reused across suites):
+
+| Table position in the suite | id base | example |
+| --- | --- | --- |
+| 1st (root, e.g. `customers` / `admins`) | `100000` | `100001`, `100002`, … |
+| 2nd (`*_basics`) | `110000` | `110001`, … |
+| 3rd (`*_secrets`) | `120000` | `120001`, … |
+| 4th (`*_password_hashes`) | `130000` | `130001`, … |
+| 5th (`*_access_tokens`) | `140000` | `140101`, `140201`, … |
+
+**dev-master master samples** get one 6-digit, 10,000-wide block per file (`100000`, `110000`, …); a
+child table's block sits above its parent's so its FK ids stay readable.
+
+**Production master (`master-*/`)** is exempt from blocks: ids are small sequential (`1`…`7`) or
+taken from `app/constants` (`AI_PROVIDER.DEFAULT.ID`), because canonical data ids are stable and
+meaningful.
+
+Rules that hold across all of these:
+
+- **Bases are 6 digits (`≥ 100000`).** A `≥ 100000` id exceeds `SMALLINT`'s max (32,767 signed /
+  65,535 unsigned), so a column wrongly declared `SMALLINT` in the migration **overflows and fails
+  at seed time** — the schema mistake is caught while seeding, not in production. Never use a
+  sub-100,000 base.
+- **The step is 10,000.** Allocate the next free 6-digit multiple of 10,000 as a new seeder/table's
+  base; never overlap two blocks that could collide within a single table.
+- **A foreign-key column in a seed holds an id from the referenced table's block**
+  (`software_package_id` → the packages block, `customer_id: 100001`). This is why bases must be
+  predictable.
+- **Rows increment by 1 within a block**; for hierarchical data, use a **structured id** that still
+  fits inside the 10,000 block (access tokens use `14` + 2-digit customer + 2-digit sequence →
+  `140101`, `140201`, `140202`, all inside the `140000` block).
+- **Why**: ids stay deterministic and non-colliding within a table, so `down` deletes exactly what
+  `up` inserted, cross-seed FKs resolve, and a row's origin is readable from its id. (Blocks are
+  per-table, so reusing `100000` in both `customers` and `admins` is safe.)
+
+Details — the FK-reference and structured-id examples, and the legacy sub-6-digit `dev-master`
+blocks — are in [id-numbering.md](./references/id-numbering.md).
+
+## 5. Timestamps come from TimestampSeedsSupplier
+
+Do **not** put `created_at` / `updated_at` in seed rows. `TimestampSeedsSupplier.supplyAll(seeds)`
+injects both (set to "now") for every row; `deleted_at` defaults to null.
+
+- `supplyOne` returns `{ created_at: now, updated_at: now, ...seed }`, so a row **can override** the
+  timestamps by including its own — but normally you don't.
+- **Business datetimes are different** — a column that means something in the domain
+  (`registered_at`, `saved_at`, `effective_at`, `generated_at`, `expired_at`) **is** written
+  explicitly in the seed (it is not an audit column). This matches the model/migration split where
+  audit timestamps come from the framework and business datetimes are their own columns.
+
+Details in [notation.md](./references/notation.md).
+
+## 6. Development fixtures cover the app's operational cases
+
+A `development/` seeder is not just "some rows to read" — it must **comprehensively cover the cases
+that arise in the app's operation**, because a unit test can only exercise a branch if a matching
+fixture row exists. Cover, at minimum:
+
+- **Success cases** — normal, valid operations that go through.
+- **Failure cases** — operations rejected by a business rule (validation, insufficient balance,
+  expired, over-limit, …).
+- **Error cases** — abnormal / inconsistent states the code must still handle.
+- **Status variety within the success cases** — one row per **distinct status** an entity defines
+  (`pending` / `active` / `suspended` / `withdrawn`, …), so every status branch has a fixture.
+
+- **Why**: happy-path-only fixtures leave the failure / error / status branches with nothing to
+  read, so each test fabricates ad-hoc rows that drift from real data. Label each row's case with a
+  comment and keep it in the suite / id-block scheme (§1, §4) so the block reads as a case list.
+- This applies to `development/` (operational fixtures) only — **not** to master / dev-master, which
+  hold canonical config data, not operational case variety.
+
+Details — the case taxonomy, per-row labeling, and scoping coverage to what the app branches on —
+are in [development-coverage.md](./references/development-coverage.md).
+
+## 7. Keep every value distinct within a seeder (so a test mix-up is caught)
+
+Choose seed values so that **the same value never appears in two different columns**. When a unit
+test fails, distinct values make it obvious which column / seeder is involved, and they stop a
+column mix-up from passing silently.
+
+- **id vs FK / related columns**: never let a row's `id` and one of its other columns share a value.
+  The 6-digit 10,000-wide id blocks (§4) already put each table's ids in a different range, so a
+  row's `id` and its FK columns (which hold the *parent* table's block ids) never collide — keep it
+  that way. If `id` is `100001`, a `user_id` on the same row must sit in a different block (e.g. from
+  `110001`), never `100001`.
+- **text columns**: columns like `username` and `name` must always hold **different** strings — do
+  not reuse one value for both.
+- **Why**: if `id` and `user_id` are both `100001`, a test that accidentally reads `user_id` where it
+  meant `id` still finds a matching row and **passes** — a false positive. Distinct values make that
+  mistake fail loudly and point straight at the offending seeder (the same reasoning as keeping
+  test-case values unique).
+
+Details in [id-numbering.md](./references/id-numbering.md).
+
+## Applying to the local DB
+
+After adding or changing a seeder, rebuild the local DB with **`npm run r`** (`db:refresh`:
+teardown → migrate → seed:dev-master → seed:dev). To seed a single set without a full teardown, run
+the matching script directly (`npm run db:seed:dev-master`, `db:seed:dev`, or `db:seed:prod`).
+
+## Detail files
+
+- [directory-structure.md](./references/directory-structure.md) — release-split master / dev-master
+  / development, `.directorykeeper`, the `db:seed:*` scripts and `db:refresh` flow, the re-export
+  DRY pattern (§1)
+- [notation.md](./references/notation.md) — file skeleton, `TimestampSeedsSupplier`, `TABLE_NAME`
+  string vs object, `seeds` arrays, `bulkInsert` / `bulkDelete`, suites and insert/delete order,
+  async fulfillment, timestamps (§2, §5)
+- [naming.md](./references/naming.md) — `{timestamp}-{6-digit-seq}-{table_name}.cjs`, timestamp /
+  creation-order ordering, `_suite`, release-dir naming (§3)
+- [id-numbering.md](./references/id-numbering.md) — the 10,000-wide id-block rule, the block tables,
+  FK references, structured ids, master exemption, legacy blocks (§4); keeping every value distinct
+  across columns so a test mix-up is caught (§7)
+- [development-coverage.md](./references/development-coverage.md) — what rows a `development/` seeder
+  must hold: success / failure / error cases and status variety, and per-row case labeling (§6)

--- a/kit/skills/backend/hb-sequelize-seeder/references/development-coverage.md
+++ b/kit/skills/backend/hb-sequelize-seeder/references/development-coverage.md
@@ -1,0 +1,74 @@
+# Development fixtures cover the app's operational cases
+
+How to decide *what rows* a `development/` seeder holds. Referenced from §6 of `SKILL.md`.
+For where `development/` sits among the directories see
+[directory-structure.md](./directory-structure.md); for the suite / id-block mechanics see
+[naming.md](./naming.md) and [id-numbering.md](./id-numbering.md).
+
+## Seed every case the app can produce, not just the happy path
+
+`development/` fixtures exist so unit tests (local + CI) have realistic rows to read
+([directory-structure.md](./directory-structure.md)). A test can only exercise a branch if a row
+matching that branch already exists. So a `development/` seeder must **comprehensively cover the
+cases that arise in the app's operation**, not only the normal success path:
+
+- **Success cases** — valid, normal operations that go through.
+- **Failure cases** — operations rejected by a business rule (validation failure, insufficient
+  balance, expired window, over-limit, …). The row is well-formed but represents a "no" outcome.
+- **Error cases** — abnormal / exceptional states the code must still handle gracefully
+  (inconsistent or partially-written data, a record whose expected relation is missing, an
+  unexpected status, …).
+- **Status variety within the success cases** — even among rows that "succeed", prepare a row for
+  **every distinct status** the entity defines (e.g. a user in `pending` / `active` / `suspended` /
+  `withdrawn`), so each status branch has a fixture to read. (Those status values are illustrative;
+  use the statuses the entity actually defines.)
+
+- **Why**: if the fixtures hold only happy-path rows, tests for failure / error / status-specific
+  behavior have nothing to read, and each such test ends up fabricating its own rows inline —
+  repetitive, and drifting from the shape of real data. Comprehensive fixtures let a test pick the
+  row that matches the case under test. A missing case means that branch is either untested or
+  tested against ad-hoc data. This is the same QA stance the rest of these skills take: do not let
+  coverage be decided by whatever the fixtures happen to contain.
+
+## Make each row's case readable
+
+Because one table now holds rows for several different cases, label which case each row represents
+so a test author can pick the right one at a glance.
+
+- Add a short comment per row (or per group of rows) naming the case
+  (`// active`, `// suspended`, `// payment failed`, `// orphaned — error path`).
+- Keep the rows inside the suite structure and the 10,000-wide id block
+  ([id-numbering.md](./id-numbering.md)); group a status's rows on adjacent ids so the block reads as
+  a case list.
+
+```js
+// Good example (a customers suite covering the status range, plus a failure / error row)
+const seeds = [
+  { id: 100001, status: 'active', /* ... */ },     // active — normal
+  { id: 100002, status: 'pending', /* ... */ },    // pending — awaiting approval
+  { id: 100003, status: 'suspended', /* ... */ },  // suspended — blocked by an admin
+  { id: 100004, status: 'withdrawn', /* ... */ },  // withdrawn — soft-left
+  { id: 100005, status: 'active', /* ... */ },     // active but a downstream op will fail (failure-case source)
+  { id: 100006, status: 'active', /* ... */ },     // relation intentionally missing (error path)
+]
+```
+
+```js
+// Bad example (only the happy path — suspended / withdrawn / failure / error branches have no fixture)
+const seeds = [
+  { id: 100001, status: 'active', /* ... */ },
+  { id: 100002, status: 'active', /* ... */ },
+]
+```
+
+## Scope it to what the app actually branches on
+
+"Comprehensive" means every case the code distinguishes — not a combinatorial explosion. Enumerate
+the statuses / outcomes the app's logic actually branches on and seed one representative row per
+branch, plus the failure / error rows the paths must handle.
+
+- Where two axes interact (status × plan, say) and a test needs the combination, add that
+  combination as its own labelled row — do not try to seed every possible pair.
+- This coverage rule is for `development/` (operational fixtures) only. It does **not** apply to
+  master / dev-master, which hold canonical config data, not operational case variety
+  ([directory-structure.md](./directory-structure.md)).

--- a/kit/skills/backend/hb-sequelize-seeder/references/directory-structure.md
+++ b/kit/skills/backend/hb-sequelize-seeder/references/directory-structure.md
@@ -1,0 +1,113 @@
+# Directory structure (release-split master / dev-master / development)
+
+The three kinds of seeder directory, what each is for, the `db:seed:*` scripts, and the re-export
+DRY pattern. Referenced from §1 of `SKILL.md`.
+
+## Two axes: environment, and kind of data
+
+Every seeder directory is classified by **environment** (production vs dev / CI) and **kind of
+data** (canonical master vs operational fixtures). This is what tells you where a new seeder
+belongs.
+
+| Directory | Script (`--seeders-path`) | Environment | Kind of data |
+| --- | --- | --- | --- |
+| `master-000001/`, `master-000002/`, … | `db:seed:prod` | production | Canonical **master** (reference / config) data. |
+| `dev-master/` | `db:seed:dev-master` | dev / CI (local + CI tests) | The **master** data for dev / CI. |
+| `development/` | `db:seed:dev` | dev / CI (local + CI tests) | **Operational fixtures** for unit tests. |
+
+- **Deciding where a seeder goes**: is it canonical data the running product depends on (providers,
+  models, tools, agents, JSON schemas, wizard templates, day-rates, packages)? → master. Is it data
+  a user / operator would create at runtime (customers, admins, payments, orders)? → `development`,
+  and only to give tests something to read.
+
+## Production master is split one directory per release
+
+Production master seeders are organized into **release-numbered directories**
+`master-<6-digit>/` — `master-000001/`, `master-000002/`, `master-000003/`, … — each holding the
+master data introduced or changed in that release.
+
+- `db:seed:prod` applies the `master-*` directories **in ascending order**, so a later release
+  builds on the state left by earlier ones. Each release's master additions stay isolated and
+  traceable to the release that shipped them.
+- **Current state**: the repo still has a single, pre-split `sequelize/seeders/master/`, and
+  `db:seed:prod` targets it directly. The release split is the **convention from here on**; the
+  `db:seed:prod` script is updated to enumerate `master-*` in order when the split lands.
+- Within a release dir, files keep the normal seeder skeleton and the standard seeder filename
+  ([naming.md](./naming.md)).
+
+## dev-master vs development — the key distinction
+
+Both run **only in dev / CI** (local machines and CI test runs), never in production. What differs
+is the *kind* of data:
+
+- **`dev-master/`** — the **same kind of canonical / config data as production master**, just loaded
+  into the dev / CI database. It mostly **re-exports** the production master files (so dev / CI sees
+  exactly production's master state), plus a few dev-only master samples for data that production
+  creates through the admin CRUD rather than through a seeder (e.g. `content-plan-rates`,
+  `software-packages`).
+- **`development/`** — **operationally-created data**: rows that in production come into existence at
+  runtime through normal operation (customer lists, admin lists, payment lists, orders, …).
+  Production never seeds these. They exist purely to give **unit tests** (local + CI) realistic rows
+  to read. They are organized as `*-suite` bundles ([naming.md](./naming.md)) and use the large
+  10,000-wide id blocks ([id-numbering.md](./id-numbering.md)).
+
+- **Why keep them separate**: master data is part of the product and ships to production; fixture
+  data is test scaffolding and must never reach production. Splitting the directories keeps that
+  boundary unambiguous, and lets `db:seed:prod` load master alone while `db:refresh` loads master +
+  fixtures for local work.
+
+## The `.directorykeeper.cjs` no-op
+
+Each directory contains a `.directorykeeper.cjs` whose `up` / `down` do nothing.
+
+```js
+'use strict'
+
+module.exports = {
+  async up () {
+    // noop
+  },
+  async down () {
+    // noop
+  },
+}
+```
+
+- **Why**: it keeps an otherwise-empty directory tracked in git and gives the seeder runner a valid
+  file to load even before any real seeder exists in that directory. Do not delete it.
+
+## Scripts and the refresh flow
+
+| Script | What it does |
+| --- | --- |
+| `db:seed:prod` | seed the production `master-*` set (`--seeders-path` at the master dirs) |
+| `db:seed:dev-master` | seed `sequelize/seeders/dev-master` |
+| `db:seed:dev` | seed `sequelize/seeders/development` |
+| `db:refresh` (alias `npm run r`) | `NODE_ENV=development` → teardown → migrate → **seed:dev-master** → **seed:dev** |
+
+- `db:refresh` deliberately runs **dev-master + development** and **not** `seed:prod` — dev / CI
+  wants the master config plus the test fixtures, and the release-split `master-*` set is for
+  production.
+- After changing any seeder, run `npm run r` to rebuild the local DB (or run the single matching
+  `db:seed:*` script to load just that set without a full teardown).
+
+## Re-export a production master file (DRY)
+
+When a `dev-master/` file must be byte-for-byte the same as a production master file, do not
+copy-paste — **re-export** it. Keep the same filename ([naming.md](./naming.md)).
+
+```js
+// dev-master/20260717135803-000001-ai_models.cjs
+'use strict'
+
+/*
+ * dev-master duplicate: apply the same AI config as the production master in dev / CI (db:refresh).
+ * The real data/logic lives in the production master release dir (DRY).
+ */
+module.exports = require('../master-000001/20260717135803-000001-ai_models.cjs')
+```
+
+- **Why**: dev / CI must exercise the *exact* master rows production ships. Re-exporting keeps a
+  single source of truth (the `master-*` file); copy-pasting would let the two drift silently.
+- A `dev-master/` file that is **not** in production master (a dev-only sample) is a normal seeder,
+  not a re-export.

--- a/kit/skills/backend/hb-sequelize-seeder/references/id-numbering.md
+++ b/kit/skills/backend/hb-sequelize-seeder/references/id-numbering.md
@@ -1,0 +1,133 @@
+# Id numbering (6-digit, 10,000-wide blocks)
+
+How seed-row ids are allocated. Referenced from §4 of `SKILL.md`.
+
+## The rule: a 6-digit, 10,000-wide id block per seeder / per table
+
+**Every seed row has an explicit `id`, and each table's rows occupy a distinct id block whose step
+is 10,000.** Bases are multiples of 10,000 **at or above `100000`** (6 digits): `100000`, `110000`,
+`120000`, … Rows increment by 1 inside the block, so a block holds up to ~10,000 rows.
+
+- **Explicit ids, never auto-increment.** `down` deletes by the exact id list
+  (`seeds.map(it => it.id)`), and other seeds' FK columns point at known ids — both need the id to
+  be fixed in the source.
+- **Bases are 6 digits (`≥ 100000`).** Never use a sub-100,000 base (`1000`, `10000`, …). A 6-digit
+  id is larger than `SMALLINT`'s maximum (32,767 signed / 65,535 unsigned), so if a column was
+  mistakenly declared `SMALLINT` in the migration, the seed insert **overflows and fails at seed
+  time** — you catch the schema mistake while running the seeders, not later in production. This is
+  why ids go in the 100,000+ range rather than smaller blocks.
+- **The step is 10,000.** Allocate the next free multiple of 10,000 (at or above 100,000) as a new
+  seeder / table's base; never let two blocks overlap in a way that could collide within a single
+  table.
+- **A base may be reused across suites.** `customers` and `admins` both start at `100000` — safe,
+  because the rows land in different tables. Uniqueness only has to hold *within one table*.
+
+## Development suites: a base per table within the suite
+
+A `development/` suite gives each table *within the suite* its own 10,000-step base, and the same
+bases recur across suites:
+
+| Table position in the suite | id base | example rows |
+| --- | --- | --- |
+| 1st (root — `customers` / `admins`) | `100000` | `100001`, `100002`, … |
+| 2nd (`*_basics`) | `110000` | `110001`, `110002`, … |
+| 3rd (`*_secrets`) | `120000` | `120001`, … |
+| 4th (`*_password_hashes`) | `130000` | `130001`, … |
+| 5th (`*_access_tokens`) | `140000` | `140101`, `140201`, … |
+
+## FK columns reference the parent block's ids
+
+A seed's foreign-key column holds an id drawn from the referenced table's block, so the reference is
+readable and stable.
+
+```js
+// software_package_options rows point at software_packages rows by their block ids
+{ id: 530001, software_package_id: 520001, /* ... */ }
+{ id: 530002, software_package_id: 520002, /* ... */ }
+
+// customer_basics rows point at customers rows
+{ id: 110001, customer_id: 100001, /* ... */ }
+```
+
+- This is why bases must be **predictable**: you allocate the parent's block first, then reference
+  those exact ids from the child block.
+
+## Hierarchical rows: a structured id inside the block
+
+For rows that fan out per parent, encode the hierarchy into the id while staying **inside the
+10,000 block**. Access tokens use `14` + a 2-digit customer number + a 2-digit sequence:
+
+```js
+{ id: 140101, customer_id: 100001, /* first token of customer 01 */ }
+{ id: 140201, customer_id: 100002, /* first token of customer 02  */ }
+{ id: 140202, customer_id: 100002, /* second token of customer 02 */ }
+```
+
+- `140101` … `143001` all sit inside the `140000` block, so the structuring does not break the
+  block rule.
+
+## Production master is exempt
+
+`master-*/` canonical data does **not** use the 6-digit 10,000-wide blocks. Its ids are small
+sequential (`1`…`7`) or taken from `app/constants` (`AI_PROVIDER.DEFAULT.ID`).
+
+- **Why exempt**: master ids are part of the product — stable, meaningful, and often referenced by
+  application code through a constant. A big fixture block would obscure that. Blocks are for
+  *fixture* data (`development/`, and dev-only samples in `dev-master/`), where the goal is
+  non-collision, traceability, and (via the 6-digit range) catching a `SMALLINT` mistake, rather
+  than a meaningful value.
+
+## Why 6-digit blocks at all
+
+- **SMALLINT detection**: a `≥ 100000` id overflows a `SMALLINT` column, so a wrong column type
+  fails at seed time instead of silently truncating.
+- **Deterministic**: `down` removes exactly what `up` inserted.
+- **Non-colliding within a table**: two seeders never fight over an id in the same table.
+- **Cross-seed FKs resolve**: a child seed can hard-reference a parent id because the parent's block
+  is known.
+- **Traceable**: a row's id tells you which seeder / table it came from at a glance.
+
+## Keep different columns' values distinct (so a test mix-up is caught)
+
+Beyond ids, choose seed values so that **the same value never appears in two different columns**. The
+block scheme already does this for ids — a row's `id` (its own table's block) and its FK columns
+(the *parent* table's block) always fall in different ranges, so they never share a value. Extend the
+same discipline to every column.
+
+- **id vs same-row FK / numeric columns**: keep them in different ranges. If a row's `id` is
+  `100001`, a `user_id` on that row must sit in a different block (e.g. from `110001`), never
+  `100001`. With the 6-digit 10,000-wide blocks this is automatic (`id: 110001` alongside
+  `customer_id: 100001`) — do not flatten them back onto the same value.
+- **text columns**: give `username` and `name` (or any two string columns) **different** values;
+  never reuse one string for both.
+- **Why**: if `id` and `user_id` are both `100001`, a unit test that accidentally reads `user_id`
+  where it meant `id` still matches a row and **passes** — a false positive that hides the bug.
+  Distinct values make the mistake fail loudly, and make it obvious, from the value in the failure
+  output, which seeder and column are involved. (This is the seeder counterpart of keeping test-case
+  values unique.)
+
+```js
+// Bad example (id == user_id, and username == name — a column mix-up would pass silently)
+{ id: 100001, user_id: 100001, username: 'taro', name: 'taro' }
+
+// Good example (every column in its own value range / space)
+{ id: 110001, user_id: 100001, username: 'user-110001', name: 'Alpha Taro' }
+```
+
+## Blocks already in use
+
+These tables already occupy the following 6-digit blocks; do not reuse a base for a new seeder in
+the same table:
+
+| Table | id base |
+| --- | --- |
+| `content_plan_rates` | `500000` |
+| `content_benchmark_samples` | `510000` |
+| `software_packages` | `520000` |
+| `software_package_options` | `530000` |
+| `integration_clients` | `600000` |
+
+- A child table's block sits above its parent's so FK ids stay readable
+  (`software_package_options` `530000` references `software_packages` `520000`).
+- Older seeders that were written before the 6-digit rule and still sit on a narrower / sub-6-digit
+  block should be renumbered into a 6-digit block (above) the next time they are touched.

--- a/kit/skills/backend/hb-sequelize-seeder/references/naming.md
+++ b/kit/skills/backend/hb-sequelize-seeder/references/naming.md
@@ -1,0 +1,59 @@
+# Naming (filename, ordering, suites)
+
+How to name a seeder file and why the ordering matters. Referenced from §3 of `SKILL.md`.
+
+## Filename `{timestamp}-{6-digit-seq}-{table_name}.cjs`
+
+A new seeder filename is a creation timestamp, a 6-digit running sequence, then the table name:
+`20260717135803-000001-customers.cjs`, `20260717140512-000002-content_plan_rates.cjs`.
+
+- **`{timestamp}`** is the creation time `YYYYMMDDHHmmss` (14 digits; `date +%Y%m%d%H%M%S`), matching
+  the migration convention
+  (`hb-sequelize-migration`).
+  Files are applied in **ascending timestamp order** — i.e. in creation-time order.
+- **`{6-digit-seq}`** is a zero-padded running number (`000001`, `000002`, …). It orders files that
+  share a timestamp and doubles as a human-facing identifier.
+- **`{table_name}`** is the physical table name in **snake_case** — the same name as the seeder's
+  `TABLE_NAME` and the migration's table. For a **suite** that fills several related tables, use the
+  domain root + `_suite` (`customers_suite`, `admin_roles_suite`).
+- Examples: `20260717135803-000001-customers.cjs`,
+  `20260717141020-000002-customers_suite.cjs`,
+  `20260717142230-000003-ai_model_tool_assignments.cjs`.
+- **Older seeders** predate this and use the `<8-digit-seq>-<kebab-entity>.cjs` form
+  (`00050002-ai-models.cjs`). Leave them as-is; write **new** files in the timestamp form above.
+
+## Ordering is by timestamp (creation order) — seed parents before children
+
+sequelize-cli runs seeders in **filename order**, which under this scheme is **ascending timestamp =
+creation order** (the same as migrations). A child seed can only reference a parent id that already
+exists, so the parent's rows must be inserted first.
+
+- **Within a suite**, the file itself inserts parent → child (and deletes child → parent), so most
+  FK dependencies are satisfied inside the one file ([notation.md](./notation.md)).
+- **Across files**, create the parent's seeder **before** the child's, so its timestamp is earlier
+  and it runs first. (This replaces the older scheme, where an 8-digit prefix mirrored the migration
+  domain group to force the order; with timestamps, creation order does the same job.)
+
+## Suites bundle a domain's tables under one `_suite` file
+
+A `*_suite.cjs` file seeds a whole cluster of related tables in one place (root + its dependent
+tables), with `TABLE_NAME` as an object and parent→child insert / child→parent delete
+([notation.md](./notation.md)).
+
+- Use a suite when the tables are only meaningful together (a customer plus its basics, secrets,
+  password hash, access tokens). Use a plain single-table name otherwise.
+
+## Production master: release directory naming
+
+Production master files live under a release-numbered directory `master-<6-digit>/`
+(`master-000001/`, `master-000002/`, …) — [directory-structure.md](./directory-structure.md). The
+release number lives on the **directory**; the **file** inside uses the standard seeder filename.
+
+## A dev-master re-export keeps the same filename
+
+A `dev-master/` file that re-exports a production master file
+([directory-structure.md](./directory-structure.md)) **keeps the identical filename** as the
+`master-*/` file it points at.
+
+- **Why**: matching filenames make the correspondence obvious and keep the two directories aligned
+  file-for-file, so it is easy to see which production master files have a dev / CI counterpart.

--- a/kit/skills/backend/hb-sequelize-seeder/references/notation.md
+++ b/kit/skills/backend/hb-sequelize-seeder/references/notation.md
@@ -1,0 +1,170 @@
+# Notation (file skeleton, seeds, bulkInsert / bulkDelete, timestamps)
+
+The skeleton of a seeder file, how to write the `seeds` arrays, the `up` / `down` bodies, suites,
+async fulfillment, and how timestamps are supplied. Referenced from §2 and §5 of `SKILL.md`. For
+the directory split see [directory-structure.md](./directory-structure.md); for ids see
+[id-numbering.md](./id-numbering.md).
+
+## CommonJS, require the supplier (and any constants)
+
+A seeder is a `.cjs` (CommonJS) file. Start with `'use strict'`, then **`require`
+`TimestampSeedsSupplier`**. Optionally `require` domain constants so the seed and the app share one
+source of truth for ids / names.
+
+```js
+'use strict'
+
+const TimestampSeedsSupplier = require('@openreachtech/renchan-sequelize/lib/tools/TimestampSeedsSupplier.cjs')
+
+const {
+  AI_PROVIDER,
+} = require('../../../app/constants/aiModel.cjs')
+```
+
+- **Why**: sequelize-cli loads seeders as CommonJS. `TimestampSeedsSupplier` injects the audit
+  timestamps (see below). Pulling ids / names from `app/constants/*` keeps a canonical value in one
+  place instead of hard-coding it in both the app and the seed.
+
+## Intent comment, then `TABLE_NAME`
+
+Put a `/* ... */` comment near the top saying what the seed is and its design-doc / plan reference
+(domain prose is Japanese in this repo). Declare `TABLE_NAME` as a **string** for a single table, or
+an **object** when one file fills several related tables (a "suite").
+
+```js
+// single table
+const TABLE_NAME = 'ai_providers'
+```
+
+```js
+// suite (several related tables in one file)
+const TABLE_NAME = {
+  CUSTOMERS: 'customers',
+  CUSTOMER_BASICS: 'customer_basics',
+  CUSTOMER_ACCESS_TOKENS: 'customer_access_tokens',
+}
+```
+
+## `seeds` arrays use physical (snake_case) column names + explicit id
+
+Each `seeds` array holds plain row objects. Keys are the **physical column names (snake_case)** —
+the migration's `field:` names, **not** the model's camelCase — because `bulkInsert` writes raw
+columns. Every row starts with an explicit `id` ([id-numbering.md](./id-numbering.md)). Do **not**
+put `created_at` / `updated_at` in the rows (see "Timestamps" below).
+
+```js
+const seeds = [
+  { id: AI_PROVIDER.DEFAULT.ID, name: AI_PROVIDER.DEFAULT.NAME },
+]
+```
+
+```js
+// FK columns are snake_case and hold an id from the referenced table's block
+const seeds = [
+  { id: 530001, software_package_id: 520001, name: 'Email integration', additional_cost: 500000, is_active: true },
+  { id: 530002, software_package_id: 520001, name: 'Advanced reporting', additional_cost: 800000, is_active: true },
+  { id: 530003, software_package_id: 520002, name: 'Multi-currency', additional_cost: 1000000, is_active: true },
+]
+```
+
+- **Why snake_case**: the seed is coupled to the physical schema (the migration), not to the model.
+  A camelCase key would write the wrong column.
+
+## `up` = bulkInsert(supplyAll(seeds)); `down` = bulkDelete by id
+
+`module.exports` has an `async up` and `async down`, each taking `(queryInterface, Sequelize)`.
+
+```js
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert(TABLE_NAME, TimestampSeedsSupplier.supplyAll(seeds), {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete(TABLE_NAME, { id: seeds.map(it => it.id) })
+  },
+}
+```
+
+- `up` inserts `TimestampSeedsSupplier.supplyAll(seeds)` (the rows with audit timestamps added). The
+  third `{}` is `bulkInsert`'s options.
+- `down` deletes exactly the rows `up` inserted, by their explicit id list
+  (`{ id: seeds.map(it => it.id) }`). This is why every row needs a stable, explicit `id`.
+
+## Suites: insert parent → child, delete child → parent
+
+When a file fills several related tables, insert **parent before child** in `up` (a child's FK
+column must see its parent row) and delete **child before parent** in `down` (reverse order).
+
+```js
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert(TABLE_NAME.CUSTOMERS, TimestampSeedsSupplier.supplyAll(customersSeeds), {})
+    await queryInterface.bulkInsert(TABLE_NAME.CUSTOMER_BASICS, TimestampSeedsSupplier.supplyAll(customerBasicsSeeds), {})
+    await queryInterface.bulkInsert(TABLE_NAME.CUSTOMER_ACCESS_TOKENS, TimestampSeedsSupplier.supplyAll(customerAccessTokensSeeds), {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete(TABLE_NAME.CUSTOMER_ACCESS_TOKENS, { id: customerAccessTokensSeeds.map(it => it.id) })
+    await queryInterface.bulkDelete(TABLE_NAME.CUSTOMER_BASICS, { id: customerBasicsSeeds.map(it => it.id) })
+    await queryInterface.bulkDelete(TABLE_NAME.CUSTOMERS, { id: customersSeeds.map(it => it.id) })
+  },
+}
+```
+
+- **Why**: there are no DB FK constraints (`hb-sequelize-migration`),
+  but ordering still keeps the data coherent (no child row referencing a not-yet-inserted parent)
+  and mirrors how the app writes these rows.
+
+## Async fulfillment (computed values such as password hashes)
+
+When a value must be computed (hashing a raw password, etc.), build the fulfilled array with
+`await Promise.all(...)` inside `up` before `bulkInsert`. Keep the plain `seeds` array for `down`'s
+id list.
+
+```js
+const encipher = Encipher.create()
+
+async function fulfillPasswordHash ({ id, customer_id, raw_password, saved_at }) {
+  const password_hash = await encipher.hash(raw_password)
+
+  return { id, customer_id, saved_at, password_hash }
+}
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const fulfilled = await Promise.all(
+      customerPasswordHashesSeeds.map(it => fulfillPasswordHash(it))
+    )
+
+    await queryInterface.bulkInsert(TABLE_NAME.CUSTOMER_PASSWORD_HASHES, TimestampSeedsSupplier.supplyAll(fulfilled), {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete(TABLE_NAME.CUSTOMER_PASSWORD_HASHES, { id: customerPasswordHashesSeeds.map(it => it.id) })
+  },
+}
+```
+
+- **Why**: seeds are data-only; when a column's value is derived, compute it at seed time rather than
+  storing a fake constant. The raw source (`raw_password`) stays in the plain array so `down` can
+  still map ids.
+
+## Timestamps come from TimestampSeedsSupplier
+
+Do **not** write `created_at` / `updated_at` in seed rows. `TimestampSeedsSupplier.supplyAll(seeds)`
+adds both to every row.
+
+```js
+// TimestampSeedsSupplier.supplyOne returns:
+{ created_at: now, updated_at: now, ...seed }
+```
+
+- Because `...seed` is spread **after** the timestamps, a row **can override** them by including its
+  own `created_at` / `updated_at` — but normally you don't. `deleted_at` is left unset (defaults to
+  null).
+- **Business datetimes are different.** A column that means something in the domain
+  (`registered_at`, `saved_at`, `effective_at`, `generated_at`, `expired_at`) **is** written
+  explicitly in the seed — it is not an audit column. This matches the model / migration split where
+  audit timestamps come from the framework and business datetimes are their own columns
+  (`hb-sequelize-migration`).

--- a/kit/skills/backend/hb-sequelize-subquery/SKILL.md
+++ b/kit/skills/backend/hb-sequelize-subquery/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: hb-sequelize-subquery
+description: >
+  Define and consume named Sequelize subqueries on renchan models (this.addSubquery inside
+  defineSubqueries in sequelize/models/*.js, consumed via Model.subquery(name, params) under Op.in
+  in a where clause). Use this skill whenever a query must filter rows by a condition on a related
+  / associated table — in this convention that is a subquery, not a JOIN — or whenever the user
+  asks to define, name, or test a subquery.
+---
+
+# Sequelize Subquery
+
+A skill for defining **named, reusable `SELECT`s** attached to a Sequelize model, and consuming
+them from a resolver's `where` clause. A subquery is registered once on the model with
+`this.addSubquery({ name, generator })` and consumed with `Model.subquery(name, params)`, which
+returns a `Sequelize.Literal` (a real SQL subquery) — so you filter one model by the result of a
+`SELECT` against another without writing a join or a raw SQL string at the call site.
+
+Registration lives in `static defineSubqueries()`, one of the six extension points of the model
+skeleton defined in `hb-sequelize-model` (an unused `defineSubqueries` stays as a noop there; this
+skill covers what to write when it *is* used). The consuming side (building a resolver's
+`where` clause) belongs to `hb-query-resolver` / `hb-mutation-resolver`; testing follows `hc-jest`.
+
+## Grand principle: the name is the query — a self-describing string registered on the model
+
+The subquery API comes from `RenchanModel` in `@openreachtech/renchan-sequelize` — **never roll
+your own** (no raw `Sequelize.literal('SELECT ...')` at a call site, no ad-hoc join to express a
+cross-table filter). Register the `SELECT` on the model that owns it, and give it a name that
+**encodes exactly its `where` conditions and its `select` columns**:
+
+```
+?<cond1>[<op1>]?<cond2>[<op2>].<result1>.<result2>
+```
+
+- **Condition columns (the `where`)** each start with `?`. The operator goes in square brackets
+  `[...]` immediately after the column name; a plain equality has **no** brackets.
+- **Result columns (the `select`)** each start with `.`.
+- **The table name never appears in the name.** The subquery is added to a target model, so the
+  table is self-evident from the model — the name encodes only conditions and results.
+- **Why a self-describing name**: the consumer reads `'?CustomerId.id'` and knows, without
+  opening the model, that it means "`WHERE customer_id = ?`, `SELECT id`". A free-form name
+  (`'ordersOfCustomer'`) forces every reader back to the definition, and drifts silently when
+  the definition changes.
+- **Why registered on the model, not inlined at the call site**: the same cross-table filter is
+  typically needed by several resolvers. A raw literal written inline duplicates SQL strings,
+  escapes nothing into the model layer, and cannot be unit-tested as a pure generator.
+
+```js
+// Good: consume a named subquery registered on the model
+const customerOrderSubquery = CustomerOrder.subquery('?CustomerId.id', {
+  customerId,
+})
+
+const whereClause = {
+  CustomerOrderId: {
+    [Op.in]: customerOrderSubquery,
+  },
+}
+```
+
+```js
+// Avoid: raw SQL literal at the call site
+//   → duplicates the SELECT wherever it is needed, leaks physical column names
+//     into the resolver, and cannot be tested as a pure generator.
+const whereClause = {
+  CustomerOrderId: {
+    [Op.in]: Sequelize.literal(
+      `(SELECT id FROM customer_orders WHERE customer_id = ${customerId})`
+    ),
+  },
+}
+```
+
+## Comment language in the sample code
+
+Comments in the `js` examples in this SKILL.md follow the prose language (here, **English**),
+because the examples are *explanation* of the skill. Comments inside the **artifact this skill
+produces** (the real model / resolver code) follow the **codebase** language — English — to match
+the surrounding source.
+
+## 1. When to reach for a subquery
+
+Reach for a subquery when a resolver needs to constrain rows of model A by a condition that
+lives on model B. Typical cases:
+
+| Requirement | Shape |
+| --- | --- |
+| "Payments of the orders that belong to this customer" | Filter `OrderPayment` by `CustomerOrderId IN (SELECT id FROM customer_orders WHERE customer_id = ?)` |
+| "Shipments whose **latest status** is in a given set" | Filter `Shipment` by `id IN (SELECT shipment_id FROM shipment_latest_statuses WHERE shipment_status_id IN (...))` |
+| "Coupons valid **at** a point in time" | Filter by `id IN (SELECT coupon_id FROM coupon_settings WHERE valid_from <= ? AND valid_until >= ?)` |
+
+- The subquery is defined **on the model that owns the condition columns** (the model whose
+  table the inner `SELECT` reads), and its result columns are what the outer `where` matches
+  against (usually an id / FK column).
+- If the requirement is "load B *together with* A for output", that is an `include` association
+  (`hb-sequelize-model` → associations), not a subquery. A subquery is for **filtering**, not
+  eager-loading.
+
+## 2. Naming convention and operator table
+
+The operator inside `[...]` maps to a Sequelize `Op` symbol in the generator's `where`:
+
+| format | meaning |
+| :-- | :-- |
+| (none) | set as value directly (plain equality) |
+| `[=]` | `Op.eq` |
+| `[>]` | `Op.gt` |
+| `[>=]` | `Op.gte` |
+| `[<]` | `Op.lt` |
+| `[<=]` | `Op.lte` |
+| `[in]` | `Op.in` |
+| `[between]` | `Op.between` |
+| `[like]` | `Op.like` |
+
+- **"Set as value directly"**: when a condition is a plain equality, omit the brackets and
+  assign the value straight onto the field — `?CustomerId.id` with a `where` of
+  `{ [CustomerIdField]: customerId }`.
+- Reading examples:
+  - `?CustomerId.id` — "`WHERE CustomerId = ?`, `SELECT id`"
+  - `?ShipmentStatusId[in].ShipmentId` — "`WHERE ShipmentStatusId IN (...)`, `SELECT ShipmentId`"
+  - `?validFrom[<=].validUntil[>=].CouponId` — two conditions, each with its own operator
+  - `?OriginObjectCategoryId?jobDivisionNumber.id` — two equality conditions (no brackets), one result
+
+## 3. Register the subquery in `defineSubqueries()`
+
+Register inside `static defineSubqueries()`. Call `super.defineSubqueries?.()` first (as with
+every extension point in `hb-sequelize-model` — otherwise a Mixin's base behavior is lost),
+read the physical field names off `this.getAttributes()`, then add each subquery with
+`this.addSubquery({ name, generator })`.
+
+The `generator` receives a params object and returns `{ attributes, where }`:
+
+- `attributes` — the `SELECT` column list, as **DB field names** (take them from
+  `this.getAttributes().<key>.field`, never hard-code snake_case strings).
+- `where` — a Sequelize where clause, keyed by DB field names, using the `Op` symbols that the
+  subquery name declares.
+
+**Basic example** (single equality condition, single result):
+
+```js
+/**
+ * Define model subqueries
+ *
+ * @override
+ */
+static defineSubqueries () {
+  super.defineSubqueries?.()
+
+  const allAttributes = this.getAttributes()
+  const idField = allAttributes.id.field
+  const CustomerIdField = allAttributes.CustomerId.field
+
+  this.addSubquery({
+    name: '?CustomerId.id',
+    generator: ({
+      customerId,
+    }) => {
+      const attributes = [
+        idField,
+      ]
+
+      const whereClause = {
+        [CustomerIdField]: customerId,
+      }
+
+      return {
+        attributes,
+        where: whereClause,
+      }
+    },
+  })
+}
+```
+
+**Advanced example** (two conditions, each with its own operator, single result):
+
+```js
+this.addSubquery({
+  name: '?validFrom[<=].validUntil[>=].CouponId',
+  generator: ({
+    now,
+  }) => {
+    const attributes = [
+      CouponIdField,
+    ]
+
+    const whereClause = {
+      [validFromField]: {
+        [SequelizeOp.lte]: now,
+      },
+      [validUntilField]: {
+        [SequelizeOp.gte]: now,
+      },
+    }
+
+    return {
+      attributes,
+      where: whereClause,
+    }
+  },
+})
+```
+
+- The `Op` symbols come from the top of the model file:
+
+```js
+import {
+  Op as SequelizeOp,
+} from 'sequelize'
+```
+
+- **The name and the generator must agree.** Every `?` column in the name appears in `where`
+  with exactly the operator its brackets declare; every `.` column appears in `attributes`.
+  A name that says `[in]` while the generator assigns a direct value is a bug — the name is
+  the contract.
+
+## 4. Consume via `Model.subquery(name, params)` under `Op.in`
+
+Call `Model.subquery(name, params)` — it returns a `Sequelize.Literal` — and drop it into a
+`where` clause, almost always as the right-hand side of an `Op.in`. Typical resolver usage
+(inside a `buildXxxWhereClause()` method, per `hb-query-resolver`):
+
+```js
+import {
+  Op,
+} from 'sequelize'
+
+// ...
+
+/**
+ * Build where clause for shipments.
+ *
+ * @param {{
+ *   tenantBrandId: number
+ * }} params - Parameters.
+ * @returns {object} Where clause.
+ */
+buildShipmentWhereClause ({
+  tenantBrandId,
+}) {
+  const shipmentLatestStatusSubquery = ShipmentLatestStatus.subquery(
+    '?ShipmentStatusId[in].ShipmentId',
+    {
+      shipmentStatusIds: [SHIPMENT_STATUS.READY_TO_SHIP.ID],
+    }
+  )
+
+  const whereClause = {
+    TenantBrandId: tenantBrandId,
+    id: {
+      [Op.in]: shipmentLatestStatusSubquery,
+    },
+  }
+
+  return whereClause
+}
+```
+
+Combining two subqueries on the same column uses `Op.and`:
+
+```js
+return {
+  ...whereClause,
+  id: {
+    [Op.and]: [
+      {
+        [Op.in]: shipmentLatestStatusSubquery,
+      },
+      {
+        [Op.in]: desiredDeliveryDateSubquery,
+      },
+    ],
+  },
+}
+```
+
+- Calling `Model.subquery(name, ...)` with a name that was never registered throws
+  `invalid subquery ${name} called.` — the name string at the call site must match the
+  registered name character for character.
+
+## 5. Testing
+
+Test the **generator**, not the SQL string. Pull it with
+`Model.getSubqueryOptionsGenerator(name)`, invoke it with `params`, and assert the returned
+`{ attributes, where }` with a single `toEqual`. The generator is pure (no DB access), so the
+test needs no seeder and lives under `tests/__tests__/sequelize/models/` (per `hc-jest` —
+DB-writing tests are the ones that go elsewhere).
+
+Structure: `describe('<Model>')` → `describe('.subquery')` → `describe('<subquery name>')` →
+`test.each`. Import `Op` from `sequelize` so the expected `where` carries the real operator
+symbols.
+
+```js
+import {
+  Op,
+} from 'sequelize'
+
+import ShipmentLatestStatus from '../../../../sequelize/models/ShipmentLatestStatus.js'
+
+describe('ShipmentLatestStatus', () => {
+  describe('.subquery', () => {
+    describe('?ShipmentStatusId[in].ShipmentId', () => {
+      const cases = [
+        {
+          params: {
+            shipmentStatusIds: [10001, 10002],
+          },
+          expected: {
+            attributes: ['shipment_id'],
+            where: {
+              shipment_status_id: {
+                [Op.in]: [10001, 10002],
+              },
+            },
+          },
+        },
+        {
+          params: {
+            shipmentStatusIds: [10003],
+          },
+          expected: {
+            attributes: ['shipment_id'],
+            where: {
+              shipment_status_id: {
+                [Op.in]: [10003],
+              },
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('shipmentStatusIds[0]: $params.shipmentStatusIds.0', ({
+        params,
+        expected,
+      }) => {
+        const generator = ShipmentLatestStatus.getSubqueryOptionsGenerator('?ShipmentStatusId[in].ShipmentId')
+
+        const actual = generator(params)
+
+        expect(actual)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+```
+
+Conventions to keep (details in `hc-jest`):
+
+- **`test.each`, prefer ≥ 2 cases** (vary the params); a trivial single-condition subquery may
+  use one case. Vary exactly one `params` field in the title and keep it unique per case — dot
+  into an array element as needed (`$params.shipmentStatusIds.0`).
+- **Cases are `{ params, expected }`** — no other keys unless justified.
+- **One `toEqual`** for the whole returned object; build the full `expected` (including `Op`
+  symbols) and compare once.
+- **AAA, no logic in the body** — arrange the generator, act by calling it, assert.
+- The expected `attributes` / `where` keys are the **DB field names** (snake_case) — that is
+  what the generator returns, and it verifies the attribute-to-field mapping too.
+- Test a subquery against real seeded data only when exercising it end-to-end through a
+  resolver that reads the DB — that is a resolver test, placed per `hc-jest`'s directory rules.
+
+## Finishing checklist
+
+- [ ] Does the subquery live in `static defineSubqueries()` on the model that owns the condition columns, added via `this.addSubquery({ name, generator })` (no raw `Sequelize.literal` at call sites)?
+- [ ] Does `defineSubqueries()` call `super.defineSubqueries?.()` first, and take field names from `this.getAttributes()` (no hard-coded snake_case strings)?
+- [ ] Does the name follow `?<condition>[<operator>].<result>` — every `?` column in `where` with exactly the declared operator, every `.` column in `attributes`, no brackets for plain equality, and **no table name**?
+- [ ] Does the generator return `{ attributes, where }` keyed by **DB field names**?
+- [ ] Does the consumer call `Model.subquery(name, params)` under `Op.in` (with `Op.and` when combining two subqueries on the same column), with the name matching the registration exactly?
+- [ ] Is the generator tested via `Model.getSubqueryOptionsGenerator(name)` with `test.each` `{ params, expected }` cases and a single `toEqual` (including the real `Op` symbols), placed under `tests/__tests__/sequelize/models/`?

--- a/kit/skills/backend/hb-strategy-pattern/SKILL.md
+++ b/kit/skills/backend/hb-strategy-pattern/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: hb-strategy-pattern
+description: >
+  Implement the strategy pattern as a trio of a base processor class, one concrete subclass per
+  variant, and a bulk loader that auto-discovers the subclasses from a directory and picks one by
+  a dispatch getter. Use this skill whenever the user asks to replace an else-if / switch chain
+  that dispatches on a "type" string with pluggable processor classes, or to add a new event /
+  webhook / message handler that must be auto-discovered.
+---
+
+# Strategy Pattern (processor classes + a bulk loader)
+
+A skill for dispatching on a string "type" value to one of several behaviors **without an
+`else if` / `switch` chain**. Each branch becomes a class; a loader auto-discovers the classes
+from a directory and picks one by a dispatch **getter**. The class skeleton each piece follows
+(one file / one class, `static create()` factory, JSDoc typedefs) comes from `class-design` —
+this skill covers how the three pieces fit together.
+
+Reach for it when:
+
+- You would otherwise write `if (type === 'a') ... else if (type === 'b') ...`.
+- New variants get added over time and you want to drop a file in a folder, not edit a switch.
+- Each branch has non-trivial logic worth testing in isolation.
+
+Do **not** reach for it for a 2-branch boolean or a value map with no behavior — a plain
+lookup hash is enough there.
+
+## Grand principle: adding a variant means adding a file, never editing a dispatch chain
+
+Every rule in this skill serves one point: **the set of variants is discovered from the
+filesystem, not listed in code**. A new variant is one new subclass file dropped into the
+processor directory; no existing file changes.
+
+- **Why not a switch**: an `else if` / `switch` chain concentrates every variant's wiring in one
+  function, so every new variant edits (and risks breaking) shared code, and each branch's logic
+  can't be tested in isolation. One-class-per-variant keeps each branch independently testable
+  and reviewable.
+- **Why auto-discovery**: if the loader imported each subclass by name, the "chain" would just
+  move into the import list. Loading every class in the directory
+  ([4](#4-bulk-loader-auto-discover-and-pick-by-getter)) makes the directory itself the
+  registry.
+- **Why dispatch by getter**: the key a processor handles is part of that processor's contract,
+  so it lives **on the subclass** as an overridden getter — not in a name field passed from
+  outside, and not in a mapping table kept next to the loader.
+
+```js
+// Good: the caller asks the loader; variants stay out of the call site
+const processor = loader.resolveProcessor(eventCategory)
+
+if (!processor) {
+  return null
+}
+
+return processor.process({
+  event,
+})
+```
+
+```js
+// Avoid: an else-if chain enumerating every variant at the call site
+//   → every new variant edits this shared function; branches can't be tested in isolation
+if (eventCategory === 'created') {
+  return handleCreated(event)
+} else if (eventCategory === 'updated') {
+  return handleUpdated(event)
+} else if (eventCategory === 'deleted') {
+  return handleDeleted(event)
+}
+```
+
+## Comment language in the sample code
+
+Comments in the `js` examples in this SKILL.md follow the prose language (here, **English**),
+because the examples are *explanation* of the skill. Comments inside the **artifact this skill
+produces** (the real processor / loader code) follow the **codebase** language — English — to
+match the surrounding source.
+
+## 1. The three pieces
+
+| Piece | Role | Count |
+| --- | --- | --- |
+| Base class | Declares the `static create()` factory, the abstract dispatch **getter** (throws until overridden), and the abstract work method (throws until overridden) | 1 |
+| Concrete subclasses | One file per variant; each overrides the dispatch getter to return its key and overrides the work method | 1 per variant |
+| Bulk loader | `static async createAsync()` loads every class in the processor directory via `DeepBulkClassLoader`, instantiates each; `resolveProcessor(key)` finds the one whose dispatch getter matches, `?? null` | 1 |
+
+Typical layout (a payment-gateway webhook example):
+
+```
+app/tools/eventProcessors/
+├── BaseEventProcessor.js
+├── concretes/
+│   ├── CreateEventProcessor.js
+│   ├── UpdateEventProcessor.js
+│   └── DeleteEventProcessor.js
+app/tools/bulkLoaders/
+└── BulkEventProcessorsLoader.js
+```
+
+## 2. Base class: an abstract getter + an abstract work method
+
+Dispatch is **by getter**, not by a `processorName` field or a `static getName()`. The getter
+throws until a subclass overrides it. `static create()` is the factory; the work method is
+abstract and also throws. Throwing abstract members are the whole "interface" — there is no
+TypeScript interface to implement.
+
+```js
+/**
+ * Base class for event processors.
+ */
+export default class BaseEventProcessor {
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof BaseEventProcessor ? X : never} T, X
+   * @param {BaseEventProcessorFactoryParams} params - Parameters for the factory.
+   * @returns {InstanceType<T>} An instance of the class.
+   * @this {T}
+   */
+  static create (params) {
+    return /** @type {InstanceType<T>} */ (
+      new this(params)
+    )
+  }
+
+  /**
+   * get: Dispatch key this processor handles.
+   *
+   * @abstract
+   * @returns {string}
+   * @throws {Error} - When not overridden in a subclass.
+   */
+  get eventCategory () {
+    throw new Error('eventCategory must be implemented in subclass')
+  }
+
+  /**
+   * Process the event.
+   *
+   * @abstract
+   * @param {EventProcessorParams} params - Parameters for processing.
+   * @returns {Promise<*>}
+   * @throws {Error} - When not overridden in a subclass.
+   */
+  async process ({
+    event,
+  }) {
+    throw new Error('process must be implemented in subclass')
+  }
+}
+
+/**
+ * @typedef {object} EventProcessorParams
+ * @property {*} event - The event to process.
+ */
+
+/**
+ * @typedef {{
+ *   [key: string]: *
+ * }} BaseEventProcessorFactoryParams
+ */
+```
+
+- When a processor needs collaborators, take them as constructor deps and default them in
+  `create()` (e.g. `static create ({ randomTextGenerator = this.createRandomTextGenerator() } = {})`),
+  following `class-design`. Keep that shape rather than `new`-ing collaborators inside the work
+  method.
+
+## 3. Concrete subclass: one file per variant
+
+Override the dispatch getter (mark it `@override`) to return the key **from a shared constant
+hash, not a bare string literal**, and override the work method. `static create()` is inherited
+from the base — subclasses only redefine it when they need extra defaults.
+
+```js
+import BaseEventProcessor from '../BaseEventProcessor.js'
+
+import CONSTANT from '../../../globals/constants.js'
+
+const {
+  EVENT_TYPE,
+} = CONSTANT
+
+/**
+ * Event processor: handle "create" events.
+ */
+export default class CreateEventProcessor extends BaseEventProcessor {
+  /**
+   * get: Dispatch key this processor handles.
+   *
+   * @override
+   * @returns {string}
+   */
+  get eventCategory () {
+    return EVENT_TYPE.CREATE_RECORD
+  }
+
+  /**
+   * Process the event.
+   *
+   * @override
+   * @param {{
+   *   event: *
+   * }} params - Parameters for processing.
+   * @returns {Promise<*>}
+   */
+  async process ({
+    event,
+  }) {
+    return this.buildResult({
+      event,
+    })
+  }
+}
+```
+
+- **Why a constant hash for the key**: the same key string appears on the producer side (the
+  webhook / message payload) and the consumer side (the getter). A shared constant makes a typo
+  a reference error instead of a silent dispatch miss.
+- Suffix concrete classes by role (`~Processor`, `~Handler`, `~Converter`), aligned with the
+  base class name.
+
+## 4. Bulk loader: auto-discover and pick by getter
+
+The loader resolves the processor directory with `rootPath.to(...)`, loads every class in it via
+`DeepBulkClassLoader.create({ poolPath }).loadClasses()`, and instantiates each with
+`.create()`. `resolveProcessor(key)` matches on the dispatch getter and returns **`?? null`** on a
+miss — there is no default / fallback processor and no throw inside the loader.
+
+```js
+import {
+  DeepBulkClassLoader,
+} from '@openreachtech/renchan'
+
+import {
+  rootPath,
+} from '../../globals/_.js'
+
+const eventProcessorPath = rootPath.to('app/tools/eventProcessors/concretes')
+
+/**
+ * Bulk loader for event processors.
+ */
+export default class BulkEventProcessorsLoader {
+  /**
+   * Constructor.
+   *
+   * @constructor
+   * @param {BulkEventProcessorsLoaderConstructorParams} params - Parameters of this constructor.
+   */
+  constructor ({
+    processors,
+  }) {
+    this.processors = processors
+  }
+
+  /**
+   * Factory method as async.
+   *
+   * @param {string} [path] - The path to load processors from.
+   * @returns {Promise<BulkEventProcessorsLoader>}
+   */
+  static async createAsync (path = eventProcessorPath) {
+    const processorClasses = await this.loadProcessorClasses(path)
+
+    const processors = processorClasses.map(ProcessorClass =>
+      ProcessorClass.create()
+    )
+
+    return new this({
+      processors,
+    })
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof BulkEventProcessorsLoader ? X : never} T, X
+   * @param {BulkEventProcessorsLoaderFactoryParams} params - Parameters for the factory.
+   * @returns {InstanceType<T>} An instance of the class.
+   * @this {T}
+   */
+  static create (params) {
+    return /** @type {InstanceType<T>} */ (
+      new this(params)
+    )
+  }
+
+  /**
+   * Load processor classes from the specified path.
+   *
+   * @param {string} path - The path to load processor classes from.
+   * @returns {Promise<Array<typeof import('../eventProcessors/BaseEventProcessor.js').default>>}
+   */
+  static async loadProcessorClasses (path) {
+    return /** @type {*} */ (
+      DeepBulkClassLoader.create({
+        poolPath: path,
+      })
+        .loadClasses()
+    )
+  }
+
+  /**
+   * Resolve a processor by dispatch key.
+   *
+   * @param {string} eventCategory - The dispatch key.
+   * @returns {import('../eventProcessors/BaseEventProcessor.js').default | null}
+   */
+  resolveProcessor (eventCategory) {
+    return this.processors.find(processor => processor.eventCategory === eventCategory)
+      ?? null
+  }
+}
+
+/**
+ * @typedef {object} BulkEventProcessorsLoaderConstructorParams
+ * @property {Array<import('../eventProcessors/BaseEventProcessor.js').default>} processors - The event processors.
+ */
+
+/**
+ * @typedef {{
+ *   processors: Array<import('../eventProcessors/BaseEventProcessor.js').default>
+ * }} BulkEventProcessorsLoaderFactoryParams
+ */
+```
+
+- **Why `?? null` and no fallback processor**: what a miss means (skip? log? error response?)
+  is the caller's decision, and it differs per call site. A `'default_processor'` chain inside
+  the loader hides unknown keys from the caller.
+- Build the loader once (at startup / in a shared instance) and reuse it — `createAsync()` reads
+  the filesystem, so don't re-run it per event.
+
+## 5. Caller side
+
+The caller asks the loader for a processor and decides what a `null` means:
+
+```js
+const loader = await BulkEventProcessorsLoader.createAsync()
+
+const processor = loader.resolveProcessor(eventCategory)
+
+if (!processor) {
+  return null
+}
+
+return processor.process({
+  event,
+})
+```
+
+## 6. Testing
+
+Following the `hc-jest` skill, split files per class.
+
+- **Base class**: each abstract member throws (`eventCategory`, the work method); `static create()`
+  returns an instance of the called class.
+- **Each concrete subclass**: inheritance (extends the base); the dispatch getter returns the
+  expected constant; the work method's behavior with `test.each()` over its variable inputs.
+- **Bulk loader**: `resolveProcessor()` returns the matching processor for each known key
+  (`test.each()` over the keys), and **`null` for an unknown key** — don't skip the miss case.
+
+## Finishing checklist
+
+- [ ] Did the change add a variant as **one new subclass file**, without editing a dispatch chain or an import list?
+- [ ] Is dispatch a **getter** overridden per subclass (no `processorName` field, no `static getName()`)?
+- [ ] Do the abstract base members throw `new Error('... must be implemented in subclass')`?
+- [ ] Does the dispatch getter return its key from a **shared constant hash**, not a bare string literal?
+- [ ] Does the loader auto-discover via `DeepBulkClassLoader` from a `rootPath.to(...)` directory, and does `resolveProcessor()` return `?? null` on a miss (no fallback processor, no throw)?
+- [ ] Is `static create()` the factory everywhere, with constructor deps defaulted in `create()` when needed (per `class-design`)?
+- [ ] One class per file, suffixed by role (`~Processor`, `~Handler`, `~Converter`)?
+- [ ] Do tests cover the abstract throws, each subclass's getter + behavior, and the loader's known-key / unknown-key cases?

--- a/kit/skills/backend/hb-stub-api/SKILL.md
+++ b/kit/skills/backend/hb-stub-api/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: hb-stub-api
+description: >
+  Implement a stub GraphQL resolver: a query/mutation resolver that returns hardcoded,
+  schema-accurate data with no DB access and no business logic, so the frontend can
+  develop against the API contract before the real backend exists. Use this skill
+  whenever the user asks to add or edit a stub resolver (a class under
+  server/graphql/resolvers/<audience>/stub/), wants "a fake API the frontend can call
+  now", or needs to migrate a finished stub into a real resolver under actual/.
+---
+
+# Stub API (schema-accurate stub resolvers)
+
+A skill for implementing **stub resolvers**: query/mutation resolver classes that return hardcoded,
+schema-accurate data. They exist so the frontend can build against the API contract while the real
+backend logic is still unwritten. A stub lives under
+`server/graphql/resolvers/<audience>/stub/{queries,mutations}/` (where `<audience>` is one of the
+app's audience folders, e.g. `customer` / `admin`); the matching real resolver later lives under
+`server/graphql/resolvers/<audience>/actual/…` with the **same class name and interface**.
+
+The schema the stub must mirror is authored per `hb-graphql-schema`. The real implementation the stub
+is eventually replaced by is authored per `hb-query-resolver` / `hb-mutation-resolver`; this skill covers
+only the stub itself and the hand-off to the real resolver.
+
+## Grand principle: a stub returns hardcoded literals only — no logic of any kind
+
+Everything a stub's `resolve()` returns is a **hardcoded literal**. No DB access, no service calls,
+no validation, no computation, no conditionals, no `map`/`filter`/`reduce` over input. The single
+exception is the pagination slice ([2](#2-paginated-query-stub)).
+
+- **Why literals only**: a stub's job is to pin down the **contract** (the response shape), not to
+  approximate the behavior. Any logic you write in a stub is unverified pseudo-implementation — it
+  can drift from the real rules, the frontend starts depending on it, and the divergence shows up
+  as breakage at migration time. A literal cannot lie about anything except the shape, and the
+  shape is exactly what a stub exists to guarantee.
+- **Why schema-accurate**: the returned shape must match the GraphQL schema exactly (every required
+  field present, correct types). A stub that omits fields forces the frontend to discover the gap
+  against the real API later — the one failure mode a stub is supposed to prevent.
+- **Echo input back only where the schema result mirrors it** (e.g. a mutation that returns the id
+  it was given); otherwise return plausible hardcoded ids/values. Echoing is reading a field, not
+  computing — transforming input is already logic and belongs to the real resolver.
+
+```js
+// Good: every field is a hardcoded literal — the stub pins the shape and nothing else
+/** @override */
+async resolve ({
+  variables: {
+    input,
+  },
+  context,
+}) {
+  return {
+    shippingAddressId: 1003,
+  }
+}
+```
+
+```js
+// Avoid: computing values from input in a stub
+//   → unverified pseudo-logic the frontend starts depending on; it drifts from the real rules and breaks at migration time
+async resolve ({
+  variables: {
+    input,
+  },
+}) {
+  const normalizedCode = input.postalCode.replace('-', '') // computation — belongs to the real resolver
+  return {
+    shippingAddressId: normalizedCode.length > 0
+      ? 1003
+      : null, // conditional — a stub never branches
+  }
+}
+```
+
+## 1. Query stub
+
+Extend `BaseQueryResolver`. `schema` is a **`static get`** returning the camelCase GraphQL
+operation name. `resolve()` destructures `{ variables: { input }, context }` and returns literals.
+
+```js
+import {
+  BaseQueryResolver,
+} from '@openreachtech/renchan'
+
+/**
+ * Stub resolver: shippingCarriers query.
+ *
+ * @extends {BaseQueryResolver}
+ */
+export default class ShippingCarriersQueryResolver extends BaseQueryResolver {
+  /**
+   * get: Operation name.
+   *
+   * @override
+   * @returns {string}
+   */
+  static get schema () {
+    return 'shippingCarriers'
+  }
+
+  /**
+   * Resolve. Returns hardcoded, schema-accurate data.
+   *
+   * @override
+   */
+  async resolve ({
+    variables: {
+      input: {
+        searchParameters,
+      },
+    },
+    context,
+  }) {
+    const allCarriers = [
+      {
+        shippingCarrierId: 1,
+        shippingCarrierName: 'Alpha Express',
+        shippingCarrierCode: 'ALPHA',
+      },
+      {
+        shippingCarrierId: 2,
+        shippingCarrierName: 'Beta Logistics',
+        shippingCarrierCode: 'BETA',
+      },
+    ]
+
+    return {
+      shippingCarriers: allCarriers,
+    }
+  }
+}
+```
+
+- If the query takes no input, drop the `input` destructuring and keep just `resolve ()` or
+  `resolve ({ context })`.
+- The file name is `<Operation>QueryResolver.js`, matching the class name.
+
+## 2. Paginated query stub
+
+When the query is paginated (`input.pagination` with `limit` / `offset` / `sort`), hardcode a full
+`const all<Things>` array of **at least 10 records** (every value unique), then return the correct
+page. The slice below is the **only** operation the whole stub is allowed to do.
+
+```js
+import {
+  BaseQueryResolver,
+} from '@openreachtech/renchan'
+
+/**
+ * Stub resolver: customerBillingHistories query (paginated).
+ *
+ * @extends {BaseQueryResolver}
+ */
+export default class CustomerBillingHistoriesQueryResolver extends BaseQueryResolver {
+  /**
+   * get: Operation name.
+   *
+   * @override
+   * @returns {string}
+   */
+  static get schema () {
+    return 'customerBillingHistories'
+  }
+
+  /**
+   * Resolve. Returns the requested page of hardcoded records.
+   *
+   * @override
+   */
+  async resolve ({
+    variables: {
+      input: {
+        pagination: {
+          limit,
+          offset,
+          sort,
+        },
+      },
+    },
+  }) {
+    const allBillingHistories = [
+      {
+        orderPaymentId: 50001,
+        totalPrice: '5450.00',
+        paidAt: new Date('2024-01-18T14:00:00.000Z'),
+        // ... the rest of the schema-required fields, all hardcoded
+      },
+      // ... at least 10 hardcoded records total, every value unique
+    ]
+
+    const totalRecords = allBillingHistories.length
+    const billingHistories = allBillingHistories.slice(offset, offset + limit)
+
+    return {
+      billingHistories,
+      pagination: {
+        limit,
+        offset,
+        sort,
+        totalRecords,
+      },
+    }
+  }
+}
+```
+
+- **Use `slice(offset, offset + limit)`** — it returns a copy of the requested page. Do **not** use
+  `splice`, which mutates the source array.
+- `totalRecords` is the array's `.length` (never a hardcoded number), so the page math stays
+  correct as records are added.
+- Hardcode **at least 10 records with every value unique**, so the frontend can see paging actually
+  advance and distinguish the records on screen.
+- This slice + `.length` is the only computation permitted; every field inside the records is a
+  hardcoded literal.
+
+## 3. Mutation stub
+
+Extend `BaseMutationResolver`. Same **`static get schema ()`**, plus a
+**`static get errorCodeHash ()`** that spreads `super.errorCodeHash`. Stubs keep the hash empty —
+real error codes are added during migration ([4](#4-migrating-a-stub-to-a-real-resolver)).
+
+```js
+import {
+  BaseMutationResolver,
+} from '@openreachtech/renchan'
+
+/**
+ * Stub resolver: addShippingAddress mutation.
+ *
+ * @extends {BaseMutationResolver}
+ */
+export default class AddShippingAddressMutationResolver extends BaseMutationResolver {
+  /**
+   * get: Operation name.
+   *
+   * @override
+   * @returns {string}
+   */
+  static get schema () {
+    return 'addShippingAddress'
+  }
+
+  /**
+   * get: Error code hash. Kept empty in a stub.
+   *
+   * @override
+   * @returns {Record<string, string>}
+   */
+  static get errorCodeHash () {
+    return {
+      ...super.errorCodeHash,
+    }
+  }
+
+  /**
+   * Resolve. Returns hardcoded, schema-accurate data.
+   *
+   * @override
+   */
+  async resolve ({
+    variables: {
+      input,
+    },
+    context,
+  }) {
+    return {
+      shippingAddressId: 1003,
+    }
+  }
+}
+```
+
+Echo input back when the result mirrors it — destructure exactly the fields you return:
+
+```js
+/** @override */
+async resolve ({
+  variables: {
+    input: {
+      originObjectCategoryId,
+      originObjectUniqueKey,
+    },
+  },
+  context,
+}) {
+  return {
+    originObjectCategoryId,
+    originObjectUniqueKey,
+    updatedColumnsWithValues: [],
+  }
+}
+```
+
+## 4. Migrating a stub to a real resolver
+
+Preserve the interface, swap only the body. The frontend must not notice the switch except that
+the data becomes real.
+
+1. **Keep the class name, `static get schema ()`, and `static get errorCodeHash ()`.** Move the
+   file from `…/stub/…` to `…/actual/…`.
+2. **Fill `errorCodeHash` with real codes** (spread `super.errorCodeHash` first):
+
+   ```js
+   /** @override */
+   static get errorCodeHash () {
+     return {
+       ...super.errorCodeHash,
+
+       InvalidPostalCode: '203.M004.001',
+       InvalidPrefecture: '203.M004.002',
+     }
+   }
+   ```
+3. **Replace the literal return with real work** — validate input, run DB/transaction logic through
+   Sequelize models, and format the response with **the same shape the stub returned**. Structure
+   the real resolver per `hb-query-resolver` / `hb-mutation-resolver` (extracted `validateInput` /
+   transaction callback / `formatResponse` — not everything inlined in `resolve()`).
+4. Throwing an error-code key surfaces it via `errorCodeHash` — this is where the codes added in
+   step 2 come into play.
+
+## Finishing checklist
+
+- [ ] Is every returned field a **hardcoded literal** (no DB, no service calls, no validation, no conditionals, no `map`/`filter`/`reduce`)?
+- [ ] Does the returned shape match the GraphQL schema **exactly** (all required fields, correct types)?
+- [ ] Is the file under `server/graphql/resolvers/<audience>/stub/{queries,mutations}/`, with class name `<Operation>QueryResolver` / `<Operation>MutationResolver` and a matching file name?
+- [ ] Does `static get schema ()` return the camelCase operation name?
+- [ ] Does a mutation stub define `static get errorCodeHash ()` spreading `super.errorCodeHash`, kept empty?
+- [ ] Paginated stub: ≥ 10 hardcoded records with unique values, page via `slice(offset, offset + limit)` (never `splice`), `totalRecords` = array `.length`?
+- [ ] Is input echoed back only where the schema result mirrors it (no transformation of input)?
+- [ ] When migrating: same class name / `schema` / `errorCodeHash` interface, file moved to `actual/`, real codes filled in, response shape unchanged?

--- a/kit/skills/backend/hb-subscription-resolver/SKILL.md
+++ b/kit/skills/backend/hb-subscription-resolver/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: hb-subscription-resolver
+description: >
+  Implement a GraphQL subscription resolver — a class extending the framework's base subscription
+  resolver that declares the subscription operation, scopes its channel per subscriber, and gates
+  who may subscribe. Use this skill whenever the user asks to add or change a subscription, scope
+  or authorize a subscription channel, or wire the publish side that pushes events to subscribers.
+---
+
+# Subscription Resolver
+
+A skill for **GraphQL subscription resolvers**: the class that lets a client **subscribe to a
+channel** and receive a **stream of pushed events**. It declares the operation, decides **which
+channel** a caller listens on, and **whether they may**. The events themselves are **published** by
+whatever changes state (a mutation or a background worker), through a PubSub **broker** — the
+subscription resolver and the publisher meet on a named channel, never calling each other directly.
+
+This overview maps each topic to a section; the details are in the detail files under `references/`.
+
+> This skill states a **general, project-independent rule** — a refined best practice, not a
+> description of any one project's code, so it need not match a given repo's existing notation. The
+> class and field names (`OnReceiveMessageSubscriptionResolver`, `onReceiveMessage`, `roomId`, …) are
+> **illustrative fakes**; use your project's own names and never bake its domain or file paths into
+> the rule. The framework base is shown as `BaseSubscriptionResolver`; treat it as "your framework's
+> base subscription resolver". Sample code follows the project's lint style (no semicolons, 2-space
+> indent, a space before the parameter parenthesis, trailing commas).
+
+## Grand principle: the resolver owns the channel; the state-changer publishes to it
+
+A subscription resolver is a **read-only push endpoint**. It does two things: **name and scope the
+channel** a subscriber listens on, and **decide if that subscriber is allowed**. It never mutates
+state and it does not produce the events — a **mutation or worker publishes** them onto the same
+channel, and the broker fans them out to every matching subscriber.
+
+- **The subscription resolver is the single source of truth for the channel contract.** The channel
+  name is derived from the resolver's `schema` (the prefix) plus its `generateChannelQuery` (the
+  scope). The publisher builds its message via the **same class** (`buildTopic`), so the two sides
+  can never disagree on the channel — that is why a publisher imports the subscription resolver.
+- **The broker decouples the two sides.** Subscriber and publisher share only a channel string; they
+  can live in **different processes** (e.g. a background worker publishes; the API process serves the
+  subscription).
+- **Keep it thin.** Scope, authorize, unwrap. No business logic, no writes.
+
+## 1. Basic notation
+
+A subscription resolver extends the framework base and overrides a small, fixed set of members. Every
+per-call method receives the **same four arguments** — `{ variables, context, information, parent }`
+(destructure what you need). The essential members:
+
+| Member | Override? | Role |
+| --- | --- | --- |
+| `static get schema ()` | **required** | the subscription operation name — also the **channel prefix** and the **message key** |
+| `generateChannelQuery ({ variables, context, … })` | usually | key/value hash that **scopes** the channel per subscriber; default `{}` = broadcast to all |
+| `async canSubscribe ({ variables, context, … })` | for auth ([§2](#2-adding-authentication)) | boolean subscribe-time gate; default `true` |
+| `static get errorCodeHash ()` | when adding auth | merge `...super.errorCodeHash` + the subscribe-denied code |
+| `resolve (payload)` | rarely | maps the published message to the returned value; the base unwraps `payload[schema]` |
+| `static get operation` / `channelPrefix` / `subscribe` / `buildTopic` / `publishTopic` | **no** | provided by the base — the subscribe flow, channel building, and publish helpers |
+
+The class skeleton, the common-arguments table, the full example, and the `@typedef` shapes are in
+[basic-notation.md](./references/basic-notation.md).
+
+## 2. Adding authentication
+
+Authorization happens **once, at subscribe time**, in **`canSubscribe`** — a boolean gate. Returning
+`false` makes the base throw the subscribe-denied error, so also declare that error code in
+`errorCodeHash`. Authenticated-only is `return context.hasAuthenticated()`; resource-scoped access
+combines the principal with the input; private streams are additionally scoped by principal in
+`generateChannelQuery`.
+
+The full `canSubscribe` / `errorCodeHash` example, the authenticated / resource-scoped / identity
+patterns, and the once-per-subscribe note are in [authentication.md](./references/authentication.md).
+
+## 3. Design philosophy
+
+- **Read-only push; the state-changer publishes.** The resolver opens a scoped, authorized channel;
+  the mutation/worker that changes state publishes to it after the change commits.
+- **One channel contract, one owner.** Both sides derive the channel from the same subscription
+  resolver class — the subscriber via `generateChannelQuery`, the publisher via `buildTopic` — so the
+  prefix and scope can never drift.
+- **Scoping = per-subscriber isolation**, and the **broker** lets the publisher run in a separate
+  process from the API. Keep the payload minimal and `resolve` thin.
+
+The publish-side example and the full rationale are in
+[design-philosophy.md](./references/design-philosophy.md).
+
+## Finishing checklist
+
+- [ ] `static get schema` returns the subscription operation name (= channel prefix = message key) ([§1](#1-basic-notation)).
+- [ ] `generateChannelQuery` scopes the channel per subscriber (or `{}` only for a true broadcast).
+- [ ] The resolver does **no** writes and **no** business logic — it scopes, authorizes, and unwraps.
+- [ ] If access is restricted: `canSubscribe` returns the boolean gate and `errorCodeHash` declares the subscribe-denied code ([§2](#2-adding-authentication)); private channels are also scoped by principal.
+- [ ] The publisher (mutation/worker) builds its topic via **this class's** `buildTopic` and publishes through the broker — no hand-written channel string ([§3](#3-design-philosophy)).
+- [ ] The published payload is minimal; `resolve` is left to the base unless a reshape is needed.
+
+## Detail files
+
+- [basic-notation.md](./references/basic-notation.md) — the class skeleton, the common
+  `{ variables, context, information, parent }` arguments, the member table in full, the example, and
+  the `@typedef` input/response shapes (§1)
+- [authentication.md](./references/authentication.md) — `canSubscribe` as the boolean gate,
+  `errorCodeHash`, the authenticated / resource-scoped / identity-scoping patterns, subscribe-time
+  timing (§2)
+- [design-philosophy.md](./references/design-philosophy.md) — read-only push, the single channel
+  contract and the publish-side example, per-subscriber isolation, broker decoupling, minimal payload
+  (§3)

--- a/kit/skills/backend/hb-subscription-resolver/references/authentication.md
+++ b/kit/skills/backend/hb-subscription-resolver/references/authentication.md
@@ -1,0 +1,99 @@
+# Adding authentication
+
+How a subscription decides who may subscribe. Referenced from §2 of [SKILL.md](../SKILL.md). Names are
+illustrative fakes — use your project's own.
+
+## The gate: `canSubscribe`
+
+Authorization happens **once, at subscribe time**, in **`canSubscribe`** — a boolean predicate.
+Returning `false` makes the base throw the subscribe-denied error, so also declare that error code in
+`errorCodeHash`.
+
+```js
+/** @override */
+static get errorCodeHash () {
+  return {
+    ...super.errorCodeHash,
+
+    CanNotSubscribe: '102.S001.001',
+  }
+}
+
+/**
+ * Whether the caller may subscribe to this channel.
+ *
+ * @override
+ * @param {{
+ *   variables: OnReceiveMessageVariables
+ *   context: GraphqlType.ResolverInputContext
+ * }} params - Parameters.
+ * @returns {Promise<boolean>}
+ */
+async canSubscribe ({
+  variables,
+  context,
+}) {
+  return context.hasAuthenticated()
+}
+```
+
+## Patterns
+
+- **Authenticated-only** — the caller must be a valid principal:
+
+  ```js
+  async canSubscribe ({
+    context,
+  }) {
+    return context.hasAuthenticated()
+  }
+  ```
+
+- **Resource-scoped** — the caller must own or belong to what they subscribe to. Combine the
+  principal with the input, and keep `canSubscribe` a predicate by doing the lookup in a separate
+  method:
+
+  ```js
+  async canSubscribe ({
+    variables,
+    context,
+  }) {
+    if (!context.hasAuthenticated()) {
+      return false
+    }
+
+    return this.isMemberOfRoom({
+      variables,
+      context,
+    })
+  }
+  ```
+
+- **Identity-scoped channel** — for a private stream, also derive the channel from the principal in
+  `generateChannelQuery` (e.g. include `context.userId`), so a subscriber can only *build* a channel
+  for their own data. Authorization and channel scoping then reinforce each other: even a caller who
+  passes `canSubscribe` receives only events on their own channel.
+
+  ```js
+  generateChannelQuery ({
+    context: {
+      userId,
+    },
+  }) {
+    return {
+      userId,
+    }
+  }
+  ```
+
+## Timing
+
+- `canSubscribe` runs **when the subscription is established, not per message** — it is a cheap,
+  one-time gate. Do not put per-message filtering here.
+- This is the subscription's **own** gate. It is in addition to any endpoint-wide authentication
+  filter the server applies before a resolver runs; the two are independent — the endpoint filter
+  decides "may this caller reach this operation at all", `canSubscribe` decides "may this caller open
+  this specific channel".
+- Because the decision is a plain boolean derived from `context` (and optionally `variables`),
+  `canSubscribe` is trivial to unit-test: feed a context with and without an authenticated principal
+  and assert the boolean.

--- a/kit/skills/backend/hb-subscription-resolver/references/basic-notation.md
+++ b/kit/skills/backend/hb-subscription-resolver/references/basic-notation.md
@@ -1,0 +1,116 @@
+# Basic notation — members & common arguments
+
+The class skeleton, the arguments every method receives, and the member contract. Referenced from §1
+of [SKILL.md](../SKILL.md). Class and field names (`OnReceiveMessageSubscriptionResolver`,
+`onReceiveMessage`, `roomId`, …) are illustrative fakes — use your project's own names.
+
+## Common arguments
+
+Every per-call method on a subscription resolver receives the **same four arguments**. Destructure
+only what the method needs.
+
+| Argument | What it is |
+| --- | --- |
+| `variables` | the subscription's input arguments |
+| `context` | the per-request context — the auth principal, and the PubSub broker (`context.broker`) |
+| `information` | GraphQL resolve info (the operation/field name) |
+| `parent` | the parent resolver's output (typically absent at the subscription root) |
+
+## Members
+
+A subscription resolver extends the framework base and overrides a small, fixed set of members. The
+rest of the subscribe flow (channel building, the async iterable, the publish helpers) is provided by
+the base and is **not** overridden.
+
+| Member | Override? | Role |
+| --- | --- | --- |
+| `static get schema ()` | **required** | the subscription operation name — also the **channel prefix** and the **message key** |
+| `generateChannelQuery ({ variables, context, … })` | usually | key/value hash that **scopes** the channel per subscriber; default `{}` = broadcast to all |
+| `async canSubscribe ({ variables, context, … })` | for auth ([authentication.md](./authentication.md)) | boolean subscribe-time gate; default `true` |
+| `static get errorCodeHash ()` | when adding auth | merge `...super.errorCodeHash` + the subscribe-denied code |
+| `resolve (payload)` | rarely | maps the published message to the returned value; the base unwraps `payload[schema]` |
+| `static get operation` | **no** | fixed to the subscription operation kind |
+| `static get channelPrefix` | **no** | defaults to `schema` |
+| `subscribe` / `generateChannel` / `generateAsyncIterable` | **no** | the base subscribe flow |
+| `static buildTopic` / `static publishTopic` | **no** (call, don't override) | the publish-side helpers used by the state-changer ([design-philosophy.md](./design-philosophy.md)) |
+
+## The skeleton
+
+```js
+import {
+  BaseSubscriptionResolver,
+} from '@openreachtech/renchan'
+
+/**
+ * Subscription resolver: push new messages of a room to its subscribers.
+ *
+ * @extends {BaseSubscriptionResolver<OnReceiveMessageVariables, OnReceiveMessageResponse>}
+ */
+export default class OnReceiveMessageSubscriptionResolver extends BaseSubscriptionResolver {
+  /** @override */
+  static get schema () {
+    return 'onReceiveMessage'
+  }
+
+  /** @override */
+  static get errorCodeHash () {
+    return {
+      ...super.errorCodeHash,
+    }
+  }
+
+  /**
+   * Scope the channel per subscriber (here: by room).
+   *
+   * @override
+   * @param {{
+   *   variables: OnReceiveMessageVariables
+   * }} params - Parameters.
+   * @returns {Record<string, string | number>} Channel query.
+   */
+  generateChannelQuery ({
+    variables: {
+      input: {
+        roomId,
+      },
+    },
+  }) {
+    return {
+      roomId,
+    }
+  }
+}
+
+/**
+ * @typedef {{
+ *   input: {
+ *     roomId: number
+ *   }
+ * }} OnReceiveMessageVariables
+ */
+
+/**
+ * @typedef {{
+ *   onReceiveMessage: {
+ *     message: {
+ *       id: number
+ *       content: string
+ *     }
+ *   }
+ * }} OnReceiveMessageResponse
+ */
+```
+
+## Notes on each member
+
+- **`schema`** is the one required member: it is the operation name **and** the channel prefix **and**
+  the key the payload is wrapped under. Keep it identical to the GraphQL field.
+- **`generateChannelQuery`** returns the values that narrow the channel. Return `{}` only when every
+  subscriber genuinely wants every event. The base calls it inside `subscribe`; you never call
+  `subscribe` yourself.
+- **`errorCodeHash`** starts as a spread of `super.errorCodeHash`; add codes only when the resolver
+  introduces its own errors (e.g. the subscribe-denied code once you add `canSubscribe`).
+- **`resolve (payload)`** is left to the base unless the pushed message must be reshaped before it
+  reaches the client; the default returns `payload[schema]`.
+- The `@typedef` blocks give the input (`Variables`) and pushed-message (`Response`) shapes — the
+  `Response` object is keyed by `schema`.

--- a/kit/skills/backend/hb-subscription-resolver/references/design-philosophy.md
+++ b/kit/skills/backend/hb-subscription-resolver/references/design-philosophy.md
@@ -1,0 +1,68 @@
+# Design philosophy
+
+Why a subscription is split into a channel-owning resolver and a separate publisher. Referenced from
+§3 of [SKILL.md](../SKILL.md). Names are illustrative fakes — use your project's own.
+
+## Read-only push; the state-changer publishes
+
+The subscription resolver only opens a **scoped, authorized channel** and streams from it. The event
+is produced by whatever **changes state** — a mutation, or a background worker — which **publishes**
+to the channel **after the change commits**. Never publish from inside the subscription resolver, and
+never mutate state there.
+
+- **Why**: publishing before the write commits would push an event that a later failure rolls back.
+  Making the state-changer own the publish keeps "the change happened" and "subscribers were told"
+  in the same place, in the right order.
+
+## One channel contract, one owner
+
+Both sides derive the channel from the **same subscription resolver class**: the subscriber via
+`subscribe` → `generateChannelQuery`, the publisher via the class's `buildTopic`. The publisher
+therefore **imports the subscription resolver** and never hand-writes a channel string — so the
+prefix and scope can never drift apart.
+
+```js
+// In the state-changer (a mutation or a worker): build the topic from the SAME subscription resolver,
+// then publish it through the broker on the context. The channel is never hand-written.
+const topic = OnReceiveMessageSubscriptionResolver.buildTopic({
+  payload: {
+    message,
+  },
+  channelQuery: {
+    roomId,
+  },
+})
+
+await this.publishTopic({
+  context,
+  topic,
+})
+```
+
+- The publisher's `channelQuery` **must match** the subscriber's `generateChannelQuery` output for
+  the event to arrive. Because both come from one class, a change to the scope updates both sides at
+  once.
+
+## Scoping = per-subscriber isolation
+
+`generateChannelQuery` narrows the channel so a subscriber receives only its own events:
+
+- **By input** (`roomId`) — topic selection: the caller chooses which stream to listen to.
+- **By principal** (`userId`) — privacy: the caller can only listen to their own stream
+  ([authentication.md](./authentication.md)).
+
+A broadcast channel (`generateChannelQuery` returns `{}`) is correct only when every subscriber
+genuinely wants every event.
+
+## Broker decoupling enables cross-process push
+
+Subscriber and publisher share only a **channel string**, exchanged through the PubSub **broker**
+(reached via the context / the app's shared instances). They never call each other. This is what lets
+the publisher run in a **separate process** from the API that serves the subscription — for example a
+background worker publishing progress that a client subscribed to in the API process.
+
+## Minimal payload, thin `resolve`
+
+Publish only what the client needs; the default `resolve` merely unwraps `payload[schema]`. Override
+`resolve` only to reshape the pushed message, never to fetch or compute — keeping the payload small
+and the resolver thin keeps the push path fast and the contract obvious.

--- a/kit/skills/backend/hb-type-interface/SKILL.md
+++ b/kit/skills/backend/hb-type-interface/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: hb-type-interface
+description: >
+  Define TypeScript type interfaces in .d.ts declaration files: model interfaces (one file per
+  model/table under types/models/, in the global `model` namespace) and resolver input/output
+  types (one file per resolver under types/resolvers/<category>/, in the global
+  `graphql.<category>` namespace, as <Resolver>Input and <Resolver>Result). Use this skill
+  whenever the user asks to add or change a model interface, a resolver's Input/Result types, or
+  another shared global type.
+---
+
+# Type Interface Definition
+
+A skill for the **`.d.ts` type declarations** that describe an app's data shapes: the **model
+interfaces** (one per table) and the **resolver input/output types** (one per resolver). Both are
+declared as **ambient global namespaces**, so any JSDoc can reference them (`model.User`,
+`graphql.user.CreateOrderInput`) without an import. The core rule is **one file per entity** — one
+model, one resolver — merged into a single namespace by TypeScript's declaration merging.
+
+> This skill states a **general, project-independent rule** — a refined best practice, not a
+> description of any one project's code, so it need not match a given repo's existing notation. The
+> directory names, namespaces (`model`, `graphql.<category>`), and example type names (`User`,
+> `Order`, `CreateOrderInput`, …) are the **recommended convention with illustrative fakes**; use your
+> project's own model and resolver names and never bake its domain concepts or file paths into the
+> rule.
+
+## Grand principle: one file per entity, merged into one global namespace
+
+Every model and every resolver gets its **own `.d.ts` file**, each declaring types into a **shared
+global namespace**. TypeScript's **declaration merging** combines the same-named `namespace` blocks
+from every file into one, so the split costs nothing at the access site.
+
+- **Why one file per entity.** A monolithic `model.d.ts` / `graphql.d.ts` is a constant merge-conflict
+  point — every model or resolver change touches the same file. Splitting to `types/models/<ModelName>.d.ts`
+  and `types/resolvers/<category>/<resolverName>.d.ts` means two changes collide **only when they
+  touch the same entity**. Adding a model = adding a file.
+- **Why it still reads as one namespace.** `declare global { namespace model { … } }` in
+  `User.d.ts` and the same block in `Order.d.ts` **merge** into a single `model` namespace. Consumers
+  write `model.User` / `model.Order` regardless of which file declared them — the file split is
+  invisible to readers.
+- **Why global (ambient).** Declared under `declare global`, the types need **no import** to be used
+  in a JSDoc annotation anywhere in the codebase. That is the point of the namespaces — a resolver's
+  JSDoc just writes `@returns {Promise<graphql.user.CreateOrderResult>}`.
+- **Wiring**: the project's `tsconfig` / `jsconfig` `include` must cover the `types/**` directory so
+  these ambient declarations are picked up project-wide.
+
+**Sample code follows the project's lint style**: `.d.ts` uses no semicolons, 2-space indent, and
+interface members are one-per-line (no trailing comma or semicolon). Comments in the files you
+generate are English for structural notes; domain notes match the surrounding language.
+
+## 1. The `.d.ts` scaffold
+
+Every declaration file has the same three-line envelope: an `export {}` module marker, then a
+`declare global` block, then the `namespace`. The interfaces go inside the namespace.
+
+```ts
+export {}
+
+declare global {
+  namespace model {
+    // interfaces here
+  }
+}
+```
+
+- **`export {}`** makes the file a module (so `declare global` is legal). It exports nothing itself.
+- **`declare global { … }`** puts the namespace in the ambient global scope — visible everywhere with
+  no import.
+- The **namespace name is fixed by kind**: `model` for model interfaces ([§2](#2-model-interfaces-one-file-per-table)),
+  `graphql.<category>` for resolver types ([§3](#3-resolver-inputoutput-types-one-file-per-resolver)).
+
+## 2. Model interfaces (one file per table)
+
+A model interface maps **1:1 to a table**. Put each in its own file
+`types/models/<ModelName>.d.ts`, declaring one interface `<ModelName>` into `namespace model`.
+
+```ts
+// types/models/User.d.ts
+export {}
+
+declare global {
+  namespace model {
+    interface User {
+      id: number
+      email: string
+      displayName: string | null
+      registeredAt: Date
+      OrganizationId: number
+    }
+  }
+}
+```
+
+```ts
+// types/models/Order.d.ts — a second model, its own file, same namespace
+export {}
+
+declare global {
+  namespace model {
+    interface Order {
+      id: number
+      UserId: number
+      totalAmount: number
+      placedAt: Date
+      canceledAt: Date | null
+    }
+  }
+}
+```
+
+- **One interface per file**, named exactly for the model, so it is reachable as `model.User` /
+  `model.Order`.
+- **Fields mirror the table's columns.** Use the precise scalar type (`number` / `string` / `Date` /
+  `boolean`); a nullable column is `<type> | null`.
+- **A field holding another model's id starts with an uppercase initial** (`UserId`,
+  `OrganizationId`), mirroring how the ORM's associations are named — this distinguishes a foreign-key
+  field from a plain scalar at a glance.
+- Optionally, a model interface may `extend` a framework base-model interface (if the architecture
+  provides one for the common columns); keep that base generic, not a hard-coded app path.
+
+## 3. Resolver input/output types (one file per resolver)
+
+A resolver's types map **1:1 to the resolver**. Put them in
+`types/resolvers/<category>/<resolverName>.d.ts`, declaring into `namespace graphql.<category>` —
+where `<category>` is the API/endpoint group (`user`, `admin`, `portal`, …). Each resolver declares
+its **`<Resolver>Input`** and its **`<Resolver>Result`** (the output / response).
+
+```ts
+// types/resolvers/user/createOrder.d.ts
+export {}
+
+declare global {
+  namespace graphql.user {
+    interface CreateOrderInput {
+      productId: number
+      quantity: number
+    }
+
+    interface CreateOrderResult {
+      order: model.Order
+    }
+  }
+}
+```
+
+- **Input** is the resolver's argument shape; **Result** is what it returns (the response). A
+  query uses the same `Input` / `Result` pairing.
+- **Reuse model interfaces in the output** — a Result field is typed as `model.<ModelName>`
+  (`order: model.Order`). The `model` and `graphql.<category>` namespaces are both global, so one
+  references the other with no import.
+- **Resolver-local helper types** (a nested filter input, a row sub-shape) live in the **same file**
+  as the resolver they belong to — they are part of that resolver's 1:1 slice, not shared globals.
+- **Category = the resolver's endpoint group.** The same resolver name under a different endpoint is a
+  different file and a different namespace (`graphql.user.FooInput` vs `graphql.admin.FooInput`).
+
+## 4. Accessing the types
+
+Because the namespaces are global, JSDoc references them directly — no import:
+
+```js
+/**
+ * @param {{
+ *   variables: {
+ *     input: graphql.user.CreateOrderInput
+ *   }
+ * }} params
+ * @returns {Promise<graphql.user.CreateOrderResult>}
+ */
+async resolve ({
+  variables: {
+    input,
+  },
+}) {
+  // input is typed as graphql.user.CreateOrderInput
+}
+```
+
+- Model shapes are referenced the same way: `@param {model.User} user`.
+- This global access is the reason the types are ambient — the split into many files never forces an
+  import.
+
+## 5. Naming & placement (quick reference)
+
+| Kind | File | Namespace | Interface names | Access |
+| --- | --- | --- | --- | --- |
+| Model | `types/models/<ModelName>.d.ts` | `model` | `<ModelName>` | `model.<ModelName>` |
+| Resolver | `types/resolvers/<category>/<resolverName>.d.ts` | `graphql.<category>` | `<Resolver>Input`, `<Resolver>Result` | `graphql.<category>.<Resolver>Input` |
+
+- File base names match the entity: `<ModelName>` (PascalCase) for models, `<resolverName>`
+  (matching the resolver, camelCase) for resolvers.
+- Avoid the denied vague identifiers in field names (`data` / `info` / `list` / …); name a field for
+  what it holds.
+
+## Finishing checklist
+
+- [ ] The type lives in its **own file** — one model → `types/models/<ModelName>.d.ts`; one resolver → `types/resolvers/<category>/<resolverName>.d.ts` ([§1](#1-the-dts-scaffold)).
+- [ ] File envelope is `export {}` → `declare global` → the correct `namespace` (`model` or `graphql.<category>`).
+- [ ] Model interface is 1:1 with a table; fields mirror columns; nullable is `| null`; a foreign-key field starts uppercase ([§2](#2-model-interfaces-one-file-per-table)).
+- [ ] Resolver file declares `<Resolver>Input` + `<Resolver>Result`, reuses `model.<ModelName>` in outputs, and keeps resolver-local helper types in the same file ([§3](#3-resolver-inputoutput-types-one-file-per-resolver)).
+- [ ] The `types/**` directory is included in the project's TS config so the ambient declarations resolve.


### PR DESCRIPTION
# Why

* Close #5

# How

* Copy `kit/skills/backend/` from `hora-skills` unchanged — 31 skills, the same paths and the same contents
* Keep the domain directory, so `flatten`'s build only needs its `DOMAIN_PREFIX` narrowed later