### PR TITLE
🧵 Ignore `kit/` in `eslint.config.js`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,10 @@ export default [
 
   {
     ignores: [
+      // dist/ is generated build output (see the flatten skill), not source.
       './dist/**',
+
+      './kit/**',
     ],
   },
 


### PR DESCRIPTION
# Why

* Close #7

# How

* Add `./kit/**` to `ignores`, alongside `./dist/**`, as `hora-skills` already does
* The skills ship their own `.mjs` / `.js` / `.cjs` helper scripts — content, not source this repository lints