### PR TITLE
🛠️ Add the equip CLI migrated from hora-skills

### DIFF
--- a/lib/equip/CommandLineArguments.js
+++ b/lib/equip/CommandLineArguments.js
@@ -1,0 +1,178 @@
+/**
+ * The arguments given to the `hora-skills-renchan` command.
+ *
+ * Both `--name value` and `--name=value` are accepted, and anything that is neither an
+ * option name nor the value following one is read as a command name.
+ */
+export default class CommandLineArguments {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   args: Array<string>
+   * }} params - Parameters.
+   */
+  constructor ({
+    args,
+  }) {
+    this.args = args
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof CommandLineArguments ? X : never} T, X
+   * @param {{
+   *   args: Array<string>
+   * }} params - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of this class.
+   * @this {T}
+   * @public
+   */
+  static create ({
+    args,
+  }) {
+    return new this({
+      args,
+    })
+  }
+
+  /**
+   * The hash a fold over the arguments starts from.
+   *
+   * @returns {ParsedArgumentsHash} Empty parse result.
+   */
+  static get initialParsedHash () {
+    return {
+      commandNames: [],
+      optionHash: {},
+      pendingName: null,
+    }
+  }
+
+  /**
+   * Fold one argument token into the parse result.
+   *
+   * @param {{
+   *   parsedHash: ParsedArgumentsHash
+   *   token: string
+   * }} params - Parameters.
+   * @returns {ParsedArgumentsHash} Parse result including the token.
+   */
+  static foldToken ({
+    parsedHash,
+    token,
+  }) {
+    if (parsedHash.pendingName) {
+      return {
+        ...parsedHash,
+        optionHash: {
+          ...parsedHash.optionHash,
+          [parsedHash.pendingName]: token,
+        },
+        pendingName: null,
+      }
+    }
+
+    const inlineMatched = token.match(/^--(?<name>[a-z][\w-]*)=(?<value>.*)$/u)
+
+    if (inlineMatched) {
+      return {
+        ...parsedHash,
+        optionHash: {
+          ...parsedHash.optionHash,
+          [inlineMatched.groups.name]: inlineMatched.groups.value,
+        },
+      }
+    }
+
+    const nameMatched = token.match(/^--(?<name>[a-z][\w-]*)$/u)
+
+    if (nameMatched) {
+      return {
+        ...parsedHash,
+        pendingName: nameMatched.groups.name,
+      }
+    }
+
+    return {
+      ...parsedHash,
+      commandNames: [
+        ...parsedHash.commandNames,
+        token,
+      ],
+    }
+  }
+
+  /**
+   * Constructor of this instance.
+   *
+   * @returns {typeof CommandLineArguments} Constructor of this instance.
+   */
+  get Ctor () {
+    return /** @type {typeof CommandLineArguments} */ (this.constructor)
+  }
+
+  /**
+   * Extract the command name.
+   *
+   * @returns {string | null} Command name, or null when none was given.
+   * @public
+   */
+  extractCommand () {
+    const { commandNames } = this.buildParsedHash()
+    const [command = null] = commandNames
+
+    return command
+  }
+
+  /**
+   * Build the parse result of every argument.
+   *
+   * @returns {ParsedArgumentsHash} Parse result.
+   */
+  buildParsedHash () {
+    return this.args
+      .reduce(
+        (parsedHash, token) => this.Ctor.foldToken({ parsedHash, token }),
+        this.Ctor.initialParsedHash
+      )
+  }
+
+  /**
+   * Extract the value of an option.
+   *
+   * @param {{
+   *   name: string
+   * }} params - Parameters.
+   * @returns {string | null} Option value, or null when the option was not given.
+   */
+  extractOptionValue ({
+    name,
+  }) {
+    const { optionHash } = this.buildParsedHash()
+
+    return optionHash[name]
+      ?? null
+  }
+
+  /**
+   * Extract the target directory given by `--dir`.
+   *
+   * @returns {string | null} Target directory, or null when the option was not given.
+   * @public
+   */
+  extractTargetDirectoryPath () {
+    return this.extractOptionValue({
+      name: 'dir',
+    })
+  }
+}
+
+/**
+ * @typedef {{
+ *   commandNames: Array<string>
+ *   optionHash: Record<string, string>
+ *   pendingName: string | null
+ * }} ParsedArgumentsHash
+ */

--- a/lib/equip/HoraSkillsCli.js
+++ b/lib/equip/HoraSkillsCli.js
@@ -1,0 +1,590 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import CommandLineArguments from './CommandLineArguments.js'
+import SkillsInstaller from './SkillsInstaller.js'
+
+import CLI_COMMAND from './constants/CLI_COMMAND.js'
+
+/**
+ * The `hora-skills-renchan` command.
+ *
+ * It installs every skill this package distributes into a consuming repository, and
+ * removes what an earlier run of it installed. Which skills a repository equips is
+ * answered by which of the sibling skill libraries it installs, so this command has
+ * nothing to select.
+ */
+export default class HoraSkillsCli {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   commandLineArguments: CommandLineArguments
+   *   workingDirectoryPath: string
+   *   logger: Console
+   * }} params - Parameters.
+   */
+  constructor ({
+    commandLineArguments,
+    workingDirectoryPath,
+    logger,
+  }) {
+    this.commandLineArguments = commandLineArguments
+    this.workingDirectoryPath = workingDirectoryPath
+    this.logger = logger
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof HoraSkillsCli ? X : never} T, X
+   * @param {{
+   *   args: Array<string>
+   *   workingDirectoryPath?: string
+   *   logger?: Console
+   * }} params - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of this class.
+   * @this {T}
+   * @public
+   */
+  static create ({
+    args,
+    workingDirectoryPath = process.cwd(),
+    logger = console,
+  }) {
+    const commandLineArguments = this.createCommandLineArguments({
+      args,
+    })
+
+    return new this({
+      commandLineArguments,
+      workingDirectoryPath,
+      logger,
+    })
+  }
+
+  /**
+   * Constructor of the command line arguments.
+   *
+   * @returns {typeof CommandLineArguments} Constructor of the command line arguments.
+   */
+  static get CommandLineArgumentsCtor () {
+    return CommandLineArguments
+  }
+
+  /**
+   * Constructor of the installer.
+   *
+   * @returns {typeof SkillsInstaller} Constructor of the installer.
+   */
+  static get SkillsInstallerCtor () {
+    return SkillsInstaller
+  }
+
+  /**
+   * Directory the skills are installed into, relative to the consuming repository.
+   *
+   * @returns {Array<string>} Path segments of the default target directory.
+   */
+  static get defaultTargetDirectorySegments () {
+    return [
+      '.claude',
+      'skills',
+    ]
+  }
+
+  /**
+   * Build the path of every step from a base directory down to a path below it.
+   *
+   * The steps are what a path is reached through, so verifying a path means verifying
+   * each of them — a link at any one of them redirects everything below it.
+   *
+   * @param {{
+   *   basePath: string
+   *   targetPath: string
+   * }} params - Parameters.
+   * @returns {Array<string>} Path of every step, the target path last.
+   */
+  static buildPathSteps ({
+    basePath,
+    targetPath,
+  }) {
+    return path.relative(basePath, targetPath)
+      .split(path.sep)
+      .filter(it => it !== '')
+      .reduce(
+        (steps, segment) => [
+          ...steps,
+          path.join(
+            steps.at(-1) ?? basePath,
+            segment
+          ),
+        ],
+        /** @type {Array<string>} */ ([])
+      )
+  }
+
+  /**
+   * Build the line a failure is reported as.
+   *
+   * A message names the path the failure happened on, and a path can carry a skill name
+   * the consuming repository chose, so the characters a terminal acts on are dropped
+   * before the line reaches one. Everything a path may legitimately hold is kept.
+   *
+   * @param {{
+   *   error: unknown
+   * }} params - Parameters.
+   * @returns {string} Line reporting the failure.
+   */
+  static buildFailureMessage ({
+    error,
+  }) {
+    const message = error instanceof Error
+      ? error.message
+      : String(error)
+
+    return [
+      ...message,
+    ]
+      .map(it => this.buildPrintableCharacter({ character: it }))
+      .join('')
+  }
+
+  /**
+   * Build the character a terminal prints in place of one it would act on.
+   *
+   * @param {{
+   *   character: string
+   * }} params - Parameters.
+   * @returns {string} The character itself, or the one standing for it.
+   */
+  static buildPrintableCharacter ({
+    character,
+  }) {
+    const codePoint = character.codePointAt(0)
+
+    if (codePoint >= 0x20 && codePoint !== 0x7f) {
+      return character
+    }
+
+    return '?'
+  }
+
+  /**
+   * Usage text.
+   *
+   * @returns {string} Usage text.
+   */
+  static get usageText () {
+    return [
+      'Usage: hora-skills-renchan <command> [options]',
+      '',
+      'Commands:',
+      '  install    Install every skill this package distributes, replacing the installed ones',
+      '  list       Print the skills this package distributes, installing nothing',
+      '  uninstall  Remove every skill this package installed',
+      '  help       Print this text',
+      '',
+      'Options:',
+      '  --dir <path>  Directory to install into (default: .claude/skills)',
+    ]
+      .join('\n')
+  }
+
+  /**
+   * Create the command line arguments.
+   *
+   * @param {{
+   *   args: Array<string>
+   * }} params - Parameters.
+   * @returns {CommandLineArguments} Command line arguments.
+   */
+  static createCommandLineArguments ({
+    args,
+  }) {
+    return this.CommandLineArgumentsCtor.create({
+      args,
+    })
+  }
+
+  /**
+   * Create the installer.
+   *
+   * @param {{
+   *   workingDirectoryPath: string
+   *   targetDirectoryPath: string
+   * }} params - Parameters.
+   * @returns {SkillsInstaller} Installer.
+   */
+  static createSkillsInstaller ({
+    workingDirectoryPath,
+    targetDirectoryPath,
+  }) {
+    return this.SkillsInstallerCtor.create({
+      workingDirectoryPath,
+      targetDirectoryPath,
+    })
+  }
+
+  /**
+   * Constructor of this instance.
+   *
+   * @returns {typeof HoraSkillsCli} Constructor of this instance.
+   */
+  get Ctor () {
+    return /** @type {typeof HoraSkillsCli} */ (this.constructor)
+  }
+
+  /**
+   * Node file system module.
+   *
+   * @returns {typeof fs} Node file system module.
+   */
+  get fs () {
+    return fs
+  }
+
+  /**
+   * Node path module.
+   *
+   * @returns {typeof path} Node path module.
+   */
+  get path () {
+    return path
+  }
+
+  /**
+   * Run the command, reporting whatever it raises.
+   *
+   * A command reaches the file system of a repository this package knows nothing about, so
+   * a failure it cannot help is ordinary: a skill directory that is a file, a `.claude/`
+   * that is read only, a disk with nothing left. None of them is worth a stack trace, so
+   * the command reports what it raised and ends with a failing exit code.
+   *
+   * @returns {number} Exit code.
+   * @public
+   */
+  run () {
+    try {
+      return this.dispatch()
+    } catch (error) {
+      return this.reportFailure({ error })
+    }
+  }
+
+  /**
+   * Dispatch to the command.
+   *
+   * @returns {number} Exit code.
+   */
+  dispatch () {
+    const command = this.commandLineArguments.extractCommand()
+      ?? CLI_COMMAND.HELP
+
+    if (command === CLI_COMMAND.INSTALL) {
+      return this.runInstall()
+    }
+
+    if (command === CLI_COMMAND.LIST) {
+      return this.runCatalog()
+    }
+
+    if (command === CLI_COMMAND.UNINSTALL) {
+      return this.runUninstall()
+    }
+
+    if (command === CLI_COMMAND.HELP) {
+      return this.runHelp()
+    }
+
+    return this.reportUnknownCommand({
+      command,
+    })
+  }
+
+  /**
+   * Install every skill this package distributes.
+   *
+   * @returns {number} Exit code.
+   */
+  runInstall () {
+    const verifiedExitCode = this.verifyPaths()
+
+    if (verifiedExitCode !== 0) {
+      return verifiedExitCode
+    }
+
+    const installer = this.buildSkillsInstaller()
+    const {
+      installedSkillNames,
+      removedSkillNames,
+    } = installer.install()
+
+    this.logger.log(`Removed ${removedSkillNames.length} skills from ${this.buildTargetDirectoryPath()}`)
+    this.logger.log(`Installed ${installedSkillNames.length} skills into ${this.buildTargetDirectoryPath()}`)
+
+    return 0
+  }
+
+  /**
+   * Build the installer against the target directory.
+   *
+   * @returns {SkillsInstaller} Installer.
+   */
+  buildSkillsInstaller () {
+    return this.Ctor.createSkillsInstaller({
+      workingDirectoryPath: this.workingDirectoryPath,
+      targetDirectoryPath: this.buildTargetDirectoryPath(),
+    })
+  }
+
+  /**
+   * Build the directory the skills are installed into.
+   *
+   * @returns {string} Target directory path.
+   */
+  buildTargetDirectoryPath () {
+    const specifiedPath = this.commandLineArguments.extractTargetDirectoryPath()
+
+    if (specifiedPath) {
+      return this.path.resolve(
+        this.workingDirectoryPath,
+        specifiedPath
+      )
+    }
+
+    return this.path.join(
+      this.workingDirectoryPath,
+      ...this.Ctor.defaultTargetDirectorySegments
+    )
+  }
+
+  /**
+   * Build the directory an installation is verified from.
+   *
+   * A `--dir` is named by whoever runs the command, so it is taken as given and only what
+   * lies below it is verified — and it is the installation directory itself, so nothing
+   * lies below it. Without one the installation is placed inside the consuming repository,
+   * and every step below that repository is verified.
+   *
+   * @returns {string} Directory the verification starts from.
+   */
+  buildVerifiedBaseDirectoryPath () {
+    const specifiedPath = this.commandLineArguments.extractTargetDirectoryPath()
+
+    if (specifiedPath) {
+      return this.buildTargetDirectoryPath()
+    }
+
+    return this.workingDirectoryPath
+  }
+
+  /**
+   * Tell whether a path is a symbolic link.
+   *
+   * A path that does not exist is not one — an installation directory is commonly absent
+   * until the first run creates it.
+   *
+   * @param {{
+   *   filePath: string
+   * }} params - Parameters.
+   * @returns {boolean} Whether the path is a symbolic link.
+   */
+  isSymbolicLink ({
+    filePath,
+  }) {
+    try {
+      return this.fs.lstatSync(filePath)
+        .isSymbolicLink()
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Tell whether a path is reached through a symbolic link.
+   *
+   * @param {{
+   *   basePath: string
+   *   targetPath: string
+   * }} params - Parameters.
+   * @returns {boolean} Whether the path is reached through a symbolic link.
+   */
+  isReachedThroughSymbolicLink ({
+    basePath,
+    targetPath,
+  }) {
+    return this.Ctor.buildPathSteps({
+      basePath,
+      targetPath,
+    })
+      .some(it => this.isSymbolicLink({ filePath: it }))
+  }
+
+  /**
+   * Collect the installation directories reached through a symbolic link.
+   *
+   * @returns {Array<string>} Installation directories reached through a symbolic link.
+   */
+  collectLinkedTargetDirectoryPaths () {
+    const basePath = this.buildVerifiedBaseDirectoryPath()
+
+    return [
+      this.buildTargetDirectoryPath(),
+    ]
+      .filter(it => this.isReachedThroughSymbolicLink({
+        basePath,
+        targetPath: it,
+      }))
+  }
+
+  /**
+   * Build the path of the record an installation writes.
+   *
+   * The record belongs to the consuming repository rather than to an installation
+   * directory, so it sits below the working directory whatever `--dir` names.
+   *
+   * @returns {string} Path of the record.
+   */
+  buildManifestFilePath () {
+    return this.path.join(
+      this.workingDirectoryPath,
+      ...this.Ctor.SkillsInstallerCtor.manifestPathSegments
+    )
+  }
+
+  /**
+   * Collect the record's path when it is reached through a symbolic link.
+   *
+   * Writing the record follows a link the way any write does, so a repository carrying
+   * one there hands this package the file at its far end to overwrite.
+   *
+   * @returns {Array<string>} Path of the record, empty when it is reached through none.
+   */
+  collectLinkedManifestFilePaths () {
+    const filePath = this.buildManifestFilePath()
+
+    if (!this.isReachedThroughSymbolicLink({
+      basePath: this.workingDirectoryPath,
+      targetPath: filePath,
+    })) {
+      return []
+    }
+
+    return [
+      filePath,
+    ]
+  }
+
+  /**
+   * Verify that nothing a command writes is reached through a symbolic link.
+   *
+   * A link is content of the repository rather than an instruction of whoever runs the
+   * command, so following one would let the repository decide where skills are written
+   * and, worse, where they are removed — and where the record is written, which overwrites
+   * whatever the link stands for. Nothing is carried through one, and the whole command
+   * ends rather than half of it running.
+   *
+   * @returns {number} Exit code, zero when every path is what it appears to be.
+   */
+  verifyPaths () {
+    const linkedPaths = [
+      ...this.collectLinkedTargetDirectoryPaths(),
+      ...this.collectLinkedManifestFilePaths(),
+    ]
+
+    if (linkedPaths.length === 0) {
+      return 0
+    }
+
+    linkedPaths.forEach(it => {
+      this.logger.error(`${it} is reached through a symbolic link.`)
+    })
+
+    this.logger.error('Nothing was changed. An installation carries nothing through a link — replace it, or give --dir the directory it resolves to.')
+
+    return 1
+  }
+
+  /**
+   * Print the skills this package distributes.
+   *
+   * @returns {number} Exit code.
+   */
+  runCatalog () {
+    const installer = this.buildSkillsInstaller()
+    const skillNames = installer.collectDistributedSkillNames()
+
+    skillNames.forEach(it => {
+      this.logger.log(it)
+    })
+
+    this.logger.log(`${skillNames.length} skills distributed`)
+
+    return 0
+  }
+
+  /**
+   * Remove every skill this package installed.
+   *
+   * @returns {number} Exit code.
+   */
+  runUninstall () {
+    const verifiedExitCode = this.verifyPaths()
+
+    if (verifiedExitCode !== 0) {
+      return verifiedExitCode
+    }
+
+    const installer = this.buildSkillsInstaller()
+    const { removedSkillNames } = installer.uninstall()
+
+    this.logger.log(`Removed ${removedSkillNames.length} skills from ${this.buildTargetDirectoryPath()}`)
+
+    return 0
+  }
+
+  /**
+   * Report a failure raised while a command ran.
+   *
+   * @param {{
+   *   error: unknown
+   * }} params - Parameters.
+   * @returns {number} Exit code.
+   */
+  reportFailure ({
+    error,
+  }) {
+    this.logger.error(this.Ctor.buildFailureMessage({ error }))
+
+    return 1
+  }
+
+  /**
+   * Print the usage text.
+   *
+   * @returns {number} Exit code.
+   */
+  runHelp () {
+    this.logger.log(this.Ctor.usageText)
+
+    return 0
+  }
+
+  /**
+   * Report a command this CLI does not have.
+   *
+   * @param {{
+   *   command: string
+   * }} params - Parameters.
+   * @returns {number} Exit code.
+   */
+  reportUnknownCommand ({
+    command,
+  }) {
+    this.logger.error(`Unknown command: ${command}`)
+    this.logger.error(this.Ctor.usageText)
+
+    return 1
+  }
+}

--- a/lib/equip/SkillsInstaller.js
+++ b/lib/equip/SkillsInstaller.js
@@ -1,0 +1,443 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import SkillsManifestFile from './SkillsManifestFile.js'
+
+/**
+ * Installer that copies the distributed skills into a consuming repository.
+ *
+ * One run replaces what the previous run wrote: the skills recorded in the manifest,
+ * along with the folders named after a distributed skill, are removed first, then the
+ * distributed skills are copied and recorded again.
+ *
+ * A folder named after nothing this package distributes, and recorded by no previous
+ * run, is never removed — that is what keeps a skill the consuming repository authored
+ * out of the way of an installation, including the very first one.
+ */
+export default class SkillsInstaller {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   sourceDirectoryPath: string
+   *   targetDirectoryPath: string
+   *   manifestFile: SkillsManifestFile
+   * }} params - Parameters.
+   */
+  constructor ({
+    sourceDirectoryPath,
+    targetDirectoryPath,
+    manifestFile,
+  }) {
+    this.sourceDirectoryPath = sourceDirectoryPath
+    this.targetDirectoryPath = targetDirectoryPath
+    this.manifestFile = manifestFile
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof SkillsInstaller ? X : never} T, X
+   * @param {{
+   *   workingDirectoryPath: string
+   *   targetDirectoryPath: string
+   *   sourceDirectoryPath?: string
+   * }} params - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of this class.
+   * @this {T}
+   * @public
+   */
+  static create ({
+    workingDirectoryPath,
+    targetDirectoryPath,
+    sourceDirectoryPath = this.buildDefaultSourceDirectoryPath(),
+  }) {
+    const manifestFile = this.createSkillsManifestFile({
+      workingDirectoryPath,
+      targetDirectoryPath,
+    })
+
+    return new this({
+      sourceDirectoryPath,
+      targetDirectoryPath,
+      manifestFile,
+    })
+  }
+
+  /**
+   * Constructor of the manifest file.
+   *
+   * @returns {typeof SkillsManifestFile} Constructor of the manifest file.
+   */
+  static get SkillsManifestFileCtor () {
+    return SkillsManifestFile
+  }
+
+  /**
+   * Path segments of the manifest, relative to the working directory.
+   *
+   * The manifest belongs to this package rather than to Claude Code, so it is kept
+   * out of the installation directory and placed under a directory of its own.
+   *
+   * It is named after this package, so that the sibling skill libraries installing into
+   * one repository each record their own installation instead of one overwriting another.
+   *
+   * @returns {Array<string>} Path segments of the manifest.
+   */
+  static get manifestPathSegments () {
+    return [
+      '.hora',
+      'hora-skills-renchan.json',
+    ]
+  }
+
+  /**
+   * Build the path of the distributed skills shipped inside this package.
+   *
+   * @returns {string} Absolute path of `dist/skills/`.
+   */
+  static buildDefaultSourceDirectoryPath () {
+    return fileURLToPath(
+      new URL('../../dist/skills/', import.meta.url)
+    )
+  }
+
+  /**
+   * Create the manifest file recording the installation into the target directory.
+   *
+   * @param {{
+   *   workingDirectoryPath: string
+   *   targetDirectoryPath: string
+   * }} params - Parameters.
+   * @returns {SkillsManifestFile} Manifest file of the working directory.
+   */
+  static createSkillsManifestFile ({
+    workingDirectoryPath,
+    targetDirectoryPath,
+  }) {
+    return this.SkillsManifestFileCtor.create({
+      filePath: path.join(
+        workingDirectoryPath,
+        ...this.manifestPathSegments
+      ),
+      installationPath: this.buildInstallationPath({
+        workingDirectoryPath,
+        targetDirectoryPath,
+      }),
+    })
+  }
+
+  /**
+   * Build the key an installation is recorded under.
+   *
+   * The path is relative to the working directory and uses forward slashes, so that
+   * the same installation is recorded under one key on every platform.
+   *
+   * @param {{
+   *   workingDirectoryPath: string
+   *   targetDirectoryPath: string
+   * }} params - Parameters.
+   * @returns {string} Key of the installation.
+   */
+  static buildInstallationPath ({
+    workingDirectoryPath,
+    targetDirectoryPath,
+  }) {
+    return path.relative(
+      workingDirectoryPath,
+      targetDirectoryPath
+    )
+      .split(path.sep)
+      .join('/')
+  }
+
+  /**
+   * Tell whether a skill name addresses a folder directly inside an installation directory.
+   *
+   * A skill name is one name of one folder, so it never carries a path. Reading one that
+   * does would let a manifest of the consuming repository name a path outside the
+   * installation directory, and a removal follows what the manifest names.
+   *
+   * The separators of both platforms are refused, rather than the one this platform uses,
+   * so that a manifest written on either is read the same way on either.
+   *
+   * @param {{
+   *   skillName: string
+   * }} params - Parameters.
+   * @returns {boolean} Whether the skill name addresses a folder of an installation directory.
+   * @public
+   */
+  static isPlainSkillName ({
+    skillName,
+  }) {
+    return skillName !== ''
+      && skillName !== '.'
+      && skillName !== '..'
+      && !skillName.includes('/')
+      && !skillName.includes('\\')
+  }
+
+  /**
+   * Constructor of this instance.
+   *
+   * @returns {typeof SkillsInstaller} Constructor of this instance.
+   */
+  get Ctor () {
+    return /** @type {typeof SkillsInstaller} */ (this.constructor)
+  }
+
+  /**
+   * Node file system module.
+   *
+   * @returns {typeof fs} Node file system module.
+   */
+  get fs () {
+    return fs
+  }
+
+  /**
+   * Node path module.
+   *
+   * @returns {typeof path} Node path module.
+   */
+  get path () {
+    return path
+  }
+
+  /**
+   * Install the selected skills, replacing whatever the previous run installed.
+   *
+   * @returns {{
+   *   installedSkillNames: Array<string>
+   *   removedSkillNames: Array<string>
+   * }} Skill folder names installed and removed by this run.
+   * @public
+   */
+  install () {
+    const removedSkillNames = this.removeInstalledSkills()
+    const installedSkillNames = this.copyDistributedSkills()
+
+    this.saveManifest({
+      skillNames: installedSkillNames,
+    })
+
+    return {
+      installedSkillNames,
+      removedSkillNames,
+    }
+  }
+
+  /**
+   * Remove the skills the previous run installed.
+   *
+   * @returns {Array<string>} Removed skill folder names.
+   */
+  removeInstalledSkills () {
+    const skillNames = this.collectRemovableSkillNames()
+
+    skillNames.forEach(it => {
+      this.fs.rmSync(
+        this.buildTargetSkillPath({ skillName: it }),
+        {
+          recursive: true,
+          force: true,
+        }
+      )
+    })
+
+    return skillNames
+  }
+
+  /**
+   * Collect the skill folder names this run may remove.
+   *
+   * The manifest records what the previous run wrote, and a folder carrying the name of
+   * a distributed skill is one this package would have written, so both are replaced.
+   * A folder named after nothing this package distributes is left alone, which is what
+   * keeps a skill the consuming repository authored out of the removal.
+   *
+   * What the manifest records is read as a claim rather than as a fact, so a name that
+   * does not address a folder of the installation directory is dropped before anything
+   * is removed.
+   *
+   * @returns {Array<string>} Skill folder names to remove.
+   */
+  collectRemovableSkillNames () {
+    return [
+      ...new Set([
+        ...this.manifestFile.loadSkillNames(),
+        ...this.collectDistributedSkillNamesInTarget(),
+      ]),
+    ]
+      .filter(it => this.Ctor.isPlainSkillName({ skillName: it }))
+      .toSorted()
+  }
+
+  /**
+   * Collect the distributed skill folder names present in the target directory.
+   *
+   * Every distributed name is considered, whether or not the manifest records it, so
+   * that a run following a version that installed more removes what it left behind.
+   *
+   * @returns {Array<string>} Distributed skill folder names sitting in the target directory.
+   */
+  collectDistributedSkillNamesInTarget () {
+    const installedSkillNames = this.collectDirectoryNames({
+      directoryPath: this.targetDirectoryPath,
+    })
+
+    return this.collectDistributedSkillNames()
+      .filter(it => installedSkillNames.includes(it))
+  }
+
+  /**
+   * Collect the names of the directories directly under a directory.
+   *
+   * @param {{
+   *   directoryPath: string
+   * }} params - Parameters.
+   * @returns {Array<string>} Directory names, empty when the directory is absent.
+   */
+  collectDirectoryNames ({
+    directoryPath,
+  }) {
+    if (!this.fs.existsSync(directoryPath)) {
+      return []
+    }
+
+    return this.fs.readdirSync(
+      directoryPath,
+      { withFileTypes: true }
+    )
+      .filter(it => it.isDirectory())
+      .map(it => it.name)
+      .toSorted()
+  }
+
+  /**
+   * Build the path a skill is installed at.
+   *
+   * @param {{
+   *   skillName: string
+   * }} params - Parameters.
+   * @returns {string} Path of the installed skill.
+   */
+  buildTargetSkillPath ({
+    skillName,
+  }) {
+    return this.path.join(
+      this.targetDirectoryPath,
+      skillName
+    )
+  }
+
+  /**
+   * Copy the distributed skills into the target directory.
+   *
+   * @returns {Array<string>} Copied skill folder names.
+   */
+  copyDistributedSkills () {
+    const skillNames = this.collectDistributedSkillNames()
+
+    this.fs.mkdirSync(
+      this.targetDirectoryPath,
+      { recursive: true }
+    )
+
+    skillNames.forEach(it => {
+      this.fs.cpSync(
+        this.buildSourceSkillPath({ skillName: it }),
+        this.buildTargetSkillPath({ skillName: it }),
+        { recursive: true }
+      )
+    })
+
+    return skillNames
+  }
+
+  /**
+   * Collect every skill folder name this package distributes.
+   *
+   * @returns {Array<string>} Distributed skill folder names.
+   * @public
+   */
+  collectDistributedSkillNames () {
+    return this.collectDirectoryNames({
+      directoryPath: this.sourceDirectoryPath,
+    })
+  }
+
+  /**
+   * Build the path a skill is distributed at.
+   *
+   * @param {{
+   *   skillName: string
+   * }} params - Parameters.
+   * @returns {string} Path of the distributed skill.
+   */
+  buildSourceSkillPath ({
+    skillName,
+  }) {
+    return this.path.join(
+      this.sourceDirectoryPath,
+      skillName
+    )
+  }
+
+  /**
+   * Record what this run installed.
+   *
+   * @param {{
+   *   skillNames: Array<string>
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  saveManifest ({
+    skillNames,
+  }) {
+    this.manifestFile.save({
+      version: this.loadPackageVersion(),
+      skillNames,
+    })
+  }
+
+  /**
+   * Load the version of this package.
+   *
+   * @returns {string | null} Version of this package, or null when unreadable.
+   */
+  loadPackageVersion () {
+    try {
+      const packageHash = JSON.parse(
+        this.fs.readFileSync(
+          new URL('../../package.json', import.meta.url),
+          'utf8'
+        )
+      )
+
+      return packageHash.version
+        ?? null
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Remove every skill this package installed, along with the manifest.
+   *
+   * @returns {{
+   *   removedSkillNames: Array<string>
+   * }} Removed skill folder names.
+   * @public
+   */
+  uninstall () {
+    const removedSkillNames = this.removeInstalledSkills()
+
+    this.manifestFile.remove()
+
+    return {
+      removedSkillNames,
+    }
+  }
+}

--- a/lib/equip/SkillsManifestFile.js
+++ b/lib/equip/SkillsManifestFile.js
@@ -1,0 +1,260 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * The record of what this package installed into a consuming repository.
+ *
+ * It exists so that a later run removes exactly what an earlier run wrote, and
+ * never a skill the consuming repository authored itself.
+ *
+ * One file holds an entry per installation directory, keyed by the path the skills
+ * were installed into, so that installing into two directories keeps two records
+ * instead of one overwriting the other.
+ *
+ * ```json
+ * {
+ *   "version": "0.1.0",
+ *   "installations": {
+ *     ".claude/skills": {
+ *       "skillNames": ["hb-jsdoc", "hb-naming"]
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export default class SkillsManifestFile {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   filePath: string
+   *   installationPath: string
+   * }} params - Parameters.
+   */
+  constructor ({
+    filePath,
+    installationPath,
+  }) {
+    this.filePath = filePath
+    this.installationPath = installationPath
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof SkillsManifestFile ? X : never} T, X
+   * @param {{
+   *   filePath: string
+   *   installationPath: string
+   * }} params - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of this class.
+   * @this {T}
+   * @public
+   */
+  static create ({
+    filePath,
+    installationPath,
+  }) {
+    return new this({
+      filePath,
+      installationPath,
+    })
+  }
+
+  /**
+   * Node file system module.
+   *
+   * @returns {typeof fs} Node file system module.
+   */
+  get fs () {
+    return fs
+  }
+
+  /**
+   * Node path module.
+   *
+   * @returns {typeof path} Node path module.
+   */
+  get path () {
+    return path
+  }
+
+  /**
+   * Load the skill names recorded for this installation directory by the previous run.
+   *
+   * The manifest sits in the consuming repository, so what it holds is not guaranteed to
+   * be what a previous run wrote. Anything but an array of strings is read as nothing
+   * recorded, and a member that is not a string is dropped from the ones that are.
+   *
+   * @returns {Array<string>} Recorded skill folder names, empty when nothing usable is recorded.
+   * @public
+   */
+  loadSkillNames () {
+    const skillNames = this.loadInstallation()
+      ?.skillNames
+
+    if (!Array.isArray(skillNames)) {
+      return []
+    }
+
+    return skillNames.filter(it => typeof it === 'string')
+  }
+
+  /**
+   * Load the entry of this installation directory.
+   *
+   * @returns {SkillsInstallationHash | null} Entry of this installation directory, or null when absent.
+   */
+  loadInstallation () {
+    const installationHash = this.loadInstallationHash()
+
+    return installationHash[this.installationPath]
+      ?? null
+  }
+
+  /**
+   * Load the entries of every installation directory.
+   *
+   * @returns {Record<string, SkillsInstallationHash>} Entries by installation directory, empty when none is readable.
+   */
+  loadInstallationHash () {
+    return this.load()
+      ?.installations
+      ?? {}
+  }
+
+  /**
+   * Load the manifest.
+   *
+   * @returns {SkillsManifestHash | null} Manifest hash, or null when absent or unreadable.
+   * @public
+   */
+  load () {
+    if (!this.fs.existsSync(this.filePath)) {
+      return null
+    }
+
+    try {
+      return JSON.parse(
+        this.fs.readFileSync(
+          this.filePath,
+          'utf8'
+        )
+      )
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Save the entry of this installation directory, keeping the entries of the others.
+   *
+   * @param {{
+   *   version: string | null
+   *   skillNames: Array<string>
+   * }} params - Parameters.
+   * @returns {void}
+   * @public
+   */
+  save ({
+    version,
+    skillNames,
+  }) {
+    this.write({
+      manifestHash: {
+        version,
+        installations: {
+          ...this.loadInstallationHash(),
+          [this.installationPath]: {
+            skillNames,
+          },
+        },
+      },
+    })
+  }
+
+  /**
+   * Write the manifest, creating the directory holding it.
+   *
+   * @param {{
+   *   manifestHash: SkillsManifestHash
+   * }} params - Parameters.
+   * @returns {void}
+   */
+  write ({
+    manifestHash,
+  }) {
+    const manifestJson = JSON.stringify(
+      manifestHash,
+      null,
+      2
+    )
+
+    this.fs.mkdirSync(
+      this.path.dirname(this.filePath),
+      { recursive: true }
+    )
+
+    this.fs.writeFileSync(
+      this.filePath,
+      `${manifestJson}\n`
+    )
+  }
+
+  /**
+   * Remove the entry of this installation directory, and the file once no entry is left.
+   *
+   * @returns {void}
+   * @public
+   */
+  remove () {
+    const manifestHash = this.load()
+
+    if (!manifestHash) {
+      return
+    }
+
+    const remainingInstallationHash = this.buildRemainingInstallationHash()
+
+    if (Object.keys(remainingInstallationHash).length === 0) {
+      this.fs.rmSync(
+        this.filePath,
+        { force: true }
+      )
+
+      return
+    }
+
+    this.write({
+      manifestHash: {
+        ...manifestHash,
+        installations: remainingInstallationHash,
+      },
+    })
+  }
+
+  /**
+   * Build the entries left after dropping the one of this installation directory.
+   *
+   * @returns {Record<string, SkillsInstallationHash>} Entries of the other installation directories.
+   */
+  buildRemainingInstallationHash () {
+    return Object.fromEntries(
+      Object.entries(this.loadInstallationHash())
+        .filter(([installationPath]) => installationPath !== this.installationPath)
+    )
+  }
+}
+
+/**
+ * @typedef {{
+ *   version: string | null
+ *   installations: Record<string, SkillsInstallationHash>
+ * }} SkillsManifestHash
+ */
+
+/**
+ * @typedef {{
+ *   skillNames: Array<string>
+ * }} SkillsInstallationHash
+ */

--- a/lib/equip/constants/CLI_COMMAND.js
+++ b/lib/equip/constants/CLI_COMMAND.js
@@ -1,0 +1,8 @@
+const CLI_COMMAND = {
+  INSTALL: 'install',
+  LIST: 'list',
+  UNINSTALL: 'uninstall',
+  HELP: 'help',
+}
+
+export default CLI_COMMAND

--- a/lib/equip/hora-skills-renchan.js
+++ b/lib/equip/hora-skills-renchan.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import HoraSkillsCli from './HoraSkillsCli.js'
+
+process.exitCode = HoraSkillsCli.create({
+  args: process.argv.slice(2),
+})
+  .run()

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "docs/",
     "lib/"
   ],
+  "bin": {
+    "hora-skills-renchan": "lib/equip/hora-skills-renchan.js"
+  },
   "keywords": [
     "hora",
     "hora-kit",

--- a/tests/__tests__/equip/CommandLineArguments.js
+++ b/tests/__tests__/equip/CommandLineArguments.js
@@ -1,0 +1,508 @@
+import CommandLineArguments from '../../../lib/equip/CommandLineArguments.js'
+
+describe('CommandLineArguments', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      describe('#args', () => {
+        const cases = [
+          {
+            input: {
+              args: [],
+            },
+            expected: [],
+          },
+          {
+            input: {
+              args: [
+                'install',
+              ],
+            },
+            expected: [
+              'install',
+            ],
+          },
+          {
+            input: {
+              args: [
+                'list',
+                '--label',
+                'alpha',
+              ],
+            },
+            expected: [
+              'list',
+              '--label',
+              'alpha',
+            ],
+          },
+        ]
+
+        test.each(cases)('args: $input.args', ({ input, expected }) => {
+          const commandLineArguments = new CommandLineArguments(input)
+
+          expect(commandLineArguments)
+            .toHaveProperty('args', expected)
+        })
+      })
+    })
+  })
+})
+
+describe('CommandLineArguments', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      const cases = [
+        {
+          input: {
+            args: [],
+          },
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--label',
+              'beta',
+            ],
+          },
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input }) => {
+        const received = CommandLineArguments.create(input)
+
+        expect(received)
+          .toBeInstanceOf(CommandLineArguments)
+      })
+    })
+
+    describe('should call constructor', () => {
+      const cases = [
+        {
+          tally: {
+            args: [],
+          },
+        },
+        {
+          tally: {
+            args: [
+              'uninstall',
+            ],
+          },
+        },
+      ]
+
+      test.each(cases)('args: $tally.args', ({ tally }) => {
+        const SpyClass = constructorSpy.spyOn(CommandLineArguments)
+
+        SpyClass.create(tally)
+
+        expect(SpyClass.__spy__)
+          .toHaveBeenCalledWith(tally)
+      })
+    })
+  })
+})
+
+describe('CommandLineArguments', () => {
+  describe('.get:initialParsedHash', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const expected = {
+          commandNames: [],
+          optionHash: {},
+          pendingName: null,
+        }
+
+        const received = CommandLineArguments.initialParsedHash
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('CommandLineArguments', () => {
+  describe('.foldToken()', () => {
+    describe('should hold a command name', () => {
+      const cases = [
+        {
+          input: {
+            parsedHash: {
+              commandNames: [],
+              optionHash: {},
+              pendingName: null,
+            },
+            token: 'install',
+          },
+          expected: {
+            commandNames: [
+              'install',
+            ],
+            optionHash: {},
+            pendingName: null,
+          },
+        },
+        {
+          input: {
+            parsedHash: {
+              commandNames: [
+                'install',
+              ],
+              optionHash: {},
+              pendingName: null,
+            },
+            token: 'extra',
+          },
+          expected: {
+            commandNames: [
+              'install',
+              'extra',
+            ],
+            optionHash: {},
+            pendingName: null,
+          },
+        },
+      ]
+
+      test.each(cases)('token: $input.token', ({ input, expected }) => {
+        const received = CommandLineArguments.foldToken(input)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should hold an option name until its value arrives', () => {
+      const cases = [
+        {
+          input: {
+            parsedHash: {
+              commandNames: [],
+              optionHash: {},
+              pendingName: null,
+            },
+            token: '--label',
+          },
+          expected: {
+            commandNames: [],
+            optionHash: {},
+            pendingName: 'label',
+          },
+        },
+        {
+          input: {
+            parsedHash: {
+              commandNames: [],
+              optionHash: {},
+              pendingName: null,
+            },
+            token: '--dry-run',
+          },
+          expected: {
+            commandNames: [],
+            optionHash: {},
+            pendingName: 'dry-run',
+          },
+        },
+      ]
+
+      test.each(cases)('token: $input.token', ({ input, expected }) => {
+        const received = CommandLineArguments.foldToken(input)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should consume the token following an option name', () => {
+      const cases = [
+        {
+          input: {
+            parsedHash: {
+              commandNames: [],
+              optionHash: {},
+              pendingName: 'label',
+            },
+            token: 'alpha',
+          },
+          expected: {
+            commandNames: [],
+            optionHash: {
+              label: 'alpha',
+            },
+            pendingName: null,
+          },
+        },
+        {
+          input: {
+            parsedHash: {
+              commandNames: [
+                'install',
+              ],
+              optionHash: {
+                dir: 'skills',
+              },
+              pendingName: 'label',
+            },
+            token: 'beta',
+          },
+          expected: {
+            commandNames: [
+              'install',
+            ],
+            optionHash: {
+              dir: 'skills',
+              label: 'beta',
+            },
+            pendingName: null,
+          },
+        },
+      ]
+
+      test.each(cases)('token: $input.token', ({ input, expected }) => {
+        const received = CommandLineArguments.foldToken(input)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should split an option joined by an equals sign', () => {
+      const cases = [
+        {
+          input: {
+            parsedHash: {
+              commandNames: [],
+              optionHash: {},
+              pendingName: null,
+            },
+            token: '--label=alpha',
+          },
+          expected: {
+            commandNames: [],
+            optionHash: {
+              label: 'alpha',
+            },
+            pendingName: null,
+          },
+        },
+        {
+          input: {
+            parsedHash: {
+              commandNames: [],
+              optionHash: {},
+              pendingName: null,
+            },
+            token: '--dir=',
+          },
+          expected: {
+            commandNames: [],
+            optionHash: {
+              dir: '',
+            },
+            pendingName: null,
+          },
+        },
+      ]
+
+      test.each(cases)('token: $input.token', ({ input, expected }) => {
+        const received = CommandLineArguments.foldToken(input)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('CommandLineArguments', () => {
+  describe('#get:Ctor', () => {
+    describe('should be the constructor of the instance', () => {
+      test('when instantiated as is', () => {
+        const commandLineArguments = CommandLineArguments.create({
+          args: [],
+        })
+
+        const received = commandLineArguments.Ctor
+
+        expect(received)
+          .toBe(CommandLineArguments) // same reference
+      })
+
+      test('when instantiated as a derived class', () => {
+        class DerivedCommandLineArguments extends CommandLineArguments {}
+
+        const commandLineArguments = DerivedCommandLineArguments.create({
+          args: [],
+        })
+
+        const received = commandLineArguments.Ctor
+
+        expect(received)
+          .toBe(DerivedCommandLineArguments) // same reference
+      })
+    })
+  })
+})
+
+describe('CommandLineArguments', () => {
+  describe('#extractCommand()', () => {
+    describe('should extract the leading non-option token', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+            ],
+          },
+          expected: 'install',
+        },
+        {
+          input: {
+            args: [
+              '--label',
+              'alpha',
+              'list',
+            ],
+          },
+          expected: 'list',
+        },
+        {
+          input: {
+            args: [
+              'uninstall',
+              'extra',
+            ],
+          },
+          expected: 'uninstall',
+        },
+        {
+          input: {
+            args: [],
+          },
+          expected: null,
+        },
+        {
+          input: {
+            args: [
+              '--label',
+              'alpha',
+            ],
+          },
+          expected: null,
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const commandLineArguments = CommandLineArguments.create(input)
+
+        const received = commandLineArguments.extractCommand()
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('CommandLineArguments', () => {
+  describe('#extractOptionValue()', () => {
+    describe('should extract the value of the named option', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              'skills',
+            ],
+            name: 'dir',
+          },
+          expected: 'skills',
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--dir=skills',
+            ],
+            name: 'dir',
+          },
+          expected: 'skills',
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              'skills',
+            ],
+            name: 'label',
+          },
+          expected: null,
+        },
+      ]
+
+      test.each(cases)('name: $input.name', ({ input, expected }) => {
+        const commandLineArguments = CommandLineArguments.create({
+          args: input.args,
+        })
+        const args = {
+          name: input.name,
+        }
+
+        const received = commandLineArguments.extractOptionValue(args)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('CommandLineArguments', () => {
+  describe('#extractTargetDirectoryPath()', () => {
+    describe('should extract the value of the dir option', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              '.claude/skills',
+            ],
+          },
+          expected: '.claude/skills',
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--dir=/tmp/skills',
+            ],
+          },
+          expected: '/tmp/skills',
+        },
+        {
+          input: {
+            args: [
+              'install',
+            ],
+          },
+          expected: null,
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const commandLineArguments = CommandLineArguments.create(input)
+
+        const received = commandLineArguments.extractTargetDirectoryPath()
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})

--- a/tests/__tests__/equip/HoraSkillsCli.js
+++ b/tests/__tests__/equip/HoraSkillsCli.js
@@ -1,0 +1,1446 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import HoraSkillsCli from '../../../lib/equip/HoraSkillsCli.js'
+
+import CommandLineArguments from '../../../lib/equip/CommandLineArguments.js'
+import SkillsInstaller from '../../../lib/equip/SkillsInstaller.js'
+
+describe('HoraSkillsCli', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      describe('#commandLineArguments', () => {
+        const cases = [
+          {
+            input: {
+              commandLineArguments: CommandLineArguments.create({
+                args: [
+                  'install',
+                ],
+              }),
+            },
+          },
+          {
+            input: {
+              commandLineArguments: CommandLineArguments.create({
+                args: [],
+              }),
+            },
+          },
+        ]
+
+        test.each(cases)('args: $input.commandLineArguments.args', ({ input }) => {
+          const args = {
+            commandLineArguments: input.commandLineArguments,
+            workingDirectoryPath: '',
+            logger: null,
+          }
+
+          const cli = new HoraSkillsCli(args)
+
+          expect(cli)
+            .toHaveProperty('commandLineArguments', input.commandLineArguments)
+        })
+      })
+
+      describe('#workingDirectoryPath', () => {
+        const cases = [
+          {
+            input: {
+              workingDirectoryPath: '/consumer',
+            },
+            expected: '/consumer',
+          },
+          {
+            input: {
+              workingDirectoryPath: '/tmp/consumer',
+            },
+            expected: '/tmp/consumer',
+          },
+        ]
+
+        test.each(cases)('workingDirectoryPath: $input.workingDirectoryPath', ({ input, expected }) => {
+          const args = {
+            commandLineArguments: null,
+            workingDirectoryPath: input.workingDirectoryPath,
+            logger: null,
+          }
+
+          const cli = new HoraSkillsCli(args)
+
+          expect(cli)
+            .toHaveProperty('workingDirectoryPath', expected)
+        })
+      })
+
+      describe('#logger', () => {
+        const cases = [
+          {
+            input: {
+              logger: console,
+            },
+          },
+          {
+            input: {
+              logger: {
+                log: () => {},
+                error: () => {},
+              },
+            },
+          },
+        ]
+
+        test.each(cases)('logger: $input.logger', ({ input }) => {
+          const args = {
+            commandLineArguments: null,
+            workingDirectoryPath: '',
+            logger: input.logger,
+          }
+
+          const cli = new HoraSkillsCli(args)
+
+          expect(cli)
+            .toHaveProperty('logger', input.logger)
+        })
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+            ],
+            workingDirectoryPath: '/consumer',
+          },
+        },
+        {
+          input: {
+            args: [],
+            workingDirectoryPath: '/tmp',
+          },
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input }) => {
+        const received = HoraSkillsCli.create(input)
+
+        expect(received)
+          .toBeInstanceOf(HoraSkillsCli)
+      })
+    })
+
+    describe('should fill default workingDirectoryPath', () => {
+      test('when omitted', () => {
+        const args = {
+          args: [],
+        }
+
+        const cli = HoraSkillsCli.create(args)
+
+        expect(cli)
+          .toHaveProperty('workingDirectoryPath', process.cwd())
+      })
+    })
+
+    describe('should fill default logger', () => {
+      test('when omitted', () => {
+        const args = {
+          args: [],
+        }
+
+        const cli = HoraSkillsCli.create(args)
+
+        expect(cli)
+          .toHaveProperty('logger', console)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('.get:CommandLineArgumentsCtor', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const received = HoraSkillsCli.CommandLineArgumentsCtor
+
+        expect(received)
+          .toBe(CommandLineArguments) // same reference
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('.get:SkillsInstallerCtor', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const received = HoraSkillsCli.SkillsInstallerCtor
+
+        expect(received)
+          .toBe(SkillsInstaller) // same reference
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('.get:defaultTargetDirectorySegments', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const expected = [
+          '.claude',
+          'skills',
+        ]
+
+        const received = HoraSkillsCli.defaultTargetDirectorySegments
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('.buildPathSteps()', () => {
+    describe('should be every step from the base path down to the target path', () => {
+      const cases = [
+        {
+          input: {
+            basePath: '/consumer',
+            targetPath: '/consumer/.claude/skills',
+          },
+          expected: [
+            '/consumer/.claude',
+            '/consumer/.claude/skills',
+          ],
+        },
+        {
+          input: {
+            basePath: '/consumer/.claude',
+            targetPath: '/consumer/.claude/skills',
+          },
+          expected: [
+            '/consumer/.claude/skills',
+          ],
+        },
+        {
+          input: {
+            basePath: '/consumer',
+            targetPath: '/consumer',
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('targetPath: $input.targetPath', ({ input, expected }) => {
+        const received = HoraSkillsCli.buildPathSteps(input)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#dispatch()', () => {
+    describe('should dispatch to the command', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+            ],
+          },
+          expected: 'runInstall',
+        },
+        {
+          input: {
+            args: [
+              'list',
+            ],
+          },
+          expected: 'runCatalog',
+        },
+        {
+          input: {
+            args: [
+              'uninstall',
+            ],
+          },
+          expected: 'runUninstall',
+        },
+        {
+          input: {
+            args: [
+              'help',
+            ],
+          },
+          expected: 'runHelp',
+        },
+        {
+          input: {
+            args: [],
+          },
+          expected: 'runHelp',
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: input.args,
+          workingDirectoryPath: '/consumer',
+          logger: {
+            log: () => {},
+            error: () => {},
+          },
+        })
+
+        const commandSpy = jest.spyOn(cli, expected)
+          .mockReturnValue(0)
+
+        cli.dispatch()
+
+        expect(commandSpy)
+          .toHaveBeenCalledWith()
+      })
+    })
+
+    describe('should report a command it does not have', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'bogus',
+            ],
+          },
+          expected: 'Unknown command: bogus',
+        },
+        {
+          input: {
+            args: [
+              'installl',
+            ],
+          },
+          expected: 'Unknown command: installl',
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: input.args,
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        const received = cli.dispatch()
+
+        expect(logger.error)
+          .toHaveBeenCalledWith(expected)
+        expect(received)
+          .toBe(1)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#runInstall()', () => {
+    describe('should install the distributed skills', () => {
+      const cases = [
+        {
+          override: {
+            installResult: {
+              installedSkillNames: [
+                'hb-query-resolver',
+              ],
+              removedSkillNames: [],
+            },
+          },
+          expected: 'Installed 1 skills into /consumer/.claude/skills',
+        },
+        {
+          override: {
+            installResult: {
+              installedSkillNames: [
+                'hb-naming',
+                'hb-jsdoc',
+              ],
+              removedSkillNames: [
+                'hb-css',
+              ],
+            },
+          },
+          expected: 'Installed 2 skills into /consumer/.claude/skills',
+        },
+      ]
+
+      test.each(cases)('installedSkillNames: $override.installResult.installedSkillNames', ({ override, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(SkillsInstaller.prototype, 'install')
+          .mockReturnValue(override.installResult)
+
+        const received = cli.runInstall()
+
+        expect(logger.log)
+          .toHaveBeenCalledWith(expected)
+        expect(received)
+          .toBe(0)
+      })
+    })
+
+    describe('should install nothing when the installation directory is reached through a symbolic link', () => {
+      test('args: install', () => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(cli, 'verifyPaths')
+          .mockReturnValue(1)
+
+        const installSpy = jest.spyOn(SkillsInstaller.prototype, 'install')
+          .mockReturnValue({
+            installedSkillNames: [],
+            removedSkillNames: [],
+          })
+
+        const received = cli.runInstall()
+
+        expect(received)
+          .toBe(1)
+        expect(installSpy)
+          .not
+          .toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#run()', () => {
+    describe('should report what a command raises, instead of letting it escape', () => {
+      const cases = [
+        {
+          override: {
+            error: new Error('ENOTDIR: not a directory, scandir \'/consumer/.claude/skills\''),
+          },
+          expected: 'ENOTDIR: not a directory, scandir \'/consumer/.claude/skills\'',
+        },
+        {
+          override: {
+            error: new Error('EACCES: permission denied, mkdir \'/consumer/.claude/skills\''),
+          },
+          expected: 'EACCES: permission denied, mkdir \'/consumer/.claude/skills\'',
+        },
+      ]
+
+      test.each(cases)('error: $override.error.message', ({ override, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(cli, 'dispatch')
+          .mockImplementation(() => {
+            throw override.error
+          })
+
+        const received = cli.run()
+
+        expect(received)
+          .toBe(1)
+        expect(logger.error)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+
+    describe('should be the exit code of the command it dispatched', () => {
+      const cases = [
+        {
+          override: {
+            exitCode: 0,
+          },
+        },
+        {
+          override: {
+            exitCode: 1,
+          },
+        },
+      ]
+
+      test.each(cases)('exitCode: $override.exitCode', ({ override }) => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(cli, 'dispatch')
+          .mockReturnValue(override.exitCode)
+
+        const received = cli.run()
+
+        expect(received)
+          .toBe(override.exitCode)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#reportFailure()', () => {
+    describe('should report the failure and fail', () => {
+      const cases = [
+        {
+          input: {
+            error: new Error('EROFS: read-only file system'),
+          },
+          expected: 'EROFS: read-only file system',
+        },
+      ]
+
+      test.each(cases)('error: $input.error.message', ({ input, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        const received = cli.reportFailure(input)
+
+        expect(received)
+          .toBe(1)
+        expect(logger.error)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('.buildFailureMessage()', () => {
+    describe('should be the message of the error', () => {
+      const cases = [
+        {
+          input: {
+            error: new Error('EACCES: permission denied'),
+          },
+          expected: 'EACCES: permission denied',
+        },
+        {
+          input: {
+            error: new Error('ENOENT: no such file, open \'/consumer/.claude/スキル\''),
+          },
+          expected: 'ENOENT: no such file, open \'/consumer/.claude/スキル\'',
+        },
+      ]
+
+      test.each(cases)('error: $input.error.message', ({ input, expected }) => {
+        const received = HoraSkillsCli.buildFailureMessage(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should drop the characters a terminal acts on', () => {
+      const cases = [
+        {
+          input: {
+            error: new Error('EACCES: denied, rm \'/consumer/.claude/skills/\u001b[2Jhora\''),
+          },
+          expected: 'EACCES: denied, rm \'/consumer/.claude/skills/?[2Jhora\'',
+        },
+        {
+          input: {
+            error: new Error('ENOENT: no such file\u0000\u007f'),
+          },
+          expected: 'ENOENT: no such file??',
+        },
+      ]
+
+      test.each(cases)('error: $input.error.message', ({ input, expected }) => {
+        const received = HoraSkillsCli.buildFailureMessage(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should be the value itself when it is not an error', () => {
+      const cases = [
+        {
+          input: {
+            error: 'raised a string',
+          },
+          expected: 'raised a string',
+        },
+        {
+          input: {
+            error: null,
+          },
+          expected: 'null',
+        },
+      ]
+
+      test.each(cases)('error: $input.error', ({ input, expected }) => {
+        const received = HoraSkillsCli.buildFailureMessage(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('.buildPrintableCharacter()', () => {
+    describe('should be the character itself when a terminal prints it', () => {
+      const cases = [
+        {
+          input: {
+            character: 'a',
+          },
+        },
+        {
+          input: {
+            character: ' ',
+          },
+        },
+        {
+          input: {
+            character: 'ス',
+          },
+        },
+      ]
+
+      test.each(cases)('character: $input.character', ({ input }) => {
+        const received = HoraSkillsCli.buildPrintableCharacter(input)
+
+        expect(received)
+          .toBe(input.character)
+      })
+    })
+
+    describe('should stand in for the character when a terminal acts on it', () => {
+      const cases = [
+        {
+          input: {
+            character: '\u001b',
+          },
+        },
+        {
+          input: {
+            character: '\u0000',
+          },
+        },
+        {
+          input: {
+            character: '\u007f',
+          },
+        },
+        {
+          input: {
+            character: '\n',
+          },
+        },
+      ]
+
+      test.each(cases)('codePoint: $input.character.codePointAt', ({ input }) => {
+        const received = HoraSkillsCli.buildPrintableCharacter(input)
+
+        expect(received)
+          .toBe('?')
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#buildSkillsInstaller()', () => {
+    describe('should build the installer with the working and the target directory', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+            ],
+            workingDirectoryPath: '/consumer',
+          },
+          expected: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/.claude/skills',
+          },
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              'tools/skills',
+            ],
+            workingDirectoryPath: '/consumer',
+          },
+          expected: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/tools/skills',
+          },
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: input.args,
+          workingDirectoryPath: input.workingDirectoryPath,
+          logger: {
+            log: () => {},
+            error: () => {},
+          },
+        })
+
+        const createSkillsInstallerSpy = jest.spyOn(HoraSkillsCli, 'createSkillsInstaller')
+          .mockReturnValue(null)
+
+        cli.buildSkillsInstaller()
+
+        expect(createSkillsInstallerSpy)
+          .toHaveBeenCalledWith({
+            workingDirectoryPath: expected.workingDirectoryPath,
+            targetDirectoryPath: expected.targetDirectoryPath,
+          })
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#buildTargetDirectoryPath()', () => {
+    describe('should be the .claude/skills of the working directory', () => {
+      const cases = [
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+          },
+          expected: '/consumer/.claude/skills',
+        },
+        {
+          input: {
+            workingDirectoryPath: '/tmp/consumer',
+          },
+          expected: '/tmp/consumer/.claude/skills',
+        },
+      ]
+
+      test.each(cases)('workingDirectoryPath: $input.workingDirectoryPath', ({ input, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: input.workingDirectoryPath,
+          logger: {
+            log: () => {},
+            error: () => {},
+          },
+        })
+
+        const received = cli.buildTargetDirectoryPath()
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should resolve the given directory against the working directory', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              'skills',
+            ],
+          },
+          expected: '/consumer/skills',
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              '/tmp/skills',
+            ],
+          },
+          expected: '/tmp/skills',
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: input.args,
+          workingDirectoryPath: '/consumer',
+          logger: {
+            log: () => {},
+            error: () => {},
+          },
+        })
+
+        const received = cli.buildTargetDirectoryPath()
+
+        expect(received)
+          .toBe(path.normalize(expected))
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#buildVerifiedBaseDirectoryPath()', () => {
+    describe('should be the working directory when no directory is given', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+            ],
+          },
+          expected: '/consumer',
+        },
+        {
+          input: {
+            args: [
+              'uninstall',
+            ],
+          },
+          expected: '/consumer',
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: input.args,
+          workingDirectoryPath: '/consumer',
+        })
+
+        const received = cli.buildVerifiedBaseDirectoryPath()
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should be the given directory when one is given', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              'tools/skills',
+            ],
+          },
+          expected: '/consumer/tools/skills',
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--dir=/opt/skills',
+            ],
+          },
+          expected: '/opt/skills',
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: input.args,
+          workingDirectoryPath: '/consumer',
+        })
+
+        const received = cli.buildVerifiedBaseDirectoryPath()
+
+        expect(received)
+          .toBe(path.normalize(expected))
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#isSymbolicLink()', () => {
+    describe('should be what lstat tells of the path', () => {
+      const cases = [
+        {
+          override: {
+            isSymbolicLink: true,
+          },
+          expected: true,
+        },
+        {
+          override: {
+            isSymbolicLink: false,
+          },
+          expected: false,
+        },
+      ]
+
+      test.each(cases)('isSymbolicLink: $override.isSymbolicLink', ({ override, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(fs, 'lstatSync')
+          .mockReturnValue(
+            /** @type {*} */ ({
+              isSymbolicLink: () => override.isSymbolicLink,
+            })
+          )
+
+        const received = cli.isSymbolicLink({
+          filePath: '/consumer/.claude',
+        })
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should be false when the path does not exist', () => {
+      test('filePath: /consumer/.claude', () => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(fs, 'lstatSync')
+          .mockImplementation(() => {
+            throw new Error('ENOENT')
+          })
+
+        const received = cli.isSymbolicLink({
+          filePath: '/consumer/.claude',
+        })
+
+        expect(received)
+          .toBe(false)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#isReachedThroughSymbolicLink()', () => {
+    describe('should be true when any step of the path is a symbolic link', () => {
+      const cases = [
+        {
+          override: {
+            linkedPaths: [
+              '/consumer/.claude',
+            ],
+          },
+          expected: true,
+        },
+        {
+          override: {
+            linkedPaths: [
+              '/consumer/.claude/skills',
+            ],
+          },
+          expected: true,
+        },
+        {
+          override: {
+            linkedPaths: [],
+          },
+          expected: false,
+        },
+        {
+          override: {
+            linkedPaths: [
+              '/consumer/tools',
+            ],
+          },
+          expected: false,
+        },
+      ]
+
+      test.each(cases)('linkedPaths: $override.linkedPaths', ({ override, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(cli, 'isSymbolicLink')
+          .mockImplementation(({ filePath }) => override.linkedPaths.includes(filePath))
+
+        const received = cli.isReachedThroughSymbolicLink({
+          basePath: '/consumer',
+          targetPath: '/consumer/.claude/skills',
+        })
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#collectLinkedTargetDirectoryPaths()', () => {
+    describe('should be the installation directory when it is reached through a symbolic link', () => {
+      const cases = [
+        {
+          override: {
+            targetDirectoryPath: '/consumer/.claude/skills',
+            linkedTargetDirectoryPaths: [
+              '/consumer/.claude/skills',
+            ],
+          },
+          expected: [
+            '/consumer/.claude/skills',
+          ],
+        },
+        {
+          override: {
+            targetDirectoryPath: '/consumer/.claude/skills',
+            linkedTargetDirectoryPaths: [],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('linkedTargetDirectoryPaths: $override.linkedTargetDirectoryPaths', ({ override, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(cli, 'buildTargetDirectoryPath')
+          .mockReturnValue(override.targetDirectoryPath)
+        jest.spyOn(cli, 'isReachedThroughSymbolicLink')
+          .mockImplementation(({ targetPath }) =>
+            override.linkedTargetDirectoryPaths.includes(targetPath)
+          )
+
+        const received = cli.collectLinkedTargetDirectoryPaths()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#verifyPaths()', () => {
+    describe('should refuse an installation directory reached through a symbolic link', () => {
+      const cases = [
+        {
+          override: {
+            linkedTargetDirectoryPaths: [
+              '/consumer/.claude/skills',
+            ],
+          },
+          expected: [
+            '/consumer/.claude/skills is reached through a symbolic link.',
+            'Nothing was changed. An installation carries nothing through a link — replace it, or give --dir the directory it resolves to.',
+          ],
+        },
+      ]
+
+      test.each(cases)('linkedTargetDirectoryPaths: $override.linkedTargetDirectoryPaths', ({ override, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(cli, 'collectLinkedTargetDirectoryPaths')
+          .mockReturnValue(override.linkedTargetDirectoryPaths)
+        jest.spyOn(cli, 'collectLinkedManifestFilePaths')
+          .mockReturnValue([])
+
+        const received = cli.verifyPaths()
+
+        expect(received)
+          .toBe(1)
+        expect(logger.error)
+          .toHaveBeenNthCalledWith(1, expected[0])
+        expect(logger.error)
+          .toHaveBeenNthCalledWith(2, expected[1])
+      })
+    })
+
+    describe('should pass when the installation directory is reached through none', () => {
+      test('linkedTargetDirectoryPaths: []', () => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(cli, 'collectLinkedTargetDirectoryPaths')
+          .mockReturnValue([])
+        jest.spyOn(cli, 'collectLinkedManifestFilePaths')
+          .mockReturnValue([])
+
+        const received = cli.verifyPaths()
+
+        expect(received)
+          .toBe(0)
+        expect(logger.error)
+          .not
+          .toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#buildManifestFilePath()', () => {
+    describe('should be the record below the working directory', () => {
+      const cases = [
+        {
+          input: {
+            args: [
+              'install',
+            ],
+          },
+          expected: '/consumer/.hora/hora-skills-renchan.json',
+        },
+        {
+          input: {
+            args: [
+              'install',
+              '--dir',
+              'tools/skills',
+            ],
+          },
+          expected: '/consumer/.hora/hora-skills-renchan.json',
+        },
+      ]
+
+      test.each(cases)('args: $input.args', ({ input, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: input.args,
+          workingDirectoryPath: '/consumer',
+        })
+
+        const received = cli.buildManifestFilePath()
+
+        expect(received)
+          .toBe(path.normalize(expected))
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#collectLinkedManifestFilePaths()', () => {
+    describe('should be the record when it is reached through a symbolic link', () => {
+      const cases = [
+        {
+          override: {
+            linkedPaths: [
+              '/consumer/.hora',
+            ],
+          },
+          expected: [
+            '/consumer/.hora/hora-skills-renchan.json',
+          ],
+        },
+        {
+          override: {
+            linkedPaths: [
+              '/consumer/.hora/hora-skills-renchan.json',
+            ],
+          },
+          expected: [
+            '/consumer/.hora/hora-skills-renchan.json',
+          ],
+        },
+        {
+          override: {
+            linkedPaths: [],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('linkedPaths: $override.linkedPaths', ({ override, expected }) => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(cli, 'isSymbolicLink')
+          .mockImplementation(({ filePath }) => override.linkedPaths.includes(filePath))
+
+        const received = cli.collectLinkedManifestFilePaths()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#verifyPaths()', () => {
+    describe('should refuse a record reached through a symbolic link', () => {
+      const cases = [
+        {
+          override: {
+            linkedManifestFilePaths: [
+              '/consumer/.hora/hora-skills-renchan.json',
+            ],
+          },
+          expected: '/consumer/.hora/hora-skills-renchan.json is reached through a symbolic link.',
+        },
+      ]
+
+      test.each(cases)('linkedManifestFilePaths: $override.linkedManifestFilePaths', ({ override, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(cli, 'collectLinkedTargetDirectoryPaths')
+          .mockReturnValue([])
+        jest.spyOn(cli, 'collectLinkedManifestFilePaths')
+          .mockReturnValue(override.linkedManifestFilePaths)
+
+        const received = cli.verifyPaths()
+
+        expect(received)
+          .toBe(1)
+        expect(logger.error)
+          .toHaveBeenNthCalledWith(1, expected)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#runCatalog()', () => {
+    describe('should print each distributed skill', () => {
+      const cases = [
+        {
+          override: {
+            distributedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          expected: '1 skills distributed',
+        },
+        {
+          override: {
+            distributedSkillNames: [
+              'hb-query-resolver',
+              'hb-stub-api',
+            ],
+          },
+          expected: '2 skills distributed',
+        },
+      ]
+
+      test.each(cases)('distributedSkillNames: $override.distributedSkillNames', ({ override, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'list',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(SkillsInstaller.prototype, 'collectDistributedSkillNames')
+          .mockReturnValue(override.distributedSkillNames)
+
+        const received = cli.runCatalog()
+
+        expect(logger.log)
+          .toHaveBeenCalledWith(expected)
+        expect(received)
+          .toBe(0)
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#runUninstall()', () => {
+    describe('should report the removed skills', () => {
+      const cases = [
+        {
+          override: {
+            uninstallResult: {
+              removedSkillNames: [
+                'hb-query-resolver',
+              ],
+            },
+          },
+          expected: 'Removed 1 skills from /consumer/.claude/skills',
+        },
+        {
+          override: {
+            uninstallResult: {
+              removedSkillNames: [],
+            },
+          },
+          expected: 'Removed 0 skills from /consumer/.claude/skills',
+        },
+      ]
+
+      test.each(cases)('removedSkillNames: $override.uninstallResult.removedSkillNames', ({ override, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'uninstall',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(SkillsInstaller.prototype, 'uninstall')
+          .mockReturnValue(override.uninstallResult)
+
+        const received = cli.runUninstall()
+
+        expect(logger.log)
+          .toHaveBeenCalledWith(expected)
+        expect(received)
+          .toBe(0)
+      })
+    })
+
+    describe('should remove nothing when the installation directory is reached through a symbolic link', () => {
+      test('args: uninstall', () => {
+        const cli = HoraSkillsCli.create({
+          args: [
+            'uninstall',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(cli, 'verifyPaths')
+          .mockReturnValue(1)
+
+        const uninstallSpy = jest.spyOn(SkillsInstaller.prototype, 'uninstall')
+          .mockReturnValue({
+            removedSkillNames: [],
+          })
+
+        const received = cli.runUninstall()
+
+        expect(received)
+          .toBe(1)
+        expect(uninstallSpy)
+          .not
+          .toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('HoraSkillsCli', () => {
+  describe('#runHelp()', () => {
+    describe('when called as is', () => {
+      test('should print the usage text', () => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraSkillsCli.create({
+          args: [
+            'help',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        const received = cli.runHelp()
+
+        expect(logger.log)
+          .toHaveBeenCalledWith(HoraSkillsCli.usageText)
+        expect(received)
+          .toBe(0)
+      })
+    })
+  })
+})

--- a/tests/__tests__/equip/SkillsInstaller.js
+++ b/tests/__tests__/equip/SkillsInstaller.js
@@ -1,0 +1,1455 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import SkillsInstaller from '../../../lib/equip/SkillsInstaller.js'
+
+import SkillsManifestFile from '../../../lib/equip/SkillsManifestFile.js'
+
+describe('SkillsInstaller', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      describe('#sourceDirectoryPath', () => {
+        const cases = [
+          {
+            input: {
+              sourceDirectoryPath: '/package/dist/skills',
+            },
+            expected: '/package/dist/skills',
+          },
+          {
+            input: {
+              sourceDirectoryPath: 'dist/skills',
+            },
+            expected: 'dist/skills',
+          },
+        ]
+
+        test.each(cases)('sourceDirectoryPath: $input.sourceDirectoryPath', ({ input, expected }) => {
+          const args = {
+            sourceDirectoryPath: input.sourceDirectoryPath,
+            targetDirectoryPath: '',
+            manifestFile: null,
+          }
+
+          const installer = new SkillsInstaller(args)
+
+          expect(installer)
+            .toHaveProperty('sourceDirectoryPath', expected)
+        })
+      })
+
+      describe('#targetDirectoryPath', () => {
+        const cases = [
+          {
+            input: {
+              workingDirectoryPath: '/consumer',
+              targetDirectoryPath: '/consumer/.claude/skills',
+            },
+            expected: '/consumer/.claude/skills',
+          },
+          {
+            input: {
+              workingDirectoryPath: '.',
+              targetDirectoryPath: '.claude/skills',
+            },
+            expected: '.claude/skills',
+          },
+        ]
+
+        test.each(cases)('targetDirectoryPath: $input.targetDirectoryPath', ({ input, expected }) => {
+          const args = {
+            sourceDirectoryPath: '',
+            targetDirectoryPath: input.targetDirectoryPath,
+            manifestFile: null,
+          }
+
+          const installer = new SkillsInstaller(args)
+
+          expect(installer)
+            .toHaveProperty('targetDirectoryPath', expected)
+        })
+      })
+
+      describe('#manifestFile', () => {
+        const cases = [
+          {
+            input: {
+              manifestFile: SkillsManifestFile.create({
+                filePath: '/consumer/.hora/hora-skills-renchan.json',
+                installationPath: '.claude/skills',
+              }),
+            },
+          },
+          {
+            input: {
+              manifestFile: SkillsManifestFile.create({
+                filePath: '.hora/hora-skills-renchan.json',
+                installationPath: 'tools/skills',
+              }),
+            },
+          },
+        ]
+
+        test.each(cases)('filePath: $input.manifestFile.filePath', ({ input }) => {
+          const args = {
+            sourceDirectoryPath: '',
+            targetDirectoryPath: '',
+            manifestFile: input.manifestFile,
+          }
+
+          const installer = new SkillsInstaller(args)
+
+          expect(installer)
+            .toHaveProperty('manifestFile', input.manifestFile)
+        })
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      const cases = [
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/.claude/skills',
+            sourceDirectoryPath: '/package/dist/skills',
+          },
+        },
+        {
+          input: {
+            workingDirectoryPath: '.',
+            targetDirectoryPath: '.claude/skills',
+            sourceDirectoryPath: 'dist/skills',
+          },
+        },
+      ]
+
+      test.each(cases)('targetDirectoryPath: $input.targetDirectoryPath', ({ input }) => {
+        const received = SkillsInstaller.create(input)
+
+        expect(received)
+          .toBeInstanceOf(SkillsInstaller)
+      })
+    })
+
+    describe('should call constructor', () => {
+      const cases = [
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/.claude/skills',
+            sourceDirectoryPath: '/package/dist/skills',
+          },
+          expected: {
+            filePath: '/consumer/.hora/hora-skills-renchan.json',
+            installationPath: '.claude/skills',
+          },
+        },
+        {
+          input: {
+            workingDirectoryPath: '/tmp',
+            targetDirectoryPath: '/tmp/skills',
+            sourceDirectoryPath: '/package/dist/skills',
+          },
+          expected: {
+            filePath: '/tmp/.hora/hora-skills-renchan.json',
+            installationPath: 'skills',
+          },
+        },
+      ]
+
+      test.each(cases)('targetDirectoryPath: $input.targetDirectoryPath', ({ input, expected }) => {
+        const args = {
+          workingDirectoryPath: input.workingDirectoryPath,
+          targetDirectoryPath: input.targetDirectoryPath,
+          sourceDirectoryPath: input.sourceDirectoryPath,
+        }
+
+        const installer = SkillsInstaller.create(args)
+        const received = installer.manifestFile
+
+        expect(received)
+          .toHaveProperty('filePath', expected.filePath)
+        expect(received)
+          .toHaveProperty('installationPath', expected.installationPath)
+      })
+    })
+
+    describe('should fill default sourceDirectoryPath', () => {
+      const cases = [
+        {
+          override: {
+            sourceDirectoryPath: '/package/dist/skills',
+          },
+        },
+        {
+          override: {
+            sourceDirectoryPath: '/elsewhere/dist/skills',
+          },
+        },
+      ]
+
+      test.each(cases)('sourceDirectoryPath: $override.sourceDirectoryPath', ({ override }) => {
+        jest.spyOn(SkillsInstaller, 'buildDefaultSourceDirectoryPath')
+          .mockReturnValue(override.sourceDirectoryPath)
+
+        const args = {
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+        }
+
+        const installer = SkillsInstaller.create(args)
+
+        expect(installer)
+          .toHaveProperty('sourceDirectoryPath', override.sourceDirectoryPath)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('.get:SkillsManifestFileCtor', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const received = SkillsInstaller.SkillsManifestFileCtor
+
+        expect(received)
+          .toBe(SkillsManifestFile) // same reference
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('.get:manifestPathSegments', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const received = SkillsInstaller.manifestPathSegments
+
+        expect(received)
+          .toEqual([
+            '.hora',
+            'hora-skills-renchan.json',
+          ])
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('.buildDefaultSourceDirectoryPath()', () => {
+    describe('when called as is', () => {
+      test('should be the distributed skills of this package', () => {
+        const expected = path.resolve(
+          import.meta.dirname,
+          '../../../dist/skills'
+        )
+
+        const received = SkillsInstaller.buildDefaultSourceDirectoryPath()
+
+        expect(received)
+          .toBe(`${expected}${path.sep}`)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('.createSkillsManifestFile()', () => {
+    describe('should place the manifest under the working directory', () => {
+      const cases = [
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/.claude/skills',
+          },
+          expected: '/consumer/.hora/hora-skills-renchan.json',
+        },
+        {
+          input: {
+            workingDirectoryPath: '/tmp',
+            targetDirectoryPath: '/tmp/skills/',
+          },
+          expected: '/tmp/.hora/hora-skills-renchan.json',
+        },
+      ]
+
+      test.each(cases)('targetDirectoryPath: $input.targetDirectoryPath', ({ input, expected }) => {
+        const manifestFile = SkillsInstaller.createSkillsManifestFile(input)
+        const received = manifestFile.filePath
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should key the entry by the installation path', () => {
+      const cases = [
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/.claude/skills',
+          },
+          expected: '.claude/skills',
+        },
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/tools/skills',
+          },
+          expected: 'tools/skills',
+        },
+      ]
+
+      test.each(cases)('targetDirectoryPath: $input.targetDirectoryPath', ({ input, expected }) => {
+        const manifestFile = SkillsInstaller.createSkillsManifestFile(input)
+        const received = manifestFile.installationPath
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('.buildInstallationPath()', () => {
+    describe('should be the target directory relative to the working directory', () => {
+      const cases = [
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/.claude/skills',
+          },
+          expected: '.claude/skills',
+        },
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/tools/skills',
+          },
+          expected: 'tools/skills',
+        },
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer',
+          },
+          expected: '',
+        },
+        {
+          input: {
+            workingDirectoryPath: '/consumer/app',
+            targetDirectoryPath: '/consumer/.claude/skills',
+          },
+          expected: '../.claude/skills',
+        },
+      ]
+
+      test.each(cases)('targetDirectoryPath: $input.targetDirectoryPath', ({ input, expected }) => {
+        const received = SkillsInstaller.buildInstallationPath(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('.isPlainSkillName()', () => {
+    describe('should be true for a folder of the installation directory', () => {
+      const cases = [
+        {
+          input: {
+            skillName: 'hb-naming',
+          },
+        },
+        {
+          input: {
+            skillName: 'hb-cp-table',
+          },
+        },
+        {
+          input: {
+            skillName: '.hidden-skill',
+          },
+        },
+        {
+          input: {
+            skillName: 'skill with space',
+          },
+        },
+      ]
+
+      test.each(cases)('skillName: $input.skillName', ({ input }) => {
+        const received = SkillsInstaller.isPlainSkillName(input)
+
+        expect(received)
+          .toBe(true)
+      })
+    })
+
+    describe('should be false for a skill name reaching outside the installation directory', () => {
+      const cases = [
+        {
+          input: {
+            skillName: '..',
+          },
+        },
+        {
+          input: {
+            skillName: '.',
+          },
+        },
+        {
+          input: {
+            skillName: '',
+          },
+        },
+        {
+          input: {
+            skillName: '../../../canary',
+          },
+        },
+        {
+          input: {
+            skillName: 'hb-naming/SKILL.md',
+          },
+        },
+        {
+          input: {
+            skillName: '/etc/hosts',
+          },
+        },
+        {
+          input: {
+            skillName: '..\\..\\canary',
+          },
+        },
+      ]
+
+      test.each(cases)('skillName: $input.skillName', ({ input }) => {
+        const received = SkillsInstaller.isPlainSkillName(input)
+
+        expect(received)
+          .toBe(false)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#get:fs', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        const received = installer.fs
+
+        expect(received)
+          .toBe(fs) // same reference
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#get:path', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        const received = installer.path
+
+        expect(received)
+          .toBe(path) // same reference
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#install()', () => {
+    describe('should record what it installed', () => {
+      const cases = [
+        {
+          override: {
+            removedSkillNames: [
+              'hb-cp-table',
+            ],
+            installedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          expected: {
+            skillNames: [
+              'hb-query-resolver',
+            ],
+          },
+        },
+        {
+          override: {
+            removedSkillNames: [],
+            installedSkillNames: [],
+          },
+          expected: {
+            skillNames: [],
+          },
+        },
+      ]
+
+      test.each(cases)('installedSkillNames: $override.installedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer, 'removeInstalledSkills')
+          .mockReturnValue(override.removedSkillNames)
+        jest.spyOn(installer, 'copyDistributedSkills')
+          .mockReturnValue(override.installedSkillNames)
+
+        const saveManifestSpy = jest.spyOn(installer, 'saveManifest')
+          .mockReturnValue()
+
+        installer.install()
+
+        expect(saveManifestSpy)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+
+    describe('should report the removed and the installed skills', () => {
+      const cases = [
+        {
+          override: {
+            removedSkillNames: [
+              'hb-cp-table',
+            ],
+            installedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          expected: {
+            removedSkillNames: [
+              'hb-cp-table',
+            ],
+            installedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+        },
+        {
+          override: {
+            removedSkillNames: [],
+            installedSkillNames: [
+              'hb-naming',
+              'hb-jsdoc',
+            ],
+          },
+          expected: {
+            removedSkillNames: [],
+            installedSkillNames: [
+              'hb-naming',
+              'hb-jsdoc',
+            ],
+          },
+        },
+      ]
+
+      test.each(cases)('installedSkillNames: $override.installedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer, 'removeInstalledSkills')
+          .mockReturnValue(override.removedSkillNames)
+        jest.spyOn(installer, 'copyDistributedSkills')
+          .mockReturnValue(override.installedSkillNames)
+        jest.spyOn(installer, 'saveManifest')
+          .mockReturnValue()
+
+        const received = installer.install()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#removeInstalledSkills()', () => {
+    describe('should remove every owned skill directory', () => {
+      const cases = [
+        {
+          override: {
+            recordedSkillNames: [
+              'hb-query-resolver',
+              'hb-stub-api',
+            ],
+          },
+          expected: [
+            [
+              '/consumer/.claude/skills/hb-query-resolver',
+              {
+                recursive: true,
+                force: true,
+              },
+            ],
+            [
+              '/consumer/.claude/skills/hb-stub-api',
+              {
+                recursive: true,
+                force: true,
+              },
+            ],
+          ],
+        },
+      ]
+
+      test.each(cases)('recordedSkillNames: $override.recordedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadSkillNames')
+          .mockReturnValue(override.recordedSkillNames)
+
+        const rmSyncSpy = jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+
+        installer.removeInstalledSkills()
+
+        expect(rmSyncSpy)
+          .toHaveBeenNthCalledWith(1, ...expected[0])
+        expect(rmSyncSpy)
+          .toHaveBeenNthCalledWith(2, ...expected[1])
+      })
+    })
+
+    describe('should report the removed skills', () => {
+      const cases = [
+        {
+          override: {
+            recordedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          expected: [
+            'hb-query-resolver',
+          ],
+        },
+        {
+          override: {
+            recordedSkillNames: [],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('recordedSkillNames: $override.recordedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadSkillNames')
+          .mockReturnValue(override.recordedSkillNames)
+        jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+
+        const received = installer.removeInstalledSkills()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should keep a skill named after nothing this package distributes', () => {
+      const cases = [
+        {
+          override: {
+            recordedSkillNames: [],
+            distributedSkillNames: [
+              'hb-query-resolver',
+              'hb-naming',
+            ],
+            directoryNames: [
+              'hb-naming',
+              'hb-own-skill',
+              'my-own-skill',
+            ],
+          },
+          expected: [
+            'hb-naming',
+          ],
+        },
+        {
+          override: {
+            recordedSkillNames: [],
+            distributedSkillNames: [
+              'hb-query-resolver',
+              'hb-naming',
+            ],
+            directoryNames: [
+              'hb-own-skill',
+              'my-own-skill',
+            ],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('directoryNames: $override.directoryNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadSkillNames')
+          .mockReturnValue(override.recordedSkillNames)
+        jest.spyOn(installer, 'collectDistributedSkillNames')
+          .mockReturnValue(override.distributedSkillNames)
+        jest.spyOn(installer, 'collectDirectoryNames')
+          .mockReturnValue(override.directoryNames)
+
+        jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+
+        const received = installer.removeInstalledSkills()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should never remove outside the installation directory', () => {
+      const cases = [
+        {
+          override: {
+            recordedSkillNames: [
+              '../../../canary',
+              'hb-naming',
+            ],
+          },
+          expected: [
+            [
+              '/consumer/.claude/skills/hb-naming',
+              {
+                recursive: true,
+                force: true,
+              },
+            ],
+          ],
+        },
+      ]
+
+      test.each(cases)('recordedSkillNames: $override.recordedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadSkillNames')
+          .mockReturnValue(override.recordedSkillNames)
+        jest.spyOn(installer, 'collectDistributedSkillNames')
+          .mockReturnValue([])
+        jest.spyOn(installer, 'collectDirectoryNames')
+          .mockReturnValue([])
+
+        const rmSyncSpy = jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+
+        installer.removeInstalledSkills()
+
+        expect(rmSyncSpy)
+          .toHaveBeenCalledTimes(1)
+        expect(rmSyncSpy)
+          .toHaveBeenNthCalledWith(1, ...expected[0])
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#collectRemovableSkillNames()', () => {
+    describe('should join what the manifest recorded and what is named after a distributed skill', () => {
+      const cases = [
+        {
+          override: {
+            recordedSkillNames: [
+              'hb-cp-table',
+            ],
+            distributedSkillNames: [
+              'hb-query-resolver',
+              'hb-naming',
+            ],
+            directoryNames: [
+              'hb-naming',
+              'hb-own-skill',
+            ],
+          },
+          expected: [
+            'hb-cp-table',
+            'hb-naming',
+          ],
+        },
+        {
+          override: {
+            recordedSkillNames: [
+              'hb-naming',
+            ],
+            distributedSkillNames: [
+              'hb-naming',
+            ],
+            directoryNames: [
+              'hb-naming',
+            ],
+          },
+          expected: [
+            'hb-naming',
+          ],
+        },
+        {
+          override: {
+            recordedSkillNames: [],
+            distributedSkillNames: [],
+            directoryNames: [
+              'hb-own-skill',
+            ],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('recordedSkillNames: $override.recordedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadSkillNames')
+          .mockReturnValue(override.recordedSkillNames)
+        jest.spyOn(installer, 'collectDistributedSkillNames')
+          .mockReturnValue(override.distributedSkillNames)
+        jest.spyOn(installer, 'collectDirectoryNames')
+          .mockReturnValue(override.directoryNames)
+
+        const received = installer.collectRemovableSkillNames()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should drop a recorded skill name that is not a plain skill name', () => {
+      const cases = [
+        {
+          override: {
+            recordedSkillNames: [
+              'hb-naming',
+              '../../../canary',
+            ],
+            distributedSkillNames: [],
+            directoryNames: [],
+          },
+          expected: [
+            'hb-naming',
+          ],
+        },
+        {
+          override: {
+            recordedSkillNames: [
+              '..',
+              '.',
+              '',
+              'hb-naming/SKILL.md',
+            ],
+            distributedSkillNames: [],
+            directoryNames: [],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('recordedSkillNames: $override.recordedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadSkillNames')
+          .mockReturnValue(override.recordedSkillNames)
+        jest.spyOn(installer, 'collectDistributedSkillNames')
+          .mockReturnValue(override.distributedSkillNames)
+        jest.spyOn(installer, 'collectDirectoryNames')
+          .mockReturnValue(override.directoryNames)
+
+        const received = installer.collectRemovableSkillNames()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#collectDistributedSkillNamesInTarget()', () => {
+    describe('should keep only the distributed names sitting in the target directory', () => {
+      const cases = [
+        {
+          override: {
+            distributedSkillNames: [
+              'hb-query-resolver',
+              'hb-jsdoc',
+              'hb-naming',
+            ],
+            directoryNames: [
+              'hb-naming',
+              'hb-own-skill',
+              'my-own-skill',
+            ],
+          },
+          expected: [
+            'hb-naming',
+          ],
+        },
+        {
+          override: {
+            distributedSkillNames: [
+              'hb-query-resolver',
+              'hb-naming',
+            ],
+            directoryNames: [
+              'hb-query-resolver',
+              'hb-naming',
+            ],
+          },
+          expected: [
+            'hb-query-resolver',
+            'hb-naming',
+          ],
+        },
+        {
+          override: {
+            distributedSkillNames: [
+              'hb-naming',
+            ],
+            directoryNames: [],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('directoryNames: $override.directoryNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer, 'collectDistributedSkillNames')
+          .mockReturnValue(override.distributedSkillNames)
+        jest.spyOn(installer, 'collectDirectoryNames')
+          .mockReturnValue(override.directoryNames)
+
+        const received = installer.collectDistributedSkillNamesInTarget()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#collectDirectoryNames()', () => {
+    describe('should be the sorted names of the directories', () => {
+      const cases = [
+        {
+          override: {
+            dirents: [
+              {
+                name: 'hb-cp-table',
+                isDirectory: () => true,
+              },
+              {
+                name: 'hb-query-resolver',
+                isDirectory: () => true,
+              },
+              {
+                name: 'README.md',
+                isDirectory: () => false,
+              },
+            ],
+          },
+          expected: [
+            'hb-cp-table',
+            'hb-query-resolver',
+          ],
+        },
+        {
+          override: {
+            dirents: [],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('dirents: $override.dirents.length', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+        const args = {
+          directoryPath: '/consumer/.claude/skills',
+        }
+
+        jest.spyOn(fs, 'existsSync')
+          .mockReturnValue(true)
+        jest.spyOn(fs, 'readdirSync')
+          .mockReturnValue(override.dirents)
+
+        const received = installer.collectDirectoryNames(args)
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should be empty when the directory is absent', () => {
+      test('when the directory does not exist', () => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+        const args = {
+          directoryPath: '/consumer/.claude/skills',
+        }
+
+        jest.spyOn(fs, 'existsSync')
+          .mockReturnValue(false)
+
+        const received = installer.collectDirectoryNames(args)
+
+        expect(received)
+          .toEqual([])
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#buildTargetSkillPath()', () => {
+    describe('should be the skill under the target directory', () => {
+      const cases = [
+        {
+          input: {
+            skillName: 'hb-query-resolver',
+          },
+          expected: '/consumer/.claude/skills/hb-query-resolver',
+        },
+        {
+          input: {
+            skillName: 'hb-naming',
+          },
+          expected: '/consumer/.claude/skills/hb-naming',
+        },
+      ]
+
+      test.each(cases)('skillName: $input.skillName', ({ input, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        const received = installer.buildTargetSkillPath(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#buildSourceSkillPath()', () => {
+    describe('should be the skill under the source directory', () => {
+      const cases = [
+        {
+          input: {
+            skillName: 'hb-query-resolver',
+          },
+          expected: '/package/dist/skills/hb-query-resolver',
+        },
+        {
+          input: {
+            skillName: 'hb-naming',
+          },
+          expected: '/package/dist/skills/hb-naming',
+        },
+      ]
+
+      test.each(cases)('skillName: $input.skillName', ({ input, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        const received = installer.buildSourceSkillPath(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#copyDistributedSkills()', () => {
+    describe('should copy each distributed skill into the target directory', () => {
+      const cases = [
+        {
+          override: {
+            distributedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          expected: [
+            '/package/dist/skills/hb-query-resolver',
+            '/consumer/.claude/skills/hb-query-resolver',
+            {
+              recursive: true,
+            },
+          ],
+        },
+        {
+          override: {
+            distributedSkillNames: [
+              'hb-naming',
+            ],
+          },
+          expected: [
+            '/package/dist/skills/hb-naming',
+            '/consumer/.claude/skills/hb-naming',
+            {
+              recursive: true,
+            },
+          ],
+        },
+      ]
+
+      test.each(cases)('distributedSkillNames: $override.distributedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer, 'collectDistributedSkillNames')
+          .mockReturnValue(override.distributedSkillNames)
+        jest.spyOn(fs, 'mkdirSync')
+          .mockReturnValue('')
+
+        const cpSyncSpy = jest.spyOn(fs, 'cpSync')
+          .mockReturnValue()
+
+        installer.copyDistributedSkills()
+
+        expect(cpSyncSpy)
+          .toHaveBeenCalledWith(...expected)
+      })
+    })
+
+    describe('should create the target directory', () => {
+      const cases = [
+        {
+          input: {
+            workingDirectoryPath: '/consumer',
+            targetDirectoryPath: '/consumer/.claude/skills',
+          },
+          expected: [
+            '/consumer/.claude/skills',
+            {
+              recursive: true,
+            },
+          ],
+        },
+        {
+          input: {
+            workingDirectoryPath: '/tmp',
+            targetDirectoryPath: '/tmp/skills',
+          },
+          expected: [
+            '/tmp/skills',
+            {
+              recursive: true,
+            },
+          ],
+        },
+      ]
+
+      test.each(cases)('targetDirectoryPath: $input.targetDirectoryPath', ({ input, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: input.workingDirectoryPath,
+          targetDirectoryPath: input.targetDirectoryPath,
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer, 'collectDistributedSkillNames')
+          .mockReturnValue([])
+
+        const mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync')
+          .mockReturnValue('')
+
+        installer.copyDistributedSkills()
+
+        expect(mkdirSyncSpy)
+          .toHaveBeenCalledWith(...expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#collectDistributedSkillNames()', () => {
+    describe('should read the source directory', () => {
+      const cases = [
+        {
+          input: {
+            sourceDirectoryPath: '/package/dist/skills',
+          },
+          expected: {
+            directoryPath: '/package/dist/skills',
+          },
+        },
+        {
+          input: {
+            sourceDirectoryPath: '/elsewhere/dist/skills',
+          },
+          expected: {
+            directoryPath: '/elsewhere/dist/skills',
+          },
+        },
+      ]
+
+      test.each(cases)('sourceDirectoryPath: $input.sourceDirectoryPath', ({ input, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: input.sourceDirectoryPath,
+        })
+
+        const collectDirectoryNamesSpy = jest.spyOn(installer, 'collectDirectoryNames')
+          .mockReturnValue([])
+
+        installer.collectDistributedSkillNames()
+
+        expect(collectDirectoryNamesSpy)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#saveManifest()', () => {
+    describe('should record the version and the skills', () => {
+      const cases = [
+        {
+          override: {
+            version: '0.0.1',
+          },
+          input: {
+            skillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          expected: {
+            version: '0.0.1',
+            skillNames: [
+              'hb-query-resolver',
+            ],
+          },
+        },
+        {
+          override: {
+            version: null,
+          },
+          input: {
+            skillNames: [],
+          },
+          expected: {
+            version: null,
+            skillNames: [],
+          },
+        },
+      ]
+
+      test.each(cases)('version: $override.version', ({ override, input, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer, 'loadPackageVersion')
+          .mockReturnValue(override.version)
+
+        const saveSpy = jest.spyOn(installer.manifestFile, 'save')
+          .mockReturnValue()
+
+        installer.saveManifest(input)
+
+        expect(saveSpy)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#loadPackageVersion()', () => {
+    describe('should be the version of this package', () => {
+      const cases = [
+        {
+          override: {
+            content: '{"version":"1.2.3"}',
+          },
+          expected: '1.2.3',
+        },
+        {
+          override: {
+            content: '{"version":"0.0.1"}',
+          },
+          expected: '0.0.1',
+        },
+      ]
+
+      test.each(cases)('content: $override.content', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(fs, 'readFileSync')
+          .mockReturnValue(override.content)
+
+        const received = installer.loadPackageVersion()
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should be null when the version is unreadable', () => {
+      const cases = [
+        {
+          override: {
+            content: 'not json',
+          },
+        },
+        {
+          override: {
+            content: '{"name":"@openreachtech/hora-skills"}',
+          },
+        },
+      ]
+
+      test.each(cases)('content: $override.content', ({ override }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(fs, 'readFileSync')
+          .mockReturnValue(override.content)
+
+        const received = installer.loadPackageVersion()
+
+        expect(received)
+          .toBeNull()
+      })
+    })
+  })
+})
+
+describe('SkillsInstaller', () => {
+  describe('#uninstall()', () => {
+    describe('should remove the installed skills and the manifest', () => {
+      const cases = [
+        {
+          override: {
+            removedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          expected: {
+            removedSkillNames: [
+              'hb-query-resolver',
+            ],
+          },
+        },
+        {
+          override: {
+            removedSkillNames: [],
+          },
+          expected: {
+            removedSkillNames: [],
+          },
+        },
+      ]
+
+      test.each(cases)('removedSkillNames: $override.removedSkillNames', ({ override, expected }) => {
+        const installer = SkillsInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer, 'removeInstalledSkills')
+          .mockReturnValue(override.removedSkillNames)
+
+        const removeSpy = jest.spyOn(installer.manifestFile, 'remove')
+          .mockReturnValue()
+
+        const received = installer.uninstall()
+
+        expect(removeSpy)
+          .toHaveBeenCalledWith()
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})

--- a/tests/__tests__/equip/SkillsManifestFile.js
+++ b/tests/__tests__/equip/SkillsManifestFile.js
@@ -1,0 +1,1121 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import SkillsManifestFile from '../../../lib/equip/SkillsManifestFile.js'
+
+describe('SkillsManifestFile', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      describe('#filePath', () => {
+        const cases = [
+          {
+            input: {
+              filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+              installationPath: '.claude/skills',
+            },
+            expected: '/tmp/app/.hora/hora-skills-renchan.json',
+          },
+          {
+            input: {
+              filePath: '.hora/hora-skills-renchan.json',
+              installationPath: 'tools/skills',
+            },
+            expected: '.hora/hora-skills-renchan.json',
+          },
+        ]
+
+        test.each(cases)('filePath: $input.filePath', ({ input, expected }) => {
+          const manifestFile = new SkillsManifestFile(input)
+
+          expect(manifestFile)
+            .toHaveProperty('filePath', expected)
+        })
+      })
+
+      describe('#installationPath', () => {
+        const cases = [
+          {
+            input: {
+              filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+              installationPath: '.claude/skills',
+            },
+            expected: '.claude/skills',
+          },
+          {
+            input: {
+              filePath: '.hora/hora-skills-renchan.json',
+              installationPath: 'tools/skills',
+            },
+            expected: 'tools/skills',
+          },
+        ]
+
+        test.each(cases)('installationPath: $input.installationPath', ({ input, expected }) => {
+          const manifestFile = new SkillsManifestFile(input)
+
+          expect(manifestFile)
+            .toHaveProperty('installationPath', expected)
+        })
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      const cases = [
+        {
+          input: {
+            filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+            installationPath: '.claude/skills',
+          },
+        },
+        {
+          input: {
+            filePath: '.hora/hora-skills-renchan.json',
+            installationPath: 'tools/skills',
+          },
+        },
+      ]
+
+      test.each(cases)('filePath: $input.filePath', ({ input }) => {
+        const received = SkillsManifestFile.create(input)
+
+        expect(received)
+          .toBeInstanceOf(SkillsManifestFile)
+      })
+    })
+
+    describe('should call constructor', () => {
+      const cases = [
+        {
+          tally: {
+            filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+            installationPath: '.claude/skills',
+          },
+        },
+        {
+          tally: {
+            filePath: '.hora/hora-skills-renchan.json',
+            installationPath: 'tools/skills',
+          },
+        },
+      ]
+
+      test.each(cases)('filePath: $tally.filePath', ({ tally }) => {
+        const SpyClass = constructorSpy.spyOn(SkillsManifestFile)
+
+        SpyClass.create(tally)
+
+        expect(SpyClass.__spy__)
+          .toHaveBeenCalledWith(tally)
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#get:fs', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        const received = manifestFile.fs
+
+        expect(received)
+          .toBe(fs) // same reference
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#get:path', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        const received = manifestFile.path
+
+        expect(received)
+          .toBe(path) // same reference
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#loadSkillNames()', () => {
+    describe('should be the skill names recorded for own installation path', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [
+                    'hb-query-resolver',
+                  ],
+                },
+              },
+            },
+          },
+          expected: [
+            'hb-query-resolver',
+          ],
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [],
+                },
+              },
+            },
+          },
+          expected: [],
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [
+                    'hb-naming',
+                  ],
+                },
+                'tools/skills': {
+                  skillNames: [
+                    'hb-query-resolver',
+                  ],
+                },
+              },
+            },
+          },
+          expected: [
+            'hb-naming',
+          ],
+        },
+      ]
+
+      test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const received = manifestFile.loadSkillNames()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should be empty when own installation path is not recorded', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: null,
+          },
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+            },
+          },
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {},
+            },
+          },
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                'tools/skills': {
+                  skillNames: [
+                    'hb-query-resolver',
+                  ],
+                },
+              },
+            },
+          },
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                },
+              },
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const received = manifestFile.loadSkillNames()
+
+        expect(received)
+          .toEqual([])
+      })
+    })
+
+    describe('should be empty when the recorded skillNames is not an array', () => {
+      const cases = [
+        {
+          override: {
+            skillNames: 'hb-naming',
+          },
+        },
+        {
+          override: {
+            skillNames: 1,
+          },
+        },
+        {
+          override: {
+            skillNames: null,
+          },
+        },
+        {
+          override: {
+            skillNames: {
+              0: 'hb-naming',
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('skillNames: $override.skillNames', ({ override }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue({
+            version: '0.0.1',
+            installations: {
+              '.claude/skills': {
+                skillNames: override.skillNames,
+              },
+            },
+          })
+
+        const received = manifestFile.loadSkillNames()
+
+        expect(received)
+          .toEqual([])
+      })
+    })
+
+    describe('should keep only the recorded skill names that are strings', () => {
+      const cases = [
+        {
+          override: {
+            skillNames: [
+              'hb-naming',
+              1,
+              'hb-query-resolver',
+            ],
+          },
+          expected: [
+            'hb-naming',
+            'hb-query-resolver',
+          ],
+        },
+        {
+          override: {
+            skillNames: [
+              null,
+              {
+                skillName: 'hb-naming',
+              },
+              [
+                'hb-naming',
+              ],
+            ],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('skillNames: $override.skillNames', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue({
+            version: '0.0.1',
+            installations: {
+              '.claude/skills': {
+                skillNames: override.skillNames,
+              },
+            },
+          })
+
+        const received = manifestFile.loadSkillNames()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#loadInstallation()', () => {
+    describe('should be the entry of own installation path', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [
+                    'hb-naming',
+                  ],
+                },
+              },
+            },
+          },
+          expected: {
+            skillNames: [
+              'hb-naming',
+            ],
+          },
+        },
+      ]
+
+      test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const received = manifestFile.loadInstallation()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should be null when own installation path is absent', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: null,
+          },
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                'tools/skills': {
+                  skillNames: [],
+                },
+              },
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const received = manifestFile.loadInstallation()
+
+        expect(received)
+          .toBeNull()
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#loadInstallationHash()', () => {
+    describe('should be the entries of every installation path', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [
+                    'hb-naming',
+                  ],
+                },
+                'tools/skills': {
+                  skillNames: [
+                    'hb-query-resolver',
+                  ],
+                },
+              },
+            },
+          },
+          expected: {
+            '.claude/skills': {
+              skillNames: [
+                'hb-naming',
+              ],
+            },
+            'tools/skills': {
+              skillNames: [
+                'hb-query-resolver',
+              ],
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const received = manifestFile.loadInstallationHash()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should be empty when no manifest is readable', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: null,
+          },
+        },
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const received = manifestFile.loadInstallationHash()
+
+        expect(received)
+          .toEqual({})
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#load()', () => {
+    describe('should parse the manifest', () => {
+      const cases = [
+        {
+          override: {
+            content: '{"version":"0.0.1","installations":{".claude/skills":{"skillNames":["hb-query-resolver"]}}}',
+          },
+          expected: {
+            version: '0.0.1',
+            installations: {
+              '.claude/skills': {
+                skillNames: [
+                  'hb-query-resolver',
+                ],
+              },
+            },
+          },
+        },
+        {
+          override: {
+            content: '{"version":null,"installations":{}}',
+          },
+          expected: {
+            version: null,
+            installations: {},
+          },
+        },
+      ]
+
+      test.each(cases)('content: $override.content', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(fs, 'existsSync')
+          .mockReturnValue(true)
+        jest.spyOn(fs, 'readFileSync')
+          .mockReturnValue(override.content)
+
+        const received = manifestFile.load()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should be null when the manifest is absent', () => {
+      test('when the file does not exist', () => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(fs, 'existsSync')
+          .mockReturnValue(false)
+
+        const received = manifestFile.load()
+
+        expect(received)
+          .toBeNull()
+      })
+    })
+
+    describe('should be null when the manifest is broken', () => {
+      const cases = [
+        {
+          override: {
+            content: 'not json',
+          },
+        },
+        {
+          override: {
+            content: '{"installations": {',
+          },
+        },
+      ]
+
+      test.each(cases)('content: $override.content', ({ override }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(fs, 'existsSync')
+          .mockReturnValue(true)
+        jest.spyOn(fs, 'readFileSync')
+          .mockReturnValue(override.content)
+
+        const received = manifestFile.load()
+
+        expect(received)
+          .toBeNull()
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#save()', () => {
+    describe('should record own installation path', () => {
+      const cases = [
+        {
+          input: {
+            version: '0.0.1',
+            skillNames: [
+              'hb-query-resolver',
+            ],
+          },
+          override: {
+            installationHash: {},
+          },
+          expected: {
+            version: '0.0.1',
+            installations: {
+              '.claude/skills': {
+                skillNames: [
+                  'hb-query-resolver',
+                ],
+              },
+            },
+          },
+        },
+        {
+          input: {
+            version: null,
+            skillNames: [],
+          },
+          override: {
+            installationHash: {},
+          },
+          expected: {
+            version: null,
+            installations: {
+              '.claude/skills': {
+                skillNames: [],
+              },
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('version: $input.version', ({ input, override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'loadInstallationHash')
+          .mockReturnValue(override.installationHash)
+
+        const writeSpy = jest.spyOn(manifestFile, 'write')
+          .mockReturnValue()
+
+        manifestFile.save(input)
+
+        expect(writeSpy)
+          .toHaveBeenCalledWith({
+            manifestHash: expected,
+          })
+      })
+    })
+
+    describe('should keep the entries of the other installation paths', () => {
+      const cases = [
+        {
+          input: {
+            version: '0.0.1',
+            skillNames: [
+              'hb-naming',
+            ],
+          },
+          override: {
+            installationHash: {
+              'tools/skills': {
+                skillNames: [
+                  'hb-query-resolver',
+                ],
+              },
+            },
+          },
+          expected: {
+            version: '0.0.1',
+            installations: {
+              'tools/skills': {
+                skillNames: [
+                  'hb-query-resolver',
+                ],
+              },
+              '.claude/skills': {
+                skillNames: [
+                  'hb-naming',
+                ],
+              },
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('version: $input.version', ({ input, override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'loadInstallationHash')
+          .mockReturnValue(override.installationHash)
+
+        const writeSpy = jest.spyOn(manifestFile, 'write')
+          .mockReturnValue()
+
+        manifestFile.save(input)
+
+        expect(writeSpy)
+          .toHaveBeenCalledWith({
+            manifestHash: expected,
+          })
+      })
+    })
+
+    describe('should replace the entry of own installation path', () => {
+      const cases = [
+        {
+          input: {
+            version: '0.0.2',
+            skillNames: [
+              'hb-naming',
+            ],
+          },
+          override: {
+            installationHash: {
+              '.claude/skills': {
+                skillNames: [
+                  'hb-cp-table',
+                ],
+              },
+            },
+          },
+          expected: {
+            version: '0.0.2',
+            installations: {
+              '.claude/skills': {
+                skillNames: [
+                  'hb-naming',
+                ],
+              },
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('version: $input.version', ({ input, override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'loadInstallationHash')
+          .mockReturnValue(override.installationHash)
+
+        const writeSpy = jest.spyOn(manifestFile, 'write')
+          .mockReturnValue()
+
+        manifestFile.save(input)
+
+        expect(writeSpy)
+          .toHaveBeenCalledWith({
+            manifestHash: expected,
+          })
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#write()', () => {
+    describe('should write the manifest as indented JSON', () => {
+      const cases = [
+        {
+          input: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [
+                    'hb-query-resolver',
+                  ],
+                },
+              },
+            },
+          },
+          expected: [
+            '/tmp/app/.hora/hora-skills-renchan.json',
+            '{\n  "version": "0.0.1",\n  "installations": {\n    ".claude/skills": {\n      "skillNames": [\n        "hb-query-resolver"\n      ]\n    }\n  }\n}\n',
+          ],
+        },
+        {
+          input: {
+            manifestHash: {
+              version: null,
+              installations: {},
+            },
+          },
+          expected: [
+            '/tmp/app/.hora/hora-skills-renchan.json',
+            '{\n  "version": null,\n  "installations": {}\n}\n',
+          ],
+        },
+      ]
+
+      test.each(cases)('version: $input.manifestHash.version', ({ input, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(fs, 'mkdirSync')
+          .mockReturnValue()
+
+        const writeFileSyncSpy = jest.spyOn(fs, 'writeFileSync')
+          .mockReturnValue()
+
+        manifestFile.write(input)
+
+        expect(writeFileSyncSpy)
+          .toHaveBeenCalledWith(...expected)
+      })
+    })
+
+    describe('should create the directory holding the manifest', () => {
+      const cases = [
+        {
+          input: {
+            manifestHash: {
+              version: null,
+              installations: {},
+            },
+          },
+          expected: [
+            '/tmp/app/.hora',
+            {
+              recursive: true,
+            },
+          ],
+        },
+      ]
+
+      test.each(cases)('version: $input.manifestHash.version', ({ input, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        const mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync')
+          .mockReturnValue()
+
+        jest.spyOn(fs, 'writeFileSync')
+          .mockReturnValue()
+
+        manifestFile.write(input)
+
+        expect(mkdirSyncSpy)
+          .toHaveBeenCalledWith(...expected)
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#remove()', () => {
+    describe('should remove the file when no entry is left', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [],
+                },
+              },
+            },
+          },
+          expected: [
+            '/tmp/app/.hora/hora-skills-renchan.json',
+            {
+              force: true,
+            },
+          ],
+        },
+      ]
+
+      test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const rmSyncSpy = jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+
+        manifestFile.remove()
+
+        expect(rmSyncSpy)
+          .toHaveBeenCalledWith(...expected)
+      })
+    })
+
+    describe('should keep the file when another entry is left', () => {
+      const cases = [
+        {
+          override: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                '.claude/skills': {
+                  skillNames: [],
+                },
+                'tools/skills': {
+                  skillNames: [
+                    'hb-query-resolver',
+                  ],
+                },
+              },
+            },
+          },
+          expected: {
+            manifestHash: {
+              version: '0.0.1',
+              installations: {
+                'tools/skills': {
+                  skillNames: [
+                    'hb-query-resolver',
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(override.manifestHash)
+
+        const rmSyncSpy = jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+        const writeSpy = jest.spyOn(manifestFile, 'write')
+          .mockReturnValue()
+
+        manifestFile.remove()
+
+        expect(writeSpy)
+          .toHaveBeenCalledWith(expected)
+        expect(rmSyncSpy)
+          .not
+          .toHaveBeenCalled()
+      })
+    })
+
+    describe('should do nothing when no manifest is readable', () => {
+      test('when the manifest is absent', () => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue(null)
+
+        const rmSyncSpy = jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+        const writeSpy = jest.spyOn(manifestFile, 'write')
+          .mockReturnValue()
+
+        manifestFile.remove()
+
+        expect(rmSyncSpy)
+          .not
+          .toHaveBeenCalled()
+        expect(writeSpy)
+          .not
+          .toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('SkillsManifestFile', () => {
+  describe('#buildRemainingInstallationHash()', () => {
+    describe('should drop the entry of own installation path', () => {
+      const cases = [
+        {
+          override: {
+            installationHash: {
+              '.claude/skills': {
+                skillNames: [],
+              },
+              'tools/skills': {
+                skillNames: [
+                  'hb-query-resolver',
+                ],
+              },
+            },
+          },
+          expected: {
+            'tools/skills': {
+              skillNames: [
+                'hb-query-resolver',
+              ],
+            },
+          },
+        },
+        {
+          override: {
+            installationHash: {
+              '.claude/skills': {
+                skillNames: [],
+              },
+            },
+          },
+          expected: {},
+        },
+        {
+          override: {
+            installationHash: {},
+          },
+          expected: {},
+        },
+      ]
+
+      test.each(cases)('installationHash: $override.installationHash', ({ override, expected }) => {
+        const manifestFile = SkillsManifestFile.create({
+          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'loadInstallationHash')
+          .mockReturnValue(override.installationHash)
+
+        const received = manifestFile.buildRemainingInstallationHash()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})

--- a/tests/__tests__/equip/constants/CLI_COMMAND.js
+++ b/tests/__tests__/equip/constants/CLI_COMMAND.js
@@ -1,0 +1,57 @@
+import CLI_COMMAND from '../../../../lib/equip/constants/CLI_COMMAND.js'
+
+describe('CLI_COMMAND', () => {
+  describe('when referenced as is', () => {
+    test('should be fixed value', () => {
+      const expected = {
+        INSTALL: 'install',
+        LIST: 'list',
+        UNINSTALL: 'uninstall',
+        HELP: 'help',
+      }
+
+      const received = CLI_COMMAND
+
+      expect(received)
+        .toEqual(expected)
+    })
+  })
+})
+
+describe('CLI_COMMAND', () => {
+  describe('should be the word typed on the command line', () => {
+    const cases = [
+      {
+        input: {
+          command: CLI_COMMAND.INSTALL,
+        },
+        expected: 'install',
+      },
+      {
+        input: {
+          command: CLI_COMMAND.LIST,
+        },
+        expected: 'list',
+      },
+      {
+        input: {
+          command: CLI_COMMAND.UNINSTALL,
+        },
+        expected: 'uninstall',
+      },
+      {
+        input: {
+          command: CLI_COMMAND.HELP,
+        },
+        expected: 'help',
+      },
+    ]
+
+    test.each(cases)('command: $expected', ({ input, expected }) => {
+      const received = input.command
+
+      expect(received)
+        .toBe(expected)
+    })
+  })
+})


### PR DESCRIPTION
# Why

* Close #11

# How

* Migrates `lib/equip/` from `hora-skills`: `HoraSkillsCli`, `CommandLineArguments`, `SkillsInstaller`, `SkillsManifestFile`, `CLI_COMMAND`, and the command itself as `lib/equip/hora-skills-renchan.js`
* Drops the domain selection — `SkillDomainFilter`, `SKILL_DOMAIN`, `SKILL_DOMAIN_PREFIX`, `ConsumerPackageConfig`, the `--domains` option and `horaSkills.domains`. This library distributes the one domain, so a repository selects domains by selecting which of the sibling libraries it installs. `#runSelection()` becomes `#runList()`, and `#selectSkillNames()` collapses into `#collectDistributedSkillNames()`
* Records the installation in `.hora/hora-skills-renchan.json` instead of `.hora/equip-skills.json`: three libraries installing into one `.claude/skills/` would otherwise share one file, and each would remove the skills the others recorded
* Adds `bin: { "hora-skills-renchan": "lib/equip/hora-skills-renchan.js" }`, so `npx @openreachtech/hora-skills-renchan install` equips this library and the three commands never collide
* Ports the test of every migrated member, dropping the cases of the members that are gone
