### PR TITLE
📦️ Rename the package to `hora-skills-ort-renchan`

### DIFF
--- a/lib/equip/CommandLineArguments.js
+++ b/lib/equip/CommandLineArguments.js
@@ -1,5 +1,5 @@
 /**
- * The arguments given to the `hora-skills-renchan` command.
+ * The arguments given to the `hora-skills-ort-renchan` command.
  *
  * Both `--name value` and `--name=value` are accepted, and anything that is neither an
  * option name nor the value following one is read as a command name.

--- a/lib/equip/HoraSkillsCli.js
+++ b/lib/equip/HoraSkillsCli.js
@@ -7,7 +7,7 @@ import SkillsInstaller from './SkillsInstaller.js'
 import CLI_COMMAND from './constants/CLI_COMMAND.js'
 
 /**
- * The `hora-skills-renchan` command.
+ * The `hora-skills-ort-renchan` command.
  *
  * It installs every skill this package distributes into a consuming repository, and
  * removes what an earlier run of it installed. Which skills a repository equips is
@@ -177,7 +177,7 @@ export default class HoraSkillsCli {
    */
   static get usageText () {
     return [
-      'Usage: hora-skills-renchan <command> [options]',
+      'Usage: hora-skills-ort-renchan <command> [options]',
       '',
       'Commands:',
       '  install    Install every skill this package distributes, replacing the installed ones',

--- a/lib/equip/SkillsInstaller.js
+++ b/lib/equip/SkillsInstaller.js
@@ -88,7 +88,7 @@ export default class SkillsInstaller {
   static get manifestPathSegments () {
     return [
       '.hora',
-      'hora-skills-renchan.json',
+      'hora-skills-ort-renchan.json',
     ]
   }
 

--- a/lib/equip/SkillsManifestFile.js
+++ b/lib/equip/SkillsManifestFile.js
@@ -16,7 +16,7 @@ import path from 'node:path'
  *   "version": "0.1.0",
  *   "installations": {
  *     ".claude/skills": {
- *       "skillNames": ["hb-jsdoc", "hb-naming"]
+ *       "skillNames": ["hor-jsdoc", "hor-naming"]
  *     }
  *   }
  * }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@openreachtech/hora-skills-renchan",
+  "name": "@openreachtech/hora-skills-ort-renchan",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@openreachtech/hora-skills-renchan",
+      "name": "@openreachtech/hora-skills-ort-renchan",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -1908,7 +1908,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihof-1.12.2.tgz",
       "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
@@ -1922,7 +1922,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihof-1.12.2.tgz",
       "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openreachtech/hora-skills-renchan",
+  "name": "@openreachtech/hora-skills-ort-renchan",
   "version": "0.0.0",
   "description": "Distributes the renchan backend skills used to develop with Hora Kit.",
   "type": "module",
@@ -9,7 +9,7 @@
     "lib/"
   ],
   "bin": {
-    "hora-skills-renchan": "lib/equip/hora-skills-renchan.js"
+    "hora-skills-ort-renchan": "lib/equip/hora-skills-ort-renchan.js"
   },
   "keywords": [
     "hora",
@@ -27,14 +27,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openreachtech/hora-skills-renchan.git"
+    "url": "git+https://github.com/openreachtech/hora-skills-ort-renchan.git"
   },
   "author": "Open Reach Tech Inc.",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/openreachtech/hora-skills-renchan/issues"
+    "url": "https://github.com/openreachtech/hora-skills-ort-renchan/issues"
   },
-  "homepage": "https://github.com/openreachtech/hora-skills-renchan#readme",
+  "homepage": "https://github.com/openreachtech/hora-skills-ort-renchan#readme",
   "dependencies": {
   },
   "devDependencies": {

--- a/tests/__tests__/equip/HoraSkillsCli.js
+++ b/tests/__tests__/equip/HoraSkillsCli.js
@@ -363,7 +363,7 @@ describe('HoraSkillsCli', () => {
           override: {
             installResult: {
               installedSkillNames: [
-                'hb-query-resolver',
+                'hor-query-resolver',
               ],
               removedSkillNames: [],
             },
@@ -374,11 +374,11 @@ describe('HoraSkillsCli', () => {
           override: {
             installResult: {
               installedSkillNames: [
-                'hb-naming',
-                'hb-jsdoc',
+                'hor-naming',
+                'hor-jsdoc',
               ],
               removedSkillNames: [
-                'hb-css',
+                'hor-css',
               ],
             },
           },
@@ -1166,7 +1166,7 @@ describe('HoraSkillsCli', () => {
               'install',
             ],
           },
-          expected: '/consumer/.hora/hora-skills-renchan.json',
+          expected: '/consumer/.hora/hora-skills-ort-renchan.json',
         },
         {
           input: {
@@ -1176,7 +1176,7 @@ describe('HoraSkillsCli', () => {
               'tools/skills',
             ],
           },
-          expected: '/consumer/.hora/hora-skills-renchan.json',
+          expected: '/consumer/.hora/hora-skills-ort-renchan.json',
         },
       ]
 
@@ -1206,17 +1206,17 @@ describe('HoraSkillsCli', () => {
             ],
           },
           expected: [
-            '/consumer/.hora/hora-skills-renchan.json',
+            '/consumer/.hora/hora-skills-ort-renchan.json',
           ],
         },
         {
           override: {
             linkedPaths: [
-              '/consumer/.hora/hora-skills-renchan.json',
+              '/consumer/.hora/hora-skills-ort-renchan.json',
             ],
           },
           expected: [
-            '/consumer/.hora/hora-skills-renchan.json',
+            '/consumer/.hora/hora-skills-ort-renchan.json',
           ],
         },
         {
@@ -1254,10 +1254,10 @@ describe('HoraSkillsCli', () => {
         {
           override: {
             linkedManifestFilePaths: [
-              '/consumer/.hora/hora-skills-renchan.json',
+              '/consumer/.hora/hora-skills-ort-renchan.json',
             ],
           },
-          expected: '/consumer/.hora/hora-skills-renchan.json is reached through a symbolic link.',
+          expected: '/consumer/.hora/hora-skills-ort-renchan.json is reached through a symbolic link.',
         },
       ]
 
@@ -1297,7 +1297,7 @@ describe('HoraSkillsCli', () => {
         {
           override: {
             distributedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: '1 skills distributed',
@@ -1305,8 +1305,8 @@ describe('HoraSkillsCli', () => {
         {
           override: {
             distributedSkillNames: [
-              'hb-query-resolver',
-              'hb-stub-api',
+              'hor-query-resolver',
+              'hor-stub-api',
             ],
           },
           expected: '2 skills distributed',
@@ -1348,7 +1348,7 @@ describe('HoraSkillsCli', () => {
           override: {
             uninstallResult: {
               removedSkillNames: [
-                'hb-query-resolver',
+                'hor-query-resolver',
               ],
             },
           },

--- a/tests/__tests__/equip/SkillsInstaller.js
+++ b/tests/__tests__/equip/SkillsInstaller.js
@@ -75,7 +75,7 @@ describe('SkillsInstaller', () => {
           {
             input: {
               manifestFile: SkillsManifestFile.create({
-                filePath: '/consumer/.hora/hora-skills-renchan.json',
+                filePath: '/consumer/.hora/hora-skills-ort-renchan.json',
                 installationPath: '.claude/skills',
               }),
             },
@@ -83,7 +83,7 @@ describe('SkillsInstaller', () => {
           {
             input: {
               manifestFile: SkillsManifestFile.create({
-                filePath: '.hora/hora-skills-renchan.json',
+                filePath: '.hora/hora-skills-ort-renchan.json',
                 installationPath: 'tools/skills',
               }),
             },
@@ -144,7 +144,7 @@ describe('SkillsInstaller', () => {
             sourceDirectoryPath: '/package/dist/skills',
           },
           expected: {
-            filePath: '/consumer/.hora/hora-skills-renchan.json',
+            filePath: '/consumer/.hora/hora-skills-ort-renchan.json',
             installationPath: '.claude/skills',
           },
         },
@@ -155,7 +155,7 @@ describe('SkillsInstaller', () => {
             sourceDirectoryPath: '/package/dist/skills',
           },
           expected: {
-            filePath: '/tmp/.hora/hora-skills-renchan.json',
+            filePath: '/tmp/.hora/hora-skills-ort-renchan.json',
             installationPath: 'skills',
           },
         },
@@ -232,7 +232,7 @@ describe('SkillsInstaller', () => {
         expect(received)
           .toEqual([
             '.hora',
-            'hora-skills-renchan.json',
+            'hora-skills-ort-renchan.json',
           ])
       })
     })
@@ -266,14 +266,14 @@ describe('SkillsInstaller', () => {
             workingDirectoryPath: '/consumer',
             targetDirectoryPath: '/consumer/.claude/skills',
           },
-          expected: '/consumer/.hora/hora-skills-renchan.json',
+          expected: '/consumer/.hora/hora-skills-ort-renchan.json',
         },
         {
           input: {
             workingDirectoryPath: '/tmp',
             targetDirectoryPath: '/tmp/skills/',
           },
-          expected: '/tmp/.hora/hora-skills-renchan.json',
+          expected: '/tmp/.hora/hora-skills-ort-renchan.json',
         },
       ]
 
@@ -365,12 +365,12 @@ describe('SkillsInstaller', () => {
       const cases = [
         {
           input: {
-            skillName: 'hb-naming',
+            skillName: 'hor-naming',
           },
         },
         {
           input: {
-            skillName: 'hb-cp-table',
+            skillName: 'hor-cp-table',
           },
         },
         {
@@ -417,7 +417,7 @@ describe('SkillsInstaller', () => {
         },
         {
           input: {
-            skillName: 'hb-naming/SKILL.md',
+            skillName: 'hor-naming/SKILL.md',
           },
         },
         {
@@ -487,15 +487,15 @@ describe('SkillsInstaller', () => {
         {
           override: {
             removedSkillNames: [
-              'hb-cp-table',
+              'hor-cp-table',
             ],
             installedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: {
             skillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
         },
@@ -537,18 +537,18 @@ describe('SkillsInstaller', () => {
         {
           override: {
             removedSkillNames: [
-              'hb-cp-table',
+              'hor-cp-table',
             ],
             installedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: {
             removedSkillNames: [
-              'hb-cp-table',
+              'hor-cp-table',
             ],
             installedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
         },
@@ -556,15 +556,15 @@ describe('SkillsInstaller', () => {
           override: {
             removedSkillNames: [],
             installedSkillNames: [
-              'hb-naming',
-              'hb-jsdoc',
+              'hor-naming',
+              'hor-jsdoc',
             ],
           },
           expected: {
             removedSkillNames: [],
             installedSkillNames: [
-              'hb-naming',
-              'hb-jsdoc',
+              'hor-naming',
+              'hor-jsdoc',
             ],
           },
         },
@@ -600,20 +600,20 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hb-query-resolver',
-              'hb-stub-api',
+              'hor-query-resolver',
+              'hor-stub-api',
             ],
           },
           expected: [
             [
-              '/consumer/.claude/skills/hb-query-resolver',
+              '/consumer/.claude/skills/hor-query-resolver',
               {
                 recursive: true,
                 force: true,
               },
             ],
             [
-              '/consumer/.claude/skills/hb-stub-api',
+              '/consumer/.claude/skills/hor-stub-api',
               {
                 recursive: true,
                 force: true,
@@ -650,11 +650,11 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: [
-            'hb-query-resolver',
+            'hor-query-resolver',
           ],
         },
         {
@@ -690,28 +690,28 @@ describe('SkillsInstaller', () => {
           override: {
             recordedSkillNames: [],
             distributedSkillNames: [
-              'hb-query-resolver',
-              'hb-naming',
+              'hor-query-resolver',
+              'hor-naming',
             ],
             directoryNames: [
-              'hb-naming',
-              'hb-own-skill',
+              'hor-naming',
+              'hor-own-skill',
               'my-own-skill',
             ],
           },
           expected: [
-            'hb-naming',
+            'hor-naming',
           ],
         },
         {
           override: {
             recordedSkillNames: [],
             distributedSkillNames: [
-              'hb-query-resolver',
-              'hb-naming',
+              'hor-query-resolver',
+              'hor-naming',
             ],
             directoryNames: [
-              'hb-own-skill',
+              'hor-own-skill',
               'my-own-skill',
             ],
           },
@@ -749,12 +749,12 @@ describe('SkillsInstaller', () => {
           override: {
             recordedSkillNames: [
               '../../../canary',
-              'hb-naming',
+              'hor-naming',
             ],
           },
           expected: [
             [
-              '/consumer/.claude/skills/hb-naming',
+              '/consumer/.claude/skills/hor-naming',
               {
                 recursive: true,
                 force: true,
@@ -799,36 +799,36 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hb-cp-table',
+              'hor-cp-table',
             ],
             distributedSkillNames: [
-              'hb-query-resolver',
-              'hb-naming',
+              'hor-query-resolver',
+              'hor-naming',
             ],
             directoryNames: [
-              'hb-naming',
-              'hb-own-skill',
+              'hor-naming',
+              'hor-own-skill',
             ],
           },
           expected: [
-            'hb-cp-table',
-            'hb-naming',
+            'hor-cp-table',
+            'hor-naming',
           ],
         },
         {
           override: {
             recordedSkillNames: [
-              'hb-naming',
+              'hor-naming',
             ],
             distributedSkillNames: [
-              'hb-naming',
+              'hor-naming',
             ],
             directoryNames: [
-              'hb-naming',
+              'hor-naming',
             ],
           },
           expected: [
-            'hb-naming',
+            'hor-naming',
           ],
         },
         {
@@ -836,7 +836,7 @@ describe('SkillsInstaller', () => {
             recordedSkillNames: [],
             distributedSkillNames: [],
             directoryNames: [
-              'hb-own-skill',
+              'hor-own-skill',
             ],
           },
           expected: [],
@@ -869,14 +869,14 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hb-naming',
+              'hor-naming',
               '../../../canary',
             ],
             distributedSkillNames: [],
             directoryNames: [],
           },
           expected: [
-            'hb-naming',
+            'hor-naming',
           ],
         },
         {
@@ -885,7 +885,7 @@ describe('SkillsInstaller', () => {
               '..',
               '.',
               '',
-              'hb-naming/SKILL.md',
+              'hor-naming/SKILL.md',
             ],
             distributedSkillNames: [],
             directoryNames: [],
@@ -924,40 +924,40 @@ describe('SkillsInstaller', () => {
         {
           override: {
             distributedSkillNames: [
-              'hb-query-resolver',
-              'hb-jsdoc',
-              'hb-naming',
+              'hor-query-resolver',
+              'hor-jsdoc',
+              'hor-naming',
             ],
             directoryNames: [
-              'hb-naming',
-              'hb-own-skill',
+              'hor-naming',
+              'hor-own-skill',
               'my-own-skill',
             ],
           },
           expected: [
-            'hb-naming',
+            'hor-naming',
           ],
         },
         {
           override: {
             distributedSkillNames: [
-              'hb-query-resolver',
-              'hb-naming',
+              'hor-query-resolver',
+              'hor-naming',
             ],
             directoryNames: [
-              'hb-query-resolver',
-              'hb-naming',
+              'hor-query-resolver',
+              'hor-naming',
             ],
           },
           expected: [
-            'hb-query-resolver',
-            'hb-naming',
+            'hor-query-resolver',
+            'hor-naming',
           ],
         },
         {
           override: {
             distributedSkillNames: [
-              'hb-naming',
+              'hor-naming',
             ],
             directoryNames: [],
           },
@@ -994,11 +994,11 @@ describe('SkillsInstaller', () => {
           override: {
             dirents: [
               {
-                name: 'hb-cp-table',
+                name: 'hor-cp-table',
                 isDirectory: () => true,
               },
               {
-                name: 'hb-query-resolver',
+                name: 'hor-query-resolver',
                 isDirectory: () => true,
               },
               {
@@ -1008,8 +1008,8 @@ describe('SkillsInstaller', () => {
             ],
           },
           expected: [
-            'hb-cp-table',
-            'hb-query-resolver',
+            'hor-cp-table',
+            'hor-query-resolver',
           ],
         },
         {
@@ -1071,15 +1071,15 @@ describe('SkillsInstaller', () => {
       const cases = [
         {
           input: {
-            skillName: 'hb-query-resolver',
+            skillName: 'hor-query-resolver',
           },
-          expected: '/consumer/.claude/skills/hb-query-resolver',
+          expected: '/consumer/.claude/skills/hor-query-resolver',
         },
         {
           input: {
-            skillName: 'hb-naming',
+            skillName: 'hor-naming',
           },
-          expected: '/consumer/.claude/skills/hb-naming',
+          expected: '/consumer/.claude/skills/hor-naming',
         },
       ]
 
@@ -1105,15 +1105,15 @@ describe('SkillsInstaller', () => {
       const cases = [
         {
           input: {
-            skillName: 'hb-query-resolver',
+            skillName: 'hor-query-resolver',
           },
-          expected: '/package/dist/skills/hb-query-resolver',
+          expected: '/package/dist/skills/hor-query-resolver',
         },
         {
           input: {
-            skillName: 'hb-naming',
+            skillName: 'hor-naming',
           },
-          expected: '/package/dist/skills/hb-naming',
+          expected: '/package/dist/skills/hor-naming',
         },
       ]
 
@@ -1140,12 +1140,12 @@ describe('SkillsInstaller', () => {
         {
           override: {
             distributedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: [
-            '/package/dist/skills/hb-query-resolver',
-            '/consumer/.claude/skills/hb-query-resolver',
+            '/package/dist/skills/hor-query-resolver',
+            '/consumer/.claude/skills/hor-query-resolver',
             {
               recursive: true,
             },
@@ -1154,12 +1154,12 @@ describe('SkillsInstaller', () => {
         {
           override: {
             distributedSkillNames: [
-              'hb-naming',
+              'hor-naming',
             ],
           },
           expected: [
-            '/package/dist/skills/hb-naming',
-            '/consumer/.claude/skills/hb-naming',
+            '/package/dist/skills/hor-naming',
+            '/consumer/.claude/skills/hor-naming',
             {
               recursive: true,
             },
@@ -1290,13 +1290,13 @@ describe('SkillsInstaller', () => {
           },
           input: {
             skillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: {
             version: '0.0.1',
             skillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
         },
@@ -1411,12 +1411,12 @@ describe('SkillsInstaller', () => {
         {
           override: {
             removedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: {
             removedSkillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
         },

--- a/tests/__tests__/equip/SkillsManifestFile.js
+++ b/tests/__tests__/equip/SkillsManifestFile.js
@@ -10,17 +10,17 @@ describe('SkillsManifestFile', () => {
         const cases = [
           {
             input: {
-              filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+              filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
               installationPath: '.claude/skills',
             },
-            expected: '/tmp/app/.hora/hora-skills-renchan.json',
+            expected: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           },
           {
             input: {
-              filePath: '.hora/hora-skills-renchan.json',
+              filePath: '.hora/hora-skills-ort-renchan.json',
               installationPath: 'tools/skills',
             },
-            expected: '.hora/hora-skills-renchan.json',
+            expected: '.hora/hora-skills-ort-renchan.json',
           },
         ]
 
@@ -36,14 +36,14 @@ describe('SkillsManifestFile', () => {
         const cases = [
           {
             input: {
-              filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+              filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
               installationPath: '.claude/skills',
             },
             expected: '.claude/skills',
           },
           {
             input: {
-              filePath: '.hora/hora-skills-renchan.json',
+              filePath: '.hora/hora-skills-ort-renchan.json',
               installationPath: 'tools/skills',
             },
             expected: 'tools/skills',
@@ -67,13 +67,13 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           input: {
-            filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+            filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
             installationPath: '.claude/skills',
           },
         },
         {
           input: {
-            filePath: '.hora/hora-skills-renchan.json',
+            filePath: '.hora/hora-skills-ort-renchan.json',
             installationPath: 'tools/skills',
           },
         },
@@ -91,13 +91,13 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           tally: {
-            filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+            filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
             installationPath: '.claude/skills',
           },
         },
         {
           tally: {
-            filePath: '.hora/hora-skills-renchan.json',
+            filePath: '.hora/hora-skills-ort-renchan.json',
             installationPath: 'tools/skills',
           },
         },
@@ -120,7 +120,7 @@ describe('SkillsManifestFile', () => {
     describe('when called as is', () => {
       test('should be fixed value', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -138,7 +138,7 @@ describe('SkillsManifestFile', () => {
     describe('when called as is', () => {
       test('should be fixed value', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -162,14 +162,14 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hb-query-resolver',
+                    'hor-query-resolver',
                   ],
                 },
               },
             },
           },
           expected: [
-            'hb-query-resolver',
+            'hor-query-resolver',
           ],
         },
         {
@@ -192,26 +192,26 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hb-naming',
+                    'hor-naming',
                   ],
                 },
                 'tools/skills': {
                   skillNames: [
-                    'hb-query-resolver',
+                    'hor-query-resolver',
                   ],
                 },
               },
             },
           },
           expected: [
-            'hb-naming',
+            'hor-naming',
           ],
         },
       ]
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -254,7 +254,7 @@ describe('SkillsManifestFile', () => {
               installations: {
                 'tools/skills': {
                   skillNames: [
-                    'hb-query-resolver',
+                    'hor-query-resolver',
                   ],
                 },
               },
@@ -276,7 +276,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -294,7 +294,7 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           override: {
-            skillNames: 'hb-naming',
+            skillNames: 'hor-naming',
           },
         },
         {
@@ -310,7 +310,7 @@ describe('SkillsManifestFile', () => {
         {
           override: {
             skillNames: {
-              0: 'hb-naming',
+              0: 'hor-naming',
             },
           },
         },
@@ -318,7 +318,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('skillNames: $override.skillNames', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -344,14 +344,14 @@ describe('SkillsManifestFile', () => {
         {
           override: {
             skillNames: [
-              'hb-naming',
+              'hor-naming',
               1,
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           expected: [
-            'hb-naming',
-            'hb-query-resolver',
+            'hor-naming',
+            'hor-query-resolver',
           ],
         },
         {
@@ -359,10 +359,10 @@ describe('SkillsManifestFile', () => {
             skillNames: [
               null,
               {
-                skillName: 'hb-naming',
+                skillName: 'hor-naming',
               },
               [
-                'hb-naming',
+                'hor-naming',
               ],
             ],
           },
@@ -372,7 +372,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('skillNames: $override.skillNames', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -406,7 +406,7 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hb-naming',
+                    'hor-naming',
                   ],
                 },
               },
@@ -414,7 +414,7 @@ describe('SkillsManifestFile', () => {
           },
           expected: {
             skillNames: [
-              'hb-naming',
+              'hor-naming',
             ],
           },
         },
@@ -422,7 +422,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -459,7 +459,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -486,12 +486,12 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hb-naming',
+                    'hor-naming',
                   ],
                 },
                 'tools/skills': {
                   skillNames: [
-                    'hb-query-resolver',
+                    'hor-query-resolver',
                   ],
                 },
               },
@@ -500,12 +500,12 @@ describe('SkillsManifestFile', () => {
           expected: {
             '.claude/skills': {
               skillNames: [
-                'hb-naming',
+                'hor-naming',
               ],
             },
             'tools/skills': {
               skillNames: [
-                'hb-query-resolver',
+                'hor-query-resolver',
               ],
             },
           },
@@ -514,7 +514,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -546,7 +546,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -568,14 +568,14 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           override: {
-            content: '{"version":"0.0.1","installations":{".claude/skills":{"skillNames":["hb-query-resolver"]}}}',
+            content: '{"version":"0.0.1","installations":{".claude/skills":{"skillNames":["hor-query-resolver"]}}}',
           },
           expected: {
             version: '0.0.1',
             installations: {
               '.claude/skills': {
                 skillNames: [
-                  'hb-query-resolver',
+                  'hor-query-resolver',
                 ],
               },
             },
@@ -594,7 +594,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('content: $override.content', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -613,7 +613,7 @@ describe('SkillsManifestFile', () => {
     describe('should be null when the manifest is absent', () => {
       test('when the file does not exist', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -643,7 +643,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('content: $override.content', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -669,7 +669,7 @@ describe('SkillsManifestFile', () => {
           input: {
             version: '0.0.1',
             skillNames: [
-              'hb-query-resolver',
+              'hor-query-resolver',
             ],
           },
           override: {
@@ -680,7 +680,7 @@ describe('SkillsManifestFile', () => {
             installations: {
               '.claude/skills': {
                 skillNames: [
-                  'hb-query-resolver',
+                  'hor-query-resolver',
                 ],
               },
             },
@@ -707,7 +707,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.version', ({ input, override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -732,14 +732,14 @@ describe('SkillsManifestFile', () => {
           input: {
             version: '0.0.1',
             skillNames: [
-              'hb-naming',
+              'hor-naming',
             ],
           },
           override: {
             installationHash: {
               'tools/skills': {
                 skillNames: [
-                  'hb-query-resolver',
+                  'hor-query-resolver',
                 ],
               },
             },
@@ -749,12 +749,12 @@ describe('SkillsManifestFile', () => {
             installations: {
               'tools/skills': {
                 skillNames: [
-                  'hb-query-resolver',
+                  'hor-query-resolver',
                 ],
               },
               '.claude/skills': {
                 skillNames: [
-                  'hb-naming',
+                  'hor-naming',
                 ],
               },
             },
@@ -764,7 +764,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.version', ({ input, override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -789,14 +789,14 @@ describe('SkillsManifestFile', () => {
           input: {
             version: '0.0.2',
             skillNames: [
-              'hb-naming',
+              'hor-naming',
             ],
           },
           override: {
             installationHash: {
               '.claude/skills': {
                 skillNames: [
-                  'hb-cp-table',
+                  'hor-cp-table',
                 ],
               },
             },
@@ -806,7 +806,7 @@ describe('SkillsManifestFile', () => {
             installations: {
               '.claude/skills': {
                 skillNames: [
-                  'hb-naming',
+                  'hor-naming',
                 ],
               },
             },
@@ -816,7 +816,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.version', ({ input, override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -848,15 +848,15 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hb-query-resolver',
+                    'hor-query-resolver',
                   ],
                 },
               },
             },
           },
           expected: [
-            '/tmp/app/.hora/hora-skills-renchan.json',
-            '{\n  "version": "0.0.1",\n  "installations": {\n    ".claude/skills": {\n      "skillNames": [\n        "hb-query-resolver"\n      ]\n    }\n  }\n}\n',
+            '/tmp/app/.hora/hora-skills-ort-renchan.json',
+            '{\n  "version": "0.0.1",\n  "installations": {\n    ".claude/skills": {\n      "skillNames": [\n        "hor-query-resolver"\n      ]\n    }\n  }\n}\n',
           ],
         },
         {
@@ -867,7 +867,7 @@ describe('SkillsManifestFile', () => {
             },
           },
           expected: [
-            '/tmp/app/.hora/hora-skills-renchan.json',
+            '/tmp/app/.hora/hora-skills-ort-renchan.json',
             '{\n  "version": null,\n  "installations": {}\n}\n',
           ],
         },
@@ -875,7 +875,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.manifestHash.version', ({ input, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -912,7 +912,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.manifestHash.version', ({ input, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -947,7 +947,7 @@ describe('SkillsManifestFile', () => {
             },
           },
           expected: [
-            '/tmp/app/.hora/hora-skills-renchan.json',
+            '/tmp/app/.hora/hora-skills-ort-renchan.json',
             {
               force: true,
             },
@@ -957,7 +957,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -986,7 +986,7 @@ describe('SkillsManifestFile', () => {
                 },
                 'tools/skills': {
                   skillNames: [
-                    'hb-query-resolver',
+                    'hor-query-resolver',
                   ],
                 },
               },
@@ -998,7 +998,7 @@ describe('SkillsManifestFile', () => {
               installations: {
                 'tools/skills': {
                   skillNames: [
-                    'hb-query-resolver',
+                    'hor-query-resolver',
                   ],
                 },
               },
@@ -1009,7 +1009,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -1034,7 +1034,7 @@ describe('SkillsManifestFile', () => {
     describe('should do nothing when no manifest is readable', () => {
       test('when the manifest is absent', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 
@@ -1071,7 +1071,7 @@ describe('SkillsManifestFile', () => {
               },
               'tools/skills': {
                 skillNames: [
-                  'hb-query-resolver',
+                  'hor-query-resolver',
                 ],
               },
             },
@@ -1079,7 +1079,7 @@ describe('SkillsManifestFile', () => {
           expected: {
             'tools/skills': {
               skillNames: [
-                'hb-query-resolver',
+                'hor-query-resolver',
               ],
             },
           },
@@ -1104,7 +1104,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installationHash: $override.installationHash', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-renchan.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-renchan.json',
           installationPath: '.claude/skills',
         })
 


### PR DESCRIPTION
# Why

* Close #26

# How

* Renames the package from `@openreachtech/hora-skills-renchan` to `@openreachtech/hora-skills-ort-renchan`, along with the URLs `package.json` declares — the repository itself was renamed on GitHub
* Renames the command with it: `bin`, the file `lib/equip/hora-skills-ort-renchan.js`, the usage text, and the record an installation writes at `.hora/hora-skills-ort-renchan.json`
* The sample skill names inside the equip tests carry the new prefix as well: they are fixtures of the files this pull request moves, and the prefix itself is renamed in #25
* The command file, `package.json` and the tests move together because a `bin` naming a file that is not there installs nothing, and the tests assert the path of the record

`hora-skills-ort-renchan list` prints the 31 skills this library distributes. The skill prefix is renamed separately.
