### PR TITLE
📄 Add the secrets tables the migration reference omits

### DIFF
--- a/kit/skills/backend/hor-cookie-authentication/references/migrations.md
+++ b/kit/skills/backend/hor-cookie-authentication/references/migrations.md
@@ -4,6 +4,7 @@ One create-table migration per credential / token table, written with the standa
 
 Tables, per actor (`<Actor>` shown):
 
+- `<actor>_secrets` (+ `<actor>_secrets_bk` backup) — `<actor>_id`, `email`, `saved_at`.
 - `<actor>_password_hashes` (+ `<actor>_password_hashes_bk` backup) — `<actor>_id`, `password_hash`, `saved_at`.
 - `<actor>_access_tokens` — `<actor>_id`, `access_token`, `session_key`, `generated_at`, `expired_at`.
 - `<actor>_refresh_tokens` — `<actor>_id`, `token_hash`, `session_key`, `used_at`, `revoked_at`, `generated_at`, `expired_at`.
@@ -13,6 +14,6 @@ Auth-specific points:
 - **Unique index on the token digest** (`token_hash`) and on `access_token` — each is the lookup key, and the unique index makes a duplicate impossible.
 - **Index `session_key`** on both token tables — rotation and revocation query by series.
 - Foreign keys (`<actor>_id`) are plain `BIGINT` columns with an index and **no** DB-level `references` constraint — the renchan convention.
-- The `_bk` backup table mirrors the source columns; it pairs with the password-hash model's backup mixin ([token-models](./token-models.md)).
+- The `_bk` backup table mirrors the source columns; it pairs with the backup mixin on the model it shadows ([token-models](./token-models.md)). **Both credential tables take one** — a secret and a digest are each replaced rather than edited, and the history is what a reset or an address change leaves behind. The token tables take none: a token is deleted or revoked, never rewritten.
 
 The columns map one-to-one to the model attributes ([token-models](./token-models.md)) — camelCase attribute ↔ snake_case column via `underscored: true`. Add or change a column in the migration and the model together.

--- a/kit/skills/backend/hor-cookie-authentication/references/token-models.md
+++ b/kit/skills/backend/hor-cookie-authentication/references/token-models.md
@@ -3,7 +3,7 @@
 An authenticated actor's credential and session live in a small cluster of tables, kept apart from the actor's profile. For an actor `<Actor>`:
 
 - `<Actor>` — the entity (its profile fields are the app's own design; see [[hor-database-design]]).
-- `<Actor>Secret` — the sign-in identifier (`email`), kept apart from the profile.
+- `<Actor>Secret` — the sign-in identifier (`email`), kept apart from the profile. Takes the backup mixin.
 - `<Actor>PasswordHash` — the password digest; verifies a candidate password.
 - `<Actor>AccessToken` — the short-lived token (15 min), sent on the `x-renchan-access-token` header.
 - `<Actor>RefreshToken` — the long-lived token; stored only as a digest, delivered as an `HttpOnly` cookie.
@@ -96,6 +96,22 @@ The shared `SessionClerk` ([session-clerk](./session-clerk.md)) holds the token 
 ```js
 extractUserId () {
   return this.get('<Actor>Id') // the Admin model returns AdminId
+}
+```
+
+## Secret
+
+`<Actor>Secret` stores `email` and uses the backup mixin, so an address change leaves the
+previous one behind rather than overwriting it. It is the only thing `signIn` looks an actor up
+by:
+
+```js
+static get Mixins () {
+  return [BackupMixinModel]
+}
+
+static get BackupModel () {
+  return this._.<Actor>SecretsBk
 }
 ```
 


### PR DESCRIPTION
# Why

* Close #36

# How

* `migrations.md`'s table list gains `<actor>_secrets` and its `_bk` backup, with the columns read off a real migration — `<actor>_id`, `email`, `saved_at`. The list already had the other four tables, so a project implementing from it built the cluster without the one table `signIn` looks an actor up by, and `email` went back onto the entity
* The `_bk` bullet no longer says the backup table pairs with "the password-hash model's" mixin, since two models take one. It now says which tables keep a history and why: a secret and a digest are each replaced rather than edited, while a token is deleted or revoked and never rewritten
* `token-models.md`'s cluster list says `<Actor>Secret` takes the backup mixin, and it gains a `## Secret` section beside the existing `## Password hash` one — a reader implementing the cluster works section by section, and that model had no section at all
* Every value here was read off `hora-simple-crm-jiro-backend` and `simple-file-management-backend`, which both carry `customer_secrets`, `customer_secrets_bk`, `admin_secrets` and `admin_secrets_bk` with the matching `CustomerSecret` / `CustomerSecretsBk` models — not inferred from the pattern of the other tables

# Out of scope

* Whether `<Actor>Secret` could hold an identifier other than an email. The reference says `email` and both projects store exactly that, so nothing here widens it
