### PR TITLE
🏷️ Check the skill names in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,6 @@ jobs:
         env:
           NODE_ENV: development
         run: npm test
+
+      - name: 🏷️ Skill names
+        run: npm run skill-names


### PR DESCRIPTION
# Why

* Close #13

# How

* Runs `npm run skill-names` in CI, so a skill whose folder name, prefix or `name:` disagree is rejected before anyone runs a build
