### PR TITLE
⚙️ Bump the two @openreachtech dev dependencies to their latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "@openreachtech/jest-constructor-spy": "^1.1.2",
         "@openreachtech/jest-deep-containing": "^1.0.2",
         "@openreachtech/jest-expect-each": "^1.0.3",
-        "@openreachtech/mentsu-rootpath": "^1.1.1",
-        "@openreachtech/renchan-env": "^1.0.4",
+        "@openreachtech/mentsu-rootpath": "^1.1.3",
+        "@openreachtech/renchan-env": "^1.0.6",
         "@types/jest": "^30.0.0",
         "eslint": "^9.39.5",
         "jest": "^30.4.2"
@@ -1426,18 +1426,18 @@
       "license": "MIT"
     },
     "node_modules/@openreachtech/mentsu-rootpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@openreachtech/mentsu-rootpath/-/mentsu-rootpath-1.1.1.tgz",
-      "integrity": "sha512-L/+E/6Olrw96W5h6+mtZ+LgNx1iUX1N2IcbyhhixebCKE7Md4l1ttZSgSOb3ZEz6rbtwi3mWtQPRtlyDgkbE1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@openreachtech/mentsu-rootpath/-/mentsu-rootpath-1.1.3.tgz",
+      "integrity": "sha512-v7CSYBFNm8OtyXT/zZMJzVDHnKK8O6n7R8vszaD7GGTbgRmyjjAft4NLu/m4CSiGKO4+JRdpxQQY1yqsk1ePvQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "Apache-2.0"
     },
     "node_modules/@openreachtech/renchan-env": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@openreachtech/renchan-env/-/renchan-env-1.0.4.tgz",
-      "integrity": "sha512-I8gyq837/4cpAKWJXFVAj8UQrdz9fZvt82KMOqR/SyWia9yPN4y+keRxE8ZFNYAfg+fnrAh1+M98AW6nyG7sfw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@openreachtech/renchan-env/-/renchan-env-1.0.6.tgz",
+      "integrity": "sha512-Ub1UtnBzTwlUf/JiH8jOUJQstDcOaQItfWKbLNUdUaq0E3jnskG1uBAk+3HB4H3wLd9DuC2yLwDhCaKEHzEBdQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@openreachtech/jest-deep-containing": "^1.0.2",
     "@openreachtech/jest-expect-each": "^1.0.3",
     "@openreachtech/mentsu-rootpath": "^1.1.3",
-    "@openreachtech/renchan-env": "^1.0.4",
+    "@openreachtech/renchan-env": "^1.0.6",
     "@types/jest": "^30.0.0",
     "eslint": "^9.39.5",
     "jest": "^30.4.2"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@openreachtech/jest-constructor-spy": "^1.1.2",
     "@openreachtech/jest-deep-containing": "^1.0.2",
     "@openreachtech/jest-expect-each": "^1.0.3",
-    "@openreachtech/mentsu-rootpath": "^1.1.1",
+    "@openreachtech/mentsu-rootpath": "^1.1.3",
     "@openreachtech/renchan-env": "^1.0.4",
     "@types/jest": "^30.0.0",
     "eslint": "^9.39.5",


### PR DESCRIPTION
# Why

* Close #47

# How

**Each version moved in its own commit against `package.json` alone, and `npm install` ran once at the end.** The lockfile is therefore one commit rather than three, and the dependency tree settled in a single place instead of being rewritten at every step.

**The declared floor was raised rather than left alone.** Both new versions already satisfied the `^` ranges on record, so regenerating the lockfile would have picked them up without touching `package.json` at all. That was rejected: the range is what tells a later reader which version the project is built and tested against, and leaving it at `^1.1.1` while the lockfile carries `1.1.3` makes it stop answering that question.

**`jest` was bumped and then dropped again.** `30.5.1` does not resolve here — the registry is read with a date cutoff — and `30.5.0` does. Taking `30.5.0` was rejected on the grounds that its own patch release already exists and cannot be reached, so the fix in `30.5.1` would be missing. `jest` stays at `^30.4.2` and moves when `30.5.1` becomes reachable.

# Note

* **`npm install` also rewrote the `license` field of both packages, from `MIT` to `Apache-2.0`.** That is upstream's own relicensing between these versions, not something this branch decided. It rides along in the lockfile because the lockfile records it.
* The lockfile diff is 10 lines: the two declared ranges at the root, and `version` / `resolved` / `integrity` / `license` for the two packages. Nothing else in the tree moved.
* The three sibling packages carry the same change under their own issues. The pull requests are independent.
