### PR TITLE
📄 Add README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,135 @@
+# @openreachtech/hora-skills-ort-renchan
+
+Hora Kit で開発するための renchan バックエンドスキルを配布するパッケージです。
+
+## コンセプト
+
+このパッケージが配布するのは **スキルのみ** です。`import` して使うライブラリはなく、同梱する唯一の実行コマンドはそのスキルを配置するためのものです。スキルとは `SKILL.md`(と任意の `references/`・`scripts/`)を収めたディレクトリで、Claude Code が読み込み `/<name>` として呼び出します。導入先のリポジトリにインストールすることで、Open Reach Tech が開発に用いている規約と手順を、そのリポジトリで作業するエージェントに届けます。
+
+配布されるスキルは 31 件、すべて `backend` ドメインのもので、内容は「renchan ベースの Node バックエンド」です。各名前の先頭 3 文字がドメインを表すので、フラットに並んだスキル一覧を見た人が、どれがこのパッケージ由来かを一目で判別できます。ドメインごとに別のパッケージになっており、リポジトリは自分が扱うドメインのものを入れます。
+
+| パッケージ | プレフィックス | ドメイン | スキル数 |
+| :-- | :-- | :-- | --: |
+| `@openreachtech/hora-skills-ort-core` | `hoc-` | `core` | 35 |
+| `@openreachtech/hora-skills-ort-renchan`(このパッケージ) | `hor-` | `backend` | 31 |
+| `@openreachtech/hora-skills-ort-furo` | `hof-` | `frontend` | 46 |
+
+[**スキルカタログ**](https://github.com/openreachtech/hora-skills-ort-renchan/blob/main/docs/skills.ja.md) ([English](https://github.com/openreachtech/hora-skills-ort-renchan/blob/main/docs/skills.md)) — このパッケージに収録された全スキルの一覧と概要(1〜2 行)を、呼び出しコマンド名で並べています。
+
+ソースは `kit/skills/backend/<name>/` に配置され、`dist/` が公開されるビルド成果物です。同じスキルフォルダからドメインの階層だけを取り除いた形で、これが Claude Code の求めるフラットな構成です。スキルフォルダ名はそのスキルの `name:` であり、インストール後のフォルダ名でもあります。一貫して同じ 1 つの文字列なので、カタログで見た名前がそのまま入力するコマンドになります。
+
+## インストール
+
+Node.js 20.0.0 以降が必要です(`package.json` の `engines` が宣言している下限)。CI は現行の LTS でビルドしています。
+
+```sh
+npm install -D @openreachtech/hora-skills-ort-renchan
+```
+
+このパッケージ自身はインストールスクリプトを同梱していません。したがって依存に追加しても、パッケージが入るだけで、何も配置されません。プロジェクト自身の `postinstall` としてコマンドを宣言してください。それだけで、`npm install` がリポジトリにスキルを装備します。
+
+```json
+{
+  "scripts": {
+    "postinstall": "hora-skills-ort-renchan install"
+  }
+}
+```
+
+プロジェクト自身のスクリプトは、npm が v12 以降で差し止める対象の外にあります。したがって、そのプロジェクトをクローンする人に何も要求しません。ここで `npx` は不要です。ライフサイクルスクリプトは `node_modules/.bin` を PATH に入れて実行されるためです。
+
+いま宣言したフックが効くのは、次の `npm install` からです。最初の配置は、コマンドを自分で実行してください。一度だけ配置したい場合や、フックを置けないリポジトリでも同じです。
+
+```sh
+npx --no hora-skills-ort-renchan install
+```
+
+**`--no` は、ダウンロードの前で npx を止めます** — 名前の解決はレジストリに問い合わせますが、取得はしないので、他人のパッケージの install スクリプトも bin も走りません。これが無いと、bin が入っていない状態は、このパッケージが持たない無スコープ名 `hora-skills-ort-renchan` で公開されたものの取得になります。
+
+パッケージを依存に入れないまま実行する場合 — 一度だけの配置や、フックを置けないリポジトリ — は、名前を省略せずに指定してください。`npx --package=@openreachtech/hora-skills-ort-renchan hora-skills-ort-renchan install` が取得するのは、他人が公開できないスコープ付きの名前です。無スコープの bin 名には、その保証がありませんでした。
+
+## 使い方
+
+スキルは自分のリポジトリの `.claude/skills/` に配置されます。Claude Code はそこからスキルを認識し、それぞれが自身の名前で呼び出せるようになります(`/hor-query-resolver`, `/hor-sequelize-model`, `/hor-post-worker` など)。インストールされたスキルは、そのリポジトリ自身のスキルと 1 つのフラットな一覧に並びます。`hor-` のプレフィックスはそのためにあります。
+
+### 複数のドメインを入れる
+
+3 つのパッケージはいずれも同じ `.claude/skills/` に配置し、それぞれが自分の配置内容を `.hora/<パッケージ名>.json` に記録します。したがって、ある実行が削除するのはそのパッケージが配置したものだけで、他の 2 つには手を触れません。
+
+```json
+{
+  "scripts": {
+    "postinstall": "hora-skills-ort-renchan install && <別の hora-skills パッケージ> install"
+  }
+}
+```
+
+プレフィックスは 1 つのパッケージだけが持ち、スキルのフォルダ名はパッケージ内で一意なので、配置されたスキルの名前が衝突することはありません。
+
+### リンクではなくディレクトリ
+
+`.claude/` と、その中の `skills/` は、シンボリックリンクではなくリポジトリのディレクトリである必要があります。インストールは対象へ至る各段を検査し、いずれかがリンクであれば、何も書き込まず、何も削除せずに終了します。 インストール内容の記録である `.hora/hora-skills-ort-renchan.json` も同じように検査します。ここにリンクがあると、書き込みがリンク先へ届き、その中身を上書きしてしまうためです。
+
+何も運ばなかったインストールは、その理由を告げ、0 以外の終了コードで終わります。プロジェクト自身の `postinstall` として実行しているなら、それは `npm install` の出力に現れます。単独で実行した場合は `npx --no hora-skills-ort-renchan install` が同じことを告げます。
+
+リンクはコマンドを実行する人の指示ではなく、リポジトリの中身です。それを辿ると、スキルをどこへ書くか、そして前回のスキルをどこから消すかを、リポジトリ側が決められることになります。
+
+いずれかをリポジトリ間で共有するディレクトリへ向けている場合は、そのディレクトリを直接名指ししてください。`npx --no hora-skills-ort-renchan install --dir <解決先のディレクトリ>` で同じ状態に到達し、リンクがある以上、スキルは `.claude/skills/` から見えます。`--dir` はコマンドを実行する人が名指しするものなので、そのまま受け入れます。
+
+### 配置を最新に保つ
+
+配置されたスキルは、リポジトリのソースではなくこのパッケージのビルド成果物です。git 管理からは外します。
+
+```gitignore
+.claude/skills/hor-*/
+.hora/
+```
+
+引数なしの `npm install` はプロジェクトの `postinstall` を再実行するので、スキルも追随します。パッケージをコマンドラインで名指しする更新(`npm install @openreachtech/hora-skills-ort-renchan@latest`)では走りません。フックを置いていないリポジトリも同じです。その場合は、同じコマンドを再実行してください。
+
+```sh
+npx --no hora-skills-ort-renchan install
+```
+
+`install` は何度実行しても同じ結果になります。前回インストールしたスキル(`.hora/hora-skills-ort-renchan.json` に記録されています)と、このパッケージが配布するスキルと同名のフォルダを削除してから、今回の出力をコピーします。そのため改名されたスキルや削除されたスキルが残らず、`dist/skills/` を手でコピーしていたリポジトリも初回の実行で整理されます。
+
+リポジトリが自分で作ったスキルは、その名前がこのパッケージの配布名と一致しない限り削除されません。`hor-` のプレフィックスを持っているだけで対象になることはなく(`hor-own-skill` は残ります)、配布スキルと完全に同じ名前を付けた場合に限り、その名前はこのパッケージのものとして扱われます。
+
+### コマンド
+
+| コマンド | 動作 |
+| :-- | :-- |
+| `hora-skills-ort-renchan install` | このパッケージが配布する全スキルを配置し、前回配置したものを置き換える |
+| `hora-skills-ort-renchan list` | このパッケージが配布するスキルを表示する(配置はしない) |
+| `hora-skills-ort-renchan uninstall` | このパッケージが配置したスキルと、その記録を削除する |
+| `hora-skills-ort-renchan help` | 使い方を表示する |
+
+`--dir <path>` で `.claude/skills` 以外のディレクトリに配置できます。
+
+## コントリビューション
+
+バグ報告・機能要望・コード貢献を歓迎します。
+
+GitHub Issues からお気軽にご連絡ください。
+
+```sh
+git clone https://github.com/openreachtech/hora-skills-ort-renchan.git
+cd hora-skills-ort-renchan
+npm install
+npm run lint
+npm test
+```
+
+## ライセンス
+
+本プロジェクトは Apache License 2.0 で公開されています。
+
+詳細は [LICENSE ファイル](./LICENSE) を参照してください。
+
+## 開発者
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## 著作権
+
+© 2026 Open Reach Tech Inc.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,135 @@
+# @openreachtech/hora-skills-ort-renchan
+
+A distribution package of the renchan backend skills for developing with Hora Kit.
+
+## Concept
+
+This package ships **skills only** — there is no library to `import`, and the one executable it carries exists to install those skills. A skill is a directory holding a `SKILL.md`, plus optional `references/` and `scripts/`, that Claude Code loads and invokes as `/<name>`. Installing this package into a repository puts the conventions and procedures Open Reach Tech develops with in front of the agent working on that repository.
+
+31 skills are distributed, all of the `backend` domain: renchan-based Node backends. The three-character prefix on every name is the domain, so a reader looking at one flat list of skills can tell at a glance which came from this package. Each domain is a package of its own, and a repository installs the ones it works in:
+
+| Package | Prefix | Domain | Skills |
+| :-- | :-- | :-- | --: |
+| `@openreachtech/hora-skills-ort-core` | `hoc-` | `core` | 35 |
+| `@openreachtech/hora-skills-ort-renchan` (this one) | `hor-` | `backend` | 31 |
+| `@openreachtech/hora-skills-ort-furo` | `hof-` | `frontend` | 46 |
+
+[**Skill catalog**](https://github.com/openreachtech/hora-skills-ort-renchan/blob/main/docs/skills.md) ([日本語](https://github.com/openreachtech/hora-skills-ort-renchan/blob/main/docs/skills.ja.md)) — every skill in this package with a one- or two-line summary, listed by the command name it is invoked by.
+
+The source is organized at `kit/skills/backend/<name>/`, and `dist/` is the published build output: the same skill folders with the domain level dropped, which is the flat shape Claude Code expects. A skill folder's name is its `name:` and the folder name it installs as — one string throughout, so the name you see in the catalog is the command you type.
+
+## Installation
+
+Requires Node.js 20.0.0 or newer, the floor `engines` declares. The CI builds against the current LTS.
+
+```sh
+npm install -D @openreachtech/hora-skills-ort-renchan
+```
+
+This package ships no install script of its own, so adding it as a dependency installs the package and places nothing. Declare the command as your own project's `postinstall`, and `npm install` alone equips the repository:
+
+```json
+{
+  "scripts": {
+    "postinstall": "hora-skills-ort-renchan install"
+  }
+}
+```
+
+A project's own scripts are outside what npm holds back from v12 on, so this asks nothing of whoever clones the repository. `npx` is not needed here either: a lifecycle script runs with `node_modules/.bin` on its PATH.
+
+The hook you just declared takes effect from the next `npm install` on, so run the command by hand for the first placement — and for a one-off, or a repository that is not yours to add a hook to:
+
+```sh
+npx --no hora-skills-ort-renchan install
+```
+
+**`--no` stops npx before it downloads**: the name is still resolved against the registry, but nothing is fetched, so neither the install script nor the bin of a stranger's package ever runs. Without it, a bin that is not installed becomes a fetch of whatever has been published under `hora-skills-ort-renchan`, an unscoped name this package does not hold.
+
+Where the package is not a dependency at all — a one-off, or a repository that is not yours to add a hook to — name it in full instead: `npx --package=@openreachtech/hora-skills-ort-renchan hora-skills-ort-renchan install`. What is fetched is then a scoped name nobody else can publish under, which is the guarantee the unscoped bin name never carried.
+
+## Usage
+
+The skills land in your repository's `.claude/skills/`. Claude Code discovers them from there, and each becomes invocable by its own name — `/hor-query-resolver`, `/hor-sequelize-model`, `/hor-post-worker`. Installed skills sit side by side with your repository's own, in one flat list, which is what the `hor-` prefix is for.
+
+### Installing more than one domain
+
+Each of the three packages installs into the same `.claude/skills/`, and each records its own installation in `.hora/<package name>.json`. A run therefore removes only what that package installed, and leaves the other two alone:
+
+```json
+{
+  "scripts": {
+    "postinstall": "hora-skills-ort-renchan install && <another hora-skills package> install"
+  }
+}
+```
+
+Because a prefix belongs to exactly one package, and every skill's folder name is unique within its own package, no two installed skills can end up with the same name.
+
+### Directories, not links
+
+`.claude/`, and the `skills/` directory inside it, have to be directories of your repository rather than symbolic links. An installation verifies every step it is reached through, and finding a link at any of them it writes nothing and removes nothing. `.hora/hora-skills-ort-renchan.json`, the record of what was installed, is verified the same way: a link there would send the write to whatever it stands for and overwrite it.
+
+An installation that carries nothing says why and ends with a failing exit code. Where the command runs as your project's own `postinstall`, that is what `npm install` reports; run on its own, `npx --no hora-skills-ort-renchan install` tells you the same.
+
+A link is content of the repository rather than an instruction of whoever runs the command, so following one would let the repository decide where skills are written and, worse, where the skills of the previous run are removed from.
+
+Where either points at a directory shared between repositories, name that directory instead — `npx --no hora-skills-ort-renchan install --dir <the directory it resolves to>` reaches the same state, and the link still makes the skills visible at `.claude/skills/`. A `--dir` is named by whoever runs the command, so it is taken as given.
+
+### Keeping the installation current
+
+The installed skills are this package's build output rather than source of your repository, so ignore them:
+
+```gitignore
+.claude/skills/hor-*/
+.hora/
+```
+
+An `npm install` with no arguments re-runs your project's `postinstall`, so the skills follow along. Naming the package on the command line — `npm install @openreachtech/hora-skills-ort-renchan@latest` — does not, and neither does a repository without a hook. Run the command again yourself:
+
+```sh
+npx --no hora-skills-ort-renchan install
+```
+
+`install` is repeatable: it removes what the previous run installed — recorded in `.hora/hora-skills-ort-renchan.json` — along with any folder named after a skill this package distributes, before copying the current output. A renamed or dropped skill therefore leaves nothing behind, and a repository that had copied `dist/skills/` by hand is tidied up on its first run.
+
+A skill your own repository authored is left alone, as long as its name is not one this package distributes. Carrying the `hor-` prefix is not enough to put it at risk — `hor-own-skill` is untouched — but naming it exactly after a distributed skill hands that name over to this package.
+
+### Commands
+
+| Command | What it does |
+| :-- | :-- |
+| `hora-skills-ort-renchan install` | Install every skill this package distributes, replacing the previously installed ones |
+| `hora-skills-ort-renchan list` | Print the skills this package distributes, installing nothing |
+| `hora-skills-ort-renchan uninstall` | Remove every skill this package installed, along with its record |
+| `hora-skills-ort-renchan help` | Print the usage text |
+
+`--dir <path>` installs into a directory other than `.claude/skills`.
+
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/hora-skills-ort-renchan.git
+cd hora-skills-ort-renchan
+npm install
+npm run lint
+npm test
+```
+
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+
+## Developer
+
+[Open Reach Tech Inc.](https://openreach.tech)
+
+## Copyright
+
+© 2026 Open Reach Tech Inc.

--- a/docs/skills.ja.md
+++ b/docs/skills.ja.md
@@ -1,0 +1,40 @@
+# スキル
+
+このパッケージに収録された全 31 スキルのカタログです。各スキルに 1〜2 行の概要を添えています。
+
+各スキルは `kit/skills/backend/<name>/` に、ドメインディレクトリの直下 1 階層で置かれます。そのフォルダ名がスキルの `name:` であり、インストール後のフォルダ名でもあります。したがって下表の **スキル** だけで足ります。`/name` として呼び出す名前、インストール後に `.claude/skills/` に現れる名前、ソースの置き場所が、すべて同じ 1 つの文字列です。先頭 3 文字はドメインを表します。配置と命名の規則は [flatten ビルド規約](https://github.com/openreachtech/hora-skills-ort-renchan/blob/main/.claude/skills/flatten/SKILL.md) を参照してください。各スキルの詳細は、それぞれの `SKILL.md` にあります。
+
+| スキル (= コマンド) | 概要 |
+| :-- | :-- |
+| `hor-agent-loop` | `@openreachtech/mentsu-agent-loop` の 3 パッケージで LLM エージェントループを構築します。core(反復エンジン)、BullMQ ジョブ実行、GraphQL の起動 mutation と進捗 subscription。 |
+| `hor-ai-agent-structure` | `mentsu-agent-loop-core` 上にアプリ側 AI エージェントを構成します。`app/agents/<name>/` に `ProceduralAgentLoop` サブクラスとステップごとの `BaseAgentAction` サブクラスを置きます。 |
+| `hor-ai-prompt-document-store` | エージェントの設定・指示文・ドキュメント・ツールスキーマをコードに埋め込まず DB に保持し、リクエスト時にプロンプトへ組み立て、バックアップテーブルでバージョン管理します。 |
+| `hor-backend-testing` | テストファイルの配置(DB 書き込みなしは `tests/__tests__`、ありは `tests/_orders`)、DB 書き込みテストの実行順の保証、実行方法、テストとダブルの純粋性ルール。 |
+| `hor-bank-id` | 1 つのバックエンドリポジトリ内で、依頼者ごとに排他的で衝突しない行 id プレフィックスを割り当てる。シーダーやテストフィクスチャで 2 人の書き手が同じ明示 id を選ばないようにする。 |
+| `hor-build-e2e-test-environment` | `e2e/docker/` 配下の手動操作用ローカル E2E 環境の構築・実行・デバッグ。コンテナ構成、本番にリバースプロキシがある場合はその層、専用シードセット、`up`/`start`/`seed`/`clean`/`down` スクリプト。 |
+| `hor-constant-definition` | アプリ定数は必ず 2 ファイルで定義します。`constants/` の CommonJS マスター(単一の情報源)と、それを再 export する `app/constants/` の ESM ブリッジ。 |
+| `hor-cookie-authentication` | renchan バックエンドのアクター別 Cookie 認証。認証情報とトークンのモデル、アクセストークンとローテーションするリフレッシュトークン(再利用検知つき)、HttpOnly のリフレッシュ Cookie、signIn / signUp / signOut / renewAccessToken の各リゾルバー。 |
+| `hor-database-design` | マイグレーションやモデルを書く前に決めるスキーマの論理設計。正規化の判断、ステータス/カテゴリの表現、カラム型、時刻の保持、読み取りのスケール、履歴とバージョン管理。 |
+| `hor-execution-placement-pattern` | 処理(特に書き込み)をどこに実装するかの判断。同期的な GraphQL/REST 操作か、API ハンドラ・post-worker・スケジュールから起動するバックグラウンドワーカーか。 |
+| `hor-external-api-client` | `@openreachtech/mentsu-rocket-client` で外部 HTTP/REST API クライアントを実装します。`app/<serviceName>Client/` 配下の Launcher / Payload / Capsule の 3 クラス構成。 |
+| `hor-graphql-schema` | renchan サーバの GraphQL SDL(`.graphql`)を書きます。オーディエンス別スキーマ、ドメイン別の番号付きファイル、カスタムスカラー、命名・null 許容・enum・ページネーションの規約。 |
+| `hor-graphql-server-engine` | エンドポイントごとの `*GraphqlServerEngine` を実装・起動します。URL、スキーマパス、リゾルバディレクトリ、Share/Context の DI、認証フィルタ、ミドルウェア、スカラー、エラーコード。 |
+| `hor-light-rag` | ベクタ DB なしで AI エージェント向けの軽量 RAG を追加します。ローカル埋め込みによる vector-first / LLM フォールバックのランキングと、MySQL の n-gram 全文検索インデックス。 |
+| `hor-multi-llm-provider` | Claude / OpenAI / Gemini を 1 つの抽象の下で扱います。抽象モデルプロセッサ、ベンダーごとの基底、モデルごとの具象クラス、モデル名で選択するローダー。 |
+| `hor-mutation-resolver` | `BaseMutationResolver` を継承した GraphQL Mutation リゾルバを実装します。状態を変更する操作と、それが動く単一トランザクション。 |
+| `hor-post-worker` | post-worker を実装します。リゾルバが解決してレスポンス送信後に発火し、API の本処理に含めない副作用(通知メール、監査ログ、キャッシュ無効化)を実行するフックです。 |
+| `hor-query-resolver` | `BaseQueryResolver` を継承した GraphQL Query リゾルバを書きます。ページネーション、関連の include、ドメインエラーの throw、actual と stub のペア。 |
+| `hor-renchan-job-bullmq` | `@openreachtech/renchan-job-bullmq` でバックグラウンドジョブを実装・配線します。Manifest / Worker / Dispatcher の 3 点セット、繰り返しジョブ、enqueue、進捗配信、並列数とリトライ。 |
+| `hor-resolver-share` | Share クラスを実装します。サーバ起動時に一度作られ `context.share` として全リゾルバに渡されるプロセス単位のシングルトン置き場で、Share と Context の使い分けも扱います。 |
+| `hor-resolver-validator` | リゾルバの入力検証クラス(`*InputValidator`)を実装します。`BaseInputValidator` を継承し、値の検査は `mentsu-value-inspector` に委譲します。 |
+| `hor-restfulapi-architecture` | renchan バックエンドの REST 層。`server/restfulapi/` 配下のレンダラーアーキテクチャ、ルートとバージョン、`render()`、レスポンス/エラーハッシュ、認証フィルタ、フラッシャー。 |
+| `hor-security-audit` | Node プロジェクト全体を読み取り専用でセキュリティ監査し、所見リストを出します。インジェクション、認証漏れ、ポート/データストア露出、シークレット、依存、CORS、レート制限、PII、アップロード。 |
+| `hor-sequelize-migration` | renchan/Sequelize のマイグレーションを書きます。`createTable`、`addColumn`/`removeColumn`、`addIndex`、インデックス命名、外部キーカラムを持たせるかの判断。 |
+| `hor-sequelize-model` | renchan/Sequelize のモデル定義を書きます。属性、`createOptions`、アソシエーション、スコープ、フック、`MixinModel` の配線。 |
+| `hor-sequelize-seeder` | renchan/Sequelize のシーダーを書きます。master / dev-master / development の 3 ディレクトリ分割、ファイル雛形、ファイル名の採番、ファイルごとの ID ブロック採番。 |
+| `hor-sequelize-subquery` | `this.addSubquery` で名前付きサブクエリを定義し、`Model.subquery(name, params)` で使います。関連テーブルの条件による絞り込みは JOIN ではなくサブクエリで行います。 |
+| `hor-strategy-pattern` | 型文字列で分岐する else-if / switch を、基底プロセッサ・バリアントごとのサブクラス・ディレクトリから自動発見して選ぶ一括ローダーの 3 点構成に置き換えます。 |
+| `hor-stub-api` | DB アクセスもビジネスロジックも持たず、スキーマどおりの固定データを返す stub リゾルバを実装します。実装前の API 契約に対してフロントエンドが開発できます。 |
+| `hor-subscription-resolver` | GraphQL subscription リゾルバを実装します。操作の宣言、購読者ごとのチャンネルのスコープ、購読可否のゲート、イベントを push する publish 側の配線。 |
+| `hor-type-interface` | `.d.ts` で型インターフェースを定義します。`types/models/` のモデルインターフェース(global `model`)と、`types/resolvers/<category>/` のリゾルバ Input/Result 型。 |
+

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,40 @@
+# Skills
+
+A catalog of every skill in this package — 31 in total — with a one- or two-line summary each.
+
+Each skill lives at `kit/skills/backend/<name>/`, one level under the domain directory, and that folder name is both the skill's `name:` and the folder name it is installed under. **Skill** below is therefore all you need: it is what you invoke as `/name`, what appears under `.claude/skills/` once installed, and where the source sits. The three-character prefix is the domain — see [the flatten build convention](https://github.com/openreachtech/hora-skills-ort-renchan/blob/main/.claude/skills/flatten/SKILL.md) for the layout and the naming rules. Full guidance for any skill is in its own `SKILL.md`.
+
+| Skill (= Command) | Summary |
+| :-- | :-- |
+| `hor-agent-loop` | Build an LLM agent loop with the three `@openreachtech/mentsu-agent-loop` packages — the core iteration engine, a BullMQ job runner, and a GraphQL mutation plus progress subscription. |
+| `hor-ai-agent-structure` | Structure an app-side AI agent on `mentsu-agent-loop-core`: a `ProceduralAgentLoop` subclass plus per-step `BaseAgentAction` subclasses under `app/agents/<name>/`. |
+| `hor-ai-prompt-document-store` | Hold agent config, instructions, documents and tool schemas in the database rather than in code, assembling the runtime prompt at request time and versioning through backup tables. |
+| `hor-backend-testing` | Where a test file goes (`tests/__tests__` vs `tests/_orders`), how run order among DB-writing tests is guaranteed, how to run the suite, and the purity rules for tests and doubles. |
+| `hor-bank-id` | Allocate an exclusive, collision-free row-id prefix for a requester inside one backend repository, so two writers never pick the same explicit id in seeders and test fixtures. |
+| `hor-build-e2e-test-environment` | Build, run and debug the hand-operated local E2E stack under `e2e/docker/` — its containers, the reverse-proxy edge where production has one, its seed set, and the `up`/`start`/`seed`/`clean`/`down` scripts. |
+| `hor-constant-definition` | Define an application constant as two files: a CommonJS master under `constants/` (the source of truth) plus an ESM bridge under `app/constants/` that re-exports it. |
+| `hor-cookie-authentication` | Cookie-based authentication for a renchan backend, per actor — the credential and token models, access plus rotating refresh tokens with reuse detection, the HttpOnly refresh cookie, and the signIn / signUp / signOut / renewAccessToken resolvers. |
+| `hor-database-design` | The logical schema decisions made before writing a migration or model — normalization, status/category representation, column types, time storage, read scaling, versioning, history. |
+| `hor-execution-placement-pattern` | Decide where processing belongs: a synchronous GraphQL/REST operation, or a background worker triggered from a handler, from a post-worker, or on a schedule. |
+| `hor-external-api-client` | Implement an external HTTP/REST API client with `@openreachtech/mentsu-rocket-client` — the Launcher / Payload / Capsule trio under `app/<serviceName>Client/`. |
+| `hor-graphql-schema` | Author GraphQL SDL files for a renchan server — per-audience schemas, numbered per-domain files, custom scalars, and naming, nullability, enum and pagination conventions. |
+| `hor-graphql-server-engine` | Implement a per-endpoint `*GraphqlServerEngine`: its URL, schema path, resolver directories, Share/Context DI, auth filter, middleware, scalars and error codes. |
+| `hor-light-rag` | Add lightweight RAG for agent documents without a vector database — a vector-first / LLM-fallback ranker over stored `Document` rows, plus a MySQL n-gram fulltext keyword index. |
+| `hor-multi-llm-provider` | Support Claude / OpenAI / Gemini behind one abstraction — an abstract model processor, a base per vendor, a concrete class per model, and a loader that picks one by model name. |
+| `hor-mutation-resolver` | Implement GraphQL Mutation resolvers extending `BaseMutationResolver` — state-changing operations and the single transaction each runs in. |
+| `hor-post-worker` | Implement a post-worker: a hook firing after a resolver has resolved and the response has been sent, for side effects outside the API's main processing. |
+| `hor-query-resolver` | Write GraphQL Query resolvers extending `BaseQueryResolver` — pagination, association includes, domain-error throwing, and the actual-vs-stub pair. |
+| `hor-renchan-job-bullmq` | Write and wire background jobs with `@openreachtech/renchan-job-bullmq` — the Manifest / Worker / Dispatcher triple, repeatable jobs, enqueuing, progress publishing, concurrency and retries. |
+| `hor-resolver-share` | Implement the Share class — the per-process container of shared singletons handed to every resolver as `context.share` — and decide what belongs in Share versus Context. |
+| `hor-resolver-validator` | Implement `*InputValidator` classes for resolvers, extending `BaseInputValidator` and delegating value checks to `mentsu-value-inspector`. |
+| `hor-restfulapi-architecture` | The REST layer of a renchan backend — the renderer architecture under `server/restfulapi/`, routes and versions, `render()`, response/error hashes, the auth filter, and flushers. |
+| `hor-security-audit` | Read-only, repo-wide security audit of a Node project, producing a findings list — injection, auth gaps, exposure, secrets, dependencies, CORS, rate limiting, PII, uploads. |
+| `hor-sequelize-migration` | Write renchan/Sequelize migrations — `createTable`, `addColumn`/`removeColumn`, `addIndex`, index naming, and whether to add a foreign-key column. |
+| `hor-sequelize-model` | Write renchan/Sequelize model definitions — attributes, `createOptions`, associations, scopes, hooks, and how to wire a `MixinModel`. |
+| `hor-sequelize-seeder` | Write renchan/Sequelize seeders — the master / dev-master / development split, the file skeleton, filename numbering, and per-file seed-id blocks. |
+| `hor-sequelize-subquery` | Define named subqueries with `this.addSubquery` and consume them via `Model.subquery(name, params)`; filtering by a related table is a subquery, not a JOIN. |
+| `hor-strategy-pattern` | Replace an else-if/switch dispatch chain with a base processor, one subclass per variant, and a bulk loader that auto-discovers subclasses and picks one by a dispatch getter. |
+| `hor-stub-api` | Implement a stub resolver returning hardcoded, schema-accurate data with no DB access, so the frontend can develop against the API contract before the real backend exists. |
+| `hor-subscription-resolver` | Implement a GraphQL subscription resolver — declare the operation, scope its channel per subscriber, gate who may subscribe, and wire the publish side. |
+| `hor-type-interface` | Define `.d.ts` type interfaces — model interfaces under `types/models/` (global `model`) and resolver Input/Result types under `types/resolvers/<category>/`. |
+


### PR DESCRIPTION
# Why

* Close #19

# How

* Follows the README of `hora-skills`, changed where the split changed the facts: the one domain, no `--domains` option and no `horaSkills.domains`, and a record named after the package
* Names the three packages in one table, so a reader landing on any of them finds the other two
* Adds a section on installing more than one domain: the packages install into one `.claude/skills/` and each records its own installation, so a run of one never removes what another placed
* `docs/skills.md` and `docs/skills.ja.md` carry this package's 31 skills, taken from the `hora-skills` catalog unchanged
* Both READMEs mirror each other: the same sections in the same order, in English and Japanese
