### PR TITLE
🛡️ Turn off the install scripts of `fsevents` and `unrs-resolver`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "@humanfs/node": "^0.16.8",
     "brace-expansion@5": "^5.0.9",
     "flatted": "^3.4.2"
+  },
+  "allowScripts": {
+    "fsevents": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "flatted": "^3.4.2"
   },
   "allowScripts": {
-    "fsevents": false
+    "fsevents": false,
+    "unrs-resolver": false
   }
 }


### PR DESCRIPTION
# Why

* Close #49

# How

**Denied rather than approved.** npm had been holding both scripts unrun for as long as the warning had been printing, and the full suite passes in that state, so there was nothing to buy by granting execution rights. `fsevents` is an optional macOS watcher jest falls back from, and `unrs-resolver`'s `postinstall` prepares a native resolver jest has not needed here.

**One package per commit, rather than one commit for the field.** The first commit opens `allowScripts` with `fsevents`, the second adds the `unrs-resolver` line. Each denial is a judgement a reviewer can accept or reject on its own, and the first commit alone leaves valid JSON and a coherent tree. A single commit carrying both would have recorded one blanket policy instead of two decisions.

**`engines` was considered and left alone.** `allowScripts` is only read by npm 11, so a contributor on npm 10 would still run the scripts — but `engines.npm` is the wrong instrument for that. npm checks `engines` on the consumer installing this package, not on the contributor developing it, and `engine-strict` is off by default, so the field would warn the audience it should not reach and stop nobody in the audience it should. The declared `node: ">=20.0.0"` stays as the only entry.

**The field was written by hand rather than through `npm install-scripts deny`.** That command rewrites `package.json` wholesale and reformats untouched parts of it, which would have put unrelated noise in the diff.

# Note

* **A fresh `npm install` leaves `package-lock.json` untouched**, so this branch is two commits and no lockfile change. `allowScripts` is a declaration that does not enter dependency resolution.
* **Where the dependency-bump pull request is still open against the same base, the two do not conflict.** `allowScripts` is appended after `overrides`, and the version ranges it touches are inside `devDependencies`. Either may merge first.
* Nothing under `dist/`, `docs/` or `lib/` moves. The release this lands in carries no change for consumers of the package.
* The three sibling packages carry the same change under their own issues. The pull requests are independent.
